### PR TITLE
Refactor loading

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/src/frontend/add-sighting.ts
+++ b/src/frontend/add-sighting.ts
@@ -32,7 +32,7 @@ export default class AddSighting extends LitElement {
       const response = await fetch(request);
       const data: UpsertSightingResponse = await response.json();
       if (response.ok) {
-        const event = new CustomEvent('database-changed', {bubbles: true, composed: true, detail: data.t});
+        const event = new CustomEvent('database-changed', {bubbles: true, composed: true});
         this.dispatchEvent(event);
         this.reset();
         return data;

--- a/src/frontend/obs-map.ts
+++ b/src/frontend/obs-map.ts
@@ -13,7 +13,6 @@ import hydrophonesURL from '../assets/orcasound-hydrophones.geojson?url';
 // imports below these lines smell like they support functionality that should be factored out
 import VectorLayer from 'ol/layer/Vector.js';
 import TileLayer from 'ol/layer/Tile.js';
-import { fromLonLat } from 'ol/proj.js';
 import XYZ from 'ol/source/XYZ.js';
 import { editStyle, featureStyle, hydrophoneStyle, selectedObservationStyle, viewingLocationStyle} from './style.ts';
 import type Point from 'ol/geom/Point.js';
@@ -34,6 +33,11 @@ import Collection from 'ol/Collection.js';
 const sphericalMercator = 'EPSG:3857';
 
 const geoJSON = new GeoJSON();
+
+export type MapMoveDetail = {
+  center: [number, number];
+  zoom: number;
+}
 
 // This is a thin wrapper around imperative code driving OpenLayers.
 // The code is informed by the `openlayers-elements` project, but we avoid taking it as a dependency.
@@ -154,6 +158,14 @@ export class ObsMap extends LitElement {
       if (!feature)
         return;
       window.open(feature.get('url'), '_blank')
+    });
+    this.map.on('moveend', () => {
+      const detail: MapMoveDetail = {
+        center: this.view.getCenter() as [number, number],
+        zoom: this.view.getZoom()!
+      };
+      const evt = new CustomEvent('map-move', {bubbles: true, composed: true, detail});
+      this.dispatchEvent(evt);
     });
   }
 

--- a/src/frontend/obs-map.ts
+++ b/src/frontend/obs-map.ts
@@ -32,8 +32,6 @@ import olCSS from 'ol/ol.css?url';
 import Collection from 'ol/Collection.js';
 
 const sphericalMercator = 'EPSG:3857';
-const initialCenter = [-122.450, 47.8];
-const initialZoom = 9;
 
 const geoJSON = new GeoJSON();
 
@@ -85,6 +83,20 @@ export class ObsMap extends LitElement {
     style: selectedObservationStyle,
   });
 
+  @property({type: Number, reflect: true})
+  private centerX!: number
+
+  @property({type: Number, reflect: true})
+  private centerY!: number
+
+  @property({type: Number, reflect: true})
+  private zoom!: number
+
+  private view = new View({
+    projection: sphericalMercator,
+    zoom: 9,
+  })
+
   public map = new OpenLayersMap({
     interactions: defaultInteractions().extend([this.#modify, this.#select]),
     layers: [
@@ -111,11 +123,7 @@ export class ObsMap extends LitElement {
         style: featureStyle,
       }),
     ],
-    view: new View({
-      center: fromLonLat(initialCenter),
-      projection: sphericalMercator,
-      zoom: initialZoom,
-    }),
+    view: this.view,
   });
 
   @query('#map', true)
@@ -157,6 +165,7 @@ export class ObsMap extends LitElement {
   }
 
   public firstUpdated(_changedProperties: PropertyValues): void {
+    this.view.setCenter([this.centerX, this.centerY, this.zoom]);
     this.map.setTarget(this.mapElement);
   }
 

--- a/src/frontend/obs-summary.ts
+++ b/src/frontend/obs-summary.ts
@@ -1,6 +1,6 @@
 import { css, LitElement, type PropertyValues } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import type { SightingProperties, UpsertSightingResponse } from "../types.ts";
+import type { SightingProperties } from "../types.ts";
 import { html, unsafeStatic } from "lit/static-html.js";
 import { tokenContext, userContext } from "./identity.ts";
 import { consume } from "@lit/context";
@@ -113,8 +113,7 @@ export class ObsSummary extends LitElement {
   private async onDelete() {
     const response = await fetch(this.sighting.path!, {headers: {Authorization: `Bearer ${this.authToken}`}, method: 'DELETE'});
     if (response.ok) {
-      const {t}: UpsertSightingResponse = await response.json();
-      const evt = new CustomEvent('database-changed', {bubbles: true, composed: true, detail: t});
+      const evt = new CustomEvent('database-changed', {bubbles: true, composed: true});
       this.dispatchEvent(evt);
     } else {
       alert(response.statusText);

--- a/src/frontend/salish-sea.ts
+++ b/src/frontend/salish-sea.ts
@@ -20,8 +20,12 @@ import { SightingLoader } from "./sighting-loader.ts";
 import type { FeatureCollection } from 'geojson';
 
 const dateRE = /^(\d\d\d\d-\d\d-\d\d)$/;
-const initialQueryDate = new URLSearchParams(document.location.search).get('d');
+const initialSearchParams = new URLSearchParams(document.location.search);
+const initialQueryDate = initialSearchParams.get('d');
 const initialDate = dateRE.test(initialQueryDate || '') && initialQueryDate || Temporal.Now.plainDateISO('PST8PDT').toString();
+const initialX = parseFloat(initialSearchParams.get('x') || '-13631071');
+const initialY = parseFloat(initialSearchParams.get('y') || '6073646');
+const initialZ = parseFloat(initialSearchParams.get('z') || '9');
 
 @customElement('salish-sea')
 export default class SalishSea extends LitElement {
@@ -112,6 +116,7 @@ export default class SalishSea extends LitElement {
   }
   #focusedSightingId: string | undefined
 
+  // add-sighting needs access to the map to add and remove interactions
   @query('obs-map', true)
   map!: ObsMap;
 
@@ -190,12 +195,13 @@ export default class SalishSea extends LitElement {
           </ul>
           <p>If you have any feedback, tap the Feedback button in the top-right of the page, or email <a href="mailto:rainhead@gmail.com">rainhead@gmail.com</a></p>
         </dialog>
-        <obs-map></obs-map>
+        <obs-map centerX=${initialX} centerY=${initialY} zoom=${initialZ}></obs-map>
         <obs-panel date=${this.date}>
           ${repeat(sightings, sighting => sighting.id, feature => {
             const id = feature.properties.id;
+            const classes = {focused: id === this.focusedSightingId};
             return html`
-              <obs-summary class=${classMap({focused: id === this.focusedSightingId})} ?focused=${id === this.focusedSightingId} id=${id} .sighting=${feature.properties} />
+              <obs-summary class=${classMap(classes)} ?focused=${id === this.focusedSightingId} id=${id} .sighting=${feature.properties} />
             `;
           })}
         </obs-panel>

--- a/src/frontend/salish-sea.ts
+++ b/src/frontend/salish-sea.ts
@@ -6,10 +6,8 @@ import { type User } from "@auth0/auth0-spa-js";
 import { doLogIn, doLogInContext, doLogOut, doLogOutContext, getTokenSilently, getUser, tokenContext, userContext } from "./identity.ts";
 import { provide } from "@lit/context";
 import { Temporal } from "temporal-polyfill";
-import { queryStringAppend } from "./util.ts";
 import type Point from "ol/geom/Point.js";
-import type {Feature as GeoJSONFeature, Point as GeoJSONPoint} from 'geojson';
-import type { SightingProperties } from "../types.ts";
+import { isSighting } from "../types.ts";
 import { repeat } from "lit/directives/repeat.js";
 import { classMap } from "lit/directives/class-map.js";
 import type Feature from "ol/Feature.js";
@@ -18,6 +16,12 @@ import type VectorSource from "ol/source/Vector.js";
 import type OpenLayersMap from "ol/Map.js";
 import mapContext from "./map-context.ts";
 import type { ObsMap } from "./obs-map.ts";
+import { SightingLoader } from "./sighting-loader.ts";
+import type { FeatureCollection } from 'geojson';
+
+const dateRE = /^(\d\d\d\d-\d\d-\d\d)$/;
+const initialQueryDate = new URLSearchParams(document.location.search).get('d');
+const initialDate = dateRE.test(initialQueryDate || '') && initialQueryDate || Temporal.Now.plainDateISO('PST8PDT').toString();
 
 @customElement('salish-sea')
 export default class SalishSea extends LitElement {
@@ -90,6 +94,8 @@ export default class SalishSea extends LitElement {
     }
   `;
 
+  private sightingLoader = new SightingLoader(this, initialDate);
+
   @provide({context: mapContext})
   olmap: OpenLayersMap | undefined
 
@@ -112,9 +118,6 @@ export default class SalishSea extends LitElement {
   @query('dialog', true)
   aboutDialog!: HTMLDialogElement;
 
-  @state()
-  private features: GeoJSONFeature<GeoJSONPoint, SightingProperties>[] = [];
-
   @provide({context: userContext})
   @state()
   protected user: User | undefined;
@@ -130,21 +133,10 @@ export default class SalishSea extends LitElement {
   _doLogOut: () => Promise<void>
 
   @property({type: String, reflect: true})
-  date: string
-
-  @property({type: String, reflect: true})
-  dbt: number = 0;
-
-  #refreshTimer: NodeJS.Timeout
+  date = initialDate
 
   constructor() {
     super();
-    const queryDate = new URLSearchParams(document.location.search).get('d');
-    if (queryDate?.match(/^\d\d\d\d-\d\d-\d\d$/)) {
-      this.date = queryDate;
-    } else {
-      this.date = Temporal.Now.plainDateISO('PST8PDT').toString();
-    }
     this._doLogIn = this.doLogIn.bind(this);
     this._doLogOut = this.doLogOut.bind(this);
     this.updateAuth();
@@ -154,29 +146,25 @@ export default class SalishSea extends LitElement {
       const e = evt as CustomEvent<string | undefined>;
       this.focusedSightingId = e.detail;
     });
-    this.addEventListener('sightings-changed', evt => {
-      const e = evt as CustomEvent<Feature<Point>[]>;
-      this.updateSightings(e.detail);
-    });
     this.addEventListener('date-selected', (evt) => {
       if (!(evt instanceof CustomEvent) || typeof evt.detail !== 'string')
         throw "oh no";
       this.date = evt.detail;
+      // Update the 'd' search param in the URL
+      const url = new URL(window.location.href);
+      url.searchParams.set('d', this.date);
+      window.history.pushState({}, '', url.toString());
+      this.sightingLoader.dateChanged(this.date);
     });
-    this.addEventListener('database-changed', (evt) => {
-      if (!(evt instanceof CustomEvent) || typeof evt.detail !== 'number')
-        throw "oh no";
-      this.dbt = evt.detail;
+    this.addEventListener('database-changed', () => {
+      this.sightingLoader.fetch();
     });
-    this.#refreshTimer = setInterval(() => this.dbt += 1, 1000 * 30);
-  }
-
-  disconnectedCallback(): void {
-    clearInterval(this.#refreshTimer);
   }
 
   protected render(): unknown {
-    const featureHref = queryStringAppend('/api/temporal-features', {d: this.date, t: this.dbt});
+    const sightings = this.sightingLoader.features
+      .filter(isSighting)
+      .toSorted((a, b) => b.properties.timestamp - a.properties.timestamp)
     return html`
       <header>
         <h1>SalishSea.io <a @click=${this.onAboutClicked} class="about-link" href="#" title="About SalishSea.io">&#9432;</a></h1>
@@ -202,9 +190,9 @@ export default class SalishSea extends LitElement {
           </ul>
           <p>If you have any feedback, tap the Feedback button in the top-right of the page, or email <a href="mailto:rainhead@gmail.com">rainhead@gmail.com</a></p>
         </dialog>
-        <obs-map date=${this.date} url=${featureHref}></obs-map>
+        <obs-map></obs-map>
         <obs-panel date=${this.date}>
-          ${repeat(this.features, f => f.properties.id, feature => {
+          ${repeat(sightings, sighting => sighting.id, feature => {
             const id = feature.properties.id;
             return html`
               <obs-summary class=${classMap({focused: id === this.focusedSightingId})} ?focused=${id === this.focusedSightingId} id=${id} .sighting=${feature.properties} />
@@ -213,6 +201,10 @@ export default class SalishSea extends LitElement {
         </obs-panel>
       </main>
     `;
+  }
+
+  setFeatures(collection: FeatureCollection) {
+    this.map.setFeatures(collection);
   }
 
   async updateAuth() {
@@ -254,22 +246,6 @@ export default class SalishSea extends LitElement {
   onCloseModal(e: Event) {
     e.preventDefault();
     this.aboutDialog.close();
-  }
-
-  // Used by the side panel
-  updateSightings(features: Feature<Point>[]) {
-    this.features = features
-      .filter(feature => feature.get('kind') === 'Sighting')
-      .toSorted((a, b) => b.get('timestamp') - a.get('timestamp'))
-      .map(f => {
-        const point = f.getGeometry() as Point;
-        const properties = f.getProperties() as SightingProperties;
-        return {
-          type: 'Feature',
-          geometry: {type: 'Point', coordinates: point.getCoordinates()},
-          properties,
-        };
-      });
   }
 }
 

--- a/src/frontend/sighting-loader.ts
+++ b/src/frontend/sighting-loader.ts
@@ -51,7 +51,12 @@ export class SightingLoader implements ReactiveController {
     const endpoint = queryStringAppend('/api/temporal-features', {d: this.date});
     try {
       const response = await fetch(endpoint, {headers: {Accept: 'application/json'}});
-      const responseGeneratedAt = Temporal.Instant.fromEpochMilliseconds(Date.parse(response.headers.get('Date')!));
+      if (!response.ok)
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      const dateHeader = response.headers.get('Date');
+      if (!dateHeader)
+        throw new Error('Response missing Date header');
+      const responseGeneratedAt = Temporal.Instant.fromEpochMilliseconds(Date.parse(dateHeader));
       const {params: {date}, ...collection}: TemporalFeaturesResponse = await response.json();
       if (date === this.date && Temporal.Instant.compare(this.lastResponseGeneratedAt, responseGeneratedAt) === -1) {
         this.features = collection.features;

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -65,11 +65,13 @@ api.get(
       return;
     }
 
+    const dbt = makeT();
     const {d} = matchedData(req) as {d: string};
     const date = Temporal.PlainDate.from(d);
     const observations = collectFeatures(date);
     res.contentType('application/geo+json');
     res.header('Cache-Control', 'public, stale-if-error=14400');
+    res.header('Date', new Date().toUTCString());
     res.json(observations);
   }
 );

--- a/src/server/database.ts
+++ b/src/server/database.ts
@@ -1,8 +1,5 @@
 import Database from 'better-sqlite3';
 import fs from 'node:fs';
-import { Temporal } from 'temporal-polyfill';
-
-export type Timestamp = number; // epoch time in milliseconds
 
 const testDatabase = () => {
   const db = new Database();
@@ -13,8 +10,3 @@ const testDatabase = () => {
 
 export const db = process.env.VITEST ? testDatabase() : new Database('salish-sea.sqlite3');
 db.pragma('journal_mode = WAL');
-
-// This is a stand-in for a monotonic change counter (causal time) in the database, a la Datomic.
-export const makeT = () => {
-  return Temporal.Now.instant().epochMilliseconds;
-}

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -1,12 +1,10 @@
 import ViteExpress from "vite-express";
 import { app } from "./app.ts";
-import { loadFerries, loadRecent } from "./sources.ts";
+import { loadRecent } from "./sources.ts";
 
 
 await loadRecent();
-await loadFerries();
 setInterval(loadRecent, 1000 * 60 * 5);
-setInterval(loadFerries, 1000 * 60);
 
 const port = 3131;
 ViteExpress.listen(app, port, () => console.debug(`Listening on port ${port}.`));

--- a/src/server/sources.ts
+++ b/src/server/sources.ts
@@ -2,7 +2,6 @@ import { Temporal } from "temporal-polyfill";
 import { acartiaExtent, salishSeaExtent, srkwExtent } from "../constants.ts";
 import * as inaturalist from "./inaturalist.ts";
 import * as maplify from "./maplify.ts";
-import * as ferries from "./ferries.ts";
 
 
 export const loadRecent = async () => {
@@ -25,13 +24,4 @@ export const loadRecent = async () => {
   } catch (e) {
     console.error(`Error loading sightings: ${e}`);
   }
-};export const loadFerries = async () => {
-  try {
-    const locations = await ferries.fetchCurrentLocations();
-    const insertionCount = ferries.loadLocations(locations);
-    console.info(`Loaded ${insertionCount} ferry locations from WSF.`);
-  } catch (e) {
-    console.error(`Error loading ferry locations: ${e}`);
-  }
 };
-

--- a/src/server/temporal-features.test.ts
+++ b/src/server/temporal-features.test.ts
@@ -12,4 +12,16 @@ describe('GET /temporal-features', () => {
     expect(response.body).toHaveProperty('type', 'FeatureCollection');
     expect(Array.isArray(response.body.features)).toBe(true);
   });
+
+  it('includes a valid Date header in the response', async () => {
+    const response = await request(app)
+      .get('/api/temporal-features')
+      .query({ d: '2025-07-05' });
+    expect(response.status).toBe(200);
+    expect(response.headers).toHaveProperty('date');
+    // Check that the Date header is a valid RFC 1123 date string
+    const dateHeader = response.headers['date'];
+    expect(typeof dateHeader).toBe('string');
+    expect(new Date(dateHeader ?? '').toString()).not.toBe('Invalid Date');
+  });
 });

--- a/src/server/travel.ts
+++ b/src/server/travel.ts
@@ -38,6 +38,7 @@ export function imputeTravelLines(sorted: Feature<Point, {timestamp: number, spe
 
       const feature: Feature<LineString, TravelLineProperties> = {
         type: 'Feature',
+        id: `${obs.id}-${candidate.id}`,
         geometry: {
           type: 'LineString',
           coordinates: [obs.geometry.coordinates, candidate.geometry.coordinates],

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { Timestamp } from './server/database.ts';
+import type { Feature, FeatureCollection, Geometry, Point } from 'geojson';
 import type {FerryLocationProperties} from './server/ferries.ts'
 import type { SightingProperties } from './server/temporal-features.ts';
 export type { SightingProperties } from './server/temporal-features.ts';
@@ -27,5 +27,12 @@ export type SightingForm = {
 
 export type UpsertSightingResponse = {
   id: string;
-  t: Timestamp;
+}
+
+export type TemporalFeaturesResponse = FeatureCollection<Geometry, FeatureProperties> & {
+  params: {date: string};
+}
+
+export function isSighting(feature: Feature): feature is Feature<Point, SightingProperties> {
+  return feature.properties?.kind === 'Sighting';
 }


### PR DESCRIPTION
A twofer:
- Replace OpenLayers' XHR-based loader with our own, fetch-based one
  - OpenLayers' XHR loader is not configurable, leading to:
    - temporal features disappearing when refreshing them fails (#48)
    - can't control request cache-control headers
    - can't read response headers
- Replace OpenLayers' Link interaction by making `SalishSea` responsible for reading from and writing to navigation history
  - We'd like to ensure the URL captures a map extent (#56) rather than center and zoom level
  - It was weird for the map to be responsible for params like `date`, or for the URL generally, when the map is only one part of the page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new map event that allows external listeners to react to map movements.
  * Added a SightingLoader to manage and periodically refresh sighting data.
  * Added a type guard for identifying sighting features.

* **Refactor**
  * Simplified map state management and feature handling for improved reactivity.
  * Centralized sighting data loading and filtering, reducing manual state management.
  * Replaced URL-based feature synchronization with explicit map properties.
  * Synchronized map and date parameters with the browser URL.

* **Bug Fixes**
  * Improved synchronization of map and date parameters with the browser URL.

* **Chores**
  * Removed unused ferry location loading and related code.
  * Streamlined timestamp handling in sighting operations.
  * Removed detail payloads from certain custom events to simplify event dispatching.

* **Tests**
  * Added a test to verify the presence of the "Date" header in temporal features API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->