### PR TITLE
Adopt tanstack form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@sentry/browser": "^10.3.0",
         "@sentry/node": "^10.3.0",
         "@sentry/vite-plugin": "^4.0.2",
+        "@tanstack/lit-form": "^1.19.2",
         "@turf/bearing": "^7.2.0",
         "@turf/distance": "^7.2.0",
         "@turf/helpers": "^7.2.0",
@@ -4046,6 +4047,45 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@tanstack/form-core": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/form-core/-/form-core-1.19.2.tgz",
+      "integrity": "sha512-g2VkZCHEQUxnPOtF+vNHQDGvmrXfMpvN1T27M+G2R/eeH2vImxEdzVzAVIR71DZ5X3QtC9rm+nR64MJrjI+yXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/store": "^0.7.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/lit-form": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/lit-form/-/lit-form-1.19.2.tgz",
+      "integrity": "sha512-wUK5sA2I7KWilaoso8ByhZ+QW/gKTclx0wd0PERhmnaLzftN5AT+aBPRsNl+AinES+t0Wk0fWCuEOTBlm6tDLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/form-core": "1.19.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@tanstack/store": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.7.2.tgz",
+      "integrity": "sha512-RP80Z30BYiPX2Pyo0Nyw4s1SJFH2jyM6f9i3HfX4pA+gm5jsnYryscdq2aIQLnL4TaGuQMO+zXmN9nh1Qck+Pg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@turf/bearing": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@sentry/browser": "^10.3.0",
     "@sentry/node": "^10.3.0",
     "@sentry/vite-plugin": "^4.0.2",
+    "@tanstack/lit-form": "^1.19.2",
     "@turf/bearing": "^7.2.0",
     "@turf/distance": "^7.2.0",
     "@turf/helpers": "^7.2.0",

--- a/src/api.ts
+++ b/src/api.ts
@@ -2,14 +2,14 @@ import { z } from 'zod';
 
 export const sightingSchema = z.object({
   body: z.string(),
-  count: z.number().optional().nullish(),
+  count: z.coerce.number().int().positive().optional().nullable(),
   direction: z.string().nullable(),
   observed_at: z.string(),
-  observer_location: z.tuple([z.number(), z.number()]).nullable(),
+  observer_location: z.tuple([z.number(), z.number()]).optional(),
   photos: z.array(z.string()).default([]),
   photo_license: z.string(),
   subject_location: z.tuple([z.number(), z.number()]),
   taxon: z.string(),
-  url: z.string().trim().nullish(),
+  url: z.string().trim().transform(s => s === '' ? undefined : s).nullish(),
 });
 export type SightingPayload = z.infer<typeof sightingSchema>;

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const sightingSchema = z.object({
+  body: z.string(),
+  count: z.number().optional().nullish(),
+  direction: z.string().nullable(),
+  observed_at: z.string(),
+  observer_location: z.tuple([z.number(), z.number()]).nullable(),
+  photos: z.array(z.string()).default([]),
+  photo_license: z.string(),
+  subject_location: z.tuple([z.number(), z.number()]),
+  taxon: z.string(),
+  url: z.string().trim().nullish(),
+});
+export type SightingPayload = z.infer<typeof sightingSchema>;

--- a/src/frontend/add-sighting.ts
+++ b/src/frontend/add-sighting.ts
@@ -23,6 +23,8 @@ import { repeat } from "lit/directives/repeat.js";
 import { cameraAddIcon, clickTargetIcon, locateMeIcon } from "./icons.ts";
 import {Task} from '@lit/task';
 import './photo-uploader.ts';
+import { type SightingPayload } from "../server/sighting.ts";
+import { TanStackFormController } from '@tanstack/lit-form';
 
 const taxa = {
   "Seals and sea lions": {
@@ -177,6 +179,53 @@ export default class AddSighting extends LitElement {
   @query('input[name=photos', true)
   private photosInput: HTMLInputElement | undefined
 
+  #form = new TanStackFormController(this, {
+    defaultValues: {
+      body: '',
+      count: 0,
+      observed_time: '',
+      observer_location: '',
+      photo_license: localStorage.getItem('photoLicenseCode') || 'cc-by',
+      subject_location: '',
+      taxon: localStorage.getItem('lastTaxon') || 'Orcinus orca',
+      travel_direction: '',
+      url: '',
+    },
+    onSubmit: ({value}) => {
+      const observedAt = Temporal.PlainDate.from(this.date)
+        .toZonedDateTime({timeZone: 'PST8PDT', plainTime: value.observed_time as string});
+      if (Temporal.ZonedDateTime.compare(observedAt, Temporal.Now.zonedDateTimeISO()) > 0) {
+        alert("Please ensure you've entered a time in the past");
+        return;
+      }
+      // data.photo = formData.getAll('photo');
+      const observerCoords = toLonLat(this.#observerPoint.getCoordinates())
+      const subjectCoords = toLonLat(this.#subjectPoint.getCoordinates());
+      const payload: SightingPayload = {
+        body: value.body,
+        count: value.count,
+        direction: value.travel_direction,
+        observed_at: observedAt.toInstant.toString(),
+        observer_location: observerCoords.length === 2 ? observerCoords as [number, number] : null,
+        photo: [],
+        photo_license: value.photo_license,
+        subject_location: subjectCoords as [number, number],
+        taxon: value.taxon,
+      };
+      const endpoint = `/api/sightings/${this.id}`;
+      const request = new Request(endpoint, {
+        body: JSON.stringify(payload),
+        headers: {
+          'Authorization': `Bearer ${this.token}`,
+          'Content-Type': 'application/json',
+        },
+        method: 'PUT',
+      });
+      this._saveTask.run([request]);
+      localStorage.setItem('lastTaxon', value.taxon);
+    },
+  })
+
   constructor() {
     super();
 
@@ -204,63 +253,89 @@ export default class AddSighting extends LitElement {
   }
 
   protected render() {
-    const lastTaxon = localStorage.getItem('lastTaxon') || 'Orcinus orca';
-    const licenseCode = localStorage.getItem('photoLicenseCode') || 'cc-by';
-
     return html`
       <input @change=${this.onFilesChanged} type="file" name="photos" accept="image/jpeg" multiple>
-      <form @submit=${this.onSubmit} @dragover=${this.onDragOver} @drop=${this.onDrop} action="/api/sightings/${this.id}">
-        <label>
-          <span class="label">URL</span>
-          <input type="url" name="url" />
-        </label>
-        <label>
-          <span class="label">Species</span>
-          <select @change=${this.onTaxonChange} name="taxon">
-            ${Object.entries(taxa).map(([group, taxa]) => html`
-              <optgroup label=${group}>${Object.entries(taxa).map(([taxon, label]) => html`
-                <option value=${taxon} ?selected=${taxon === lastTaxon}>${label}</option>
-              `)}</optgroup>
-            `)}
-          </select>
-        </label>
-        <label>
-          <span class="label">Count</span>
-          <input type="number" name="count" value="" min="0" max="100">
-        </label>
-        <label>
-          <span class="label">Time</span>
-          <input type="time" name="observed_time" step="1" required />
-        </label>
-        <label>
-          <span class="label">Observer location</span>
-          <input @change=${this.onObserverInputChange} type="text" name="observer_location" size="14" placeholder="lat, lon">
-          <button @click=${this.placeObserver} title="Locate on map" type="button"><svg class="inline-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">${clickTargetIcon}</svg></button>
-          <button @click=${this.locateMe} ?disabled=${!('geolocation' in navigator)} title="My location" type="button"><svg class="inline-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">${locateMeIcon}</svg></button>
-        </label>
-        <label>
-          <span class="label">Subject location</span>
-          <input @change=${this.onSubjectInputChange} type="text" name="subject_location" size="14" placeholder="lat, lon" required>
-          <button @click=${this.placeSubject} title="Locate on map" type="button"><svg class="inline-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">${clickTargetIcon}</svg></button>
-        </label>
-        <label>
-          <span class="label">Travel direction</span>
-          <select name="direction">
-            <option value="" selected>None or unknown</option>
-            <option value="north">North</option>
-            <option value="northeast">Northeast</option>
-            <option value="east">East</option>
-            <option value="southeast">Southeast</option>
-            <option value="south">South</option>
-            <option value="southwest">Southwest</option>
-            <option value="west">West</option>
-            <option value="northwest">Northwest</option>
-          </select>
-        </label>
-        <label>
-          <span class="label">Notes</span>
-          <textarea name="body" rows="3" cols="21"></textarea>
-        </label>
+      <form
+        @submit=${(e: Event) => {
+          e.preventDefault();
+          this.#form.api.handleSubmit();
+        }}
+        @dragover=${this.onDragOver}
+        @drop=${this.onDrop}
+      >
+        ${this.#form.field({name: 'url'}, field => html`
+          <label>
+            <span class="label">URL</span>
+            <input type="url" name="${field.name}" .value=${field.state.value} @change=${(e: Event) => field.handleChange((e.target as HTMLInputElement).value)}>
+          </label>
+        `)}
+        ${this.#form.field({name: 'taxon'}, field => html`
+          <label>
+            <span class="label">Species</span>
+            <select @change=${field.handleChange} name="${field.name}" .value=${field.state.value}>
+              ${Object.entries(taxa).map(([group, taxa]) => html`
+                <optgroup label=${group}>${Object.entries(taxa).map(([taxon, label]) => html`
+                  <option value=${taxon}>${label}</option>
+                `)}</optgroup>
+              `)}
+            </select>
+          </label>
+        `)}
+        ${this.#form.field({name: 'count'}, field => html`
+          <label>
+            <span class="label">Count</span>
+            <input type="number" name="${field.name}" .value=${field.state.value} min="0" max="100" @change=${(e: Event) => field.handleChange((e.target as HTMLInputElement).valueAsNumber)}>
+          </label>
+        `)}
+        ${this.#form.field({name: 'observed_time'}, field => html`
+          <label>
+            <span class="label">Time</span>
+            <input type="time" name="${field.name}" step="1" required .value=${field.state.value} @change=${(e: InputEvent) => field.handleChange((e.target as HTMLInputElement).value)}>
+          </label>
+        `)}
+        ${this.#form.field({name: 'observer_location'}, field => html`
+          <label>
+            <span class="label">Observer location</span>
+            <input type="text" name="${field.name}" size="14" placeholder="lat, lon" .value=${field.state.value} @change=${(e: InputEvent) => {
+              field.handleChange((e.target as HTMLInputElement).value);
+              this.onObserverInputChange(e);
+            }}>
+            <button @click=${this.placeObserver} title="Locate on map" type="button"><svg class="inline-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">${clickTargetIcon}</svg></button>
+            <button @click=${this.locateMe} ?disabled=${!('geolocation' in navigator)} title="My location" type="button"><svg class="inline-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">${locateMeIcon}</svg></button>
+          </label>
+        `)}
+        ${this.#form.field({name: 'subject_location'}, field => html`
+          <label>
+            <span class="label">Subject location</span>
+            <input type="text" name="${field.name}" size="14" placeholder="lat, lon" required .value=${field.state.value} @change=${(e: InputEvent) => {
+              field.handleChange((e.target as HTMLInputElement).value);
+              this.onSubjectInputChange(e);
+            }}>
+            <button @click=${this.placeSubject} title="Locate on map" type="button"><svg class="inline-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">${clickTargetIcon}</svg></button>
+          </label>
+        `)}
+        ${this.#form.field({name: 'travel_direction'}, field => html`
+          <label>
+            <span class="label">Travel direction</span>
+            <select name="${field.name}" .value=${field.state.value} @change=${(e: Event) => field.handleChange((e.target as HTMLSelectElement).value)}>
+              <option value="">None or unknown</option>
+              <option value="north">North</option>
+              <option value="northeast">Northeast</option>
+              <option value="east">East</option>
+              <option value="southeast">Southeast</option>
+              <option value="south">South</option>
+              <option value="southwest">Southwest</option>
+              <option value="west">West</option>
+              <option value="northwest">Northwest</option>
+            </select>
+          </label>
+        `)}
+        ${this.#form.field({name: 'body'}, field => html`
+          <label>
+            <span class="label">Notes</span>
+            <textarea name="${field.name}" rows="3" cols="21" .value=${field.state.value} @change=${(e: Event) => field.handleChange((e.target as HTMLTextAreaElement).value)}></textarea>
+          </label>
+        `)}
         <label>
           <span>Photos</span>
           <div class="thumbnails">
@@ -275,14 +350,16 @@ export default class AddSighting extends LitElement {
             </button>
           </div>
         </label>
-        <label>
-          <span class="label">Photo license</span>
-          <select @change=${this.onLicenseChange} name="license_code">
-            ${Object.entries(licenseCodes).map(([code, description]) => html`
-              <option value=${code} ?selected=${code === licenseCode}>${description}</option>
-            `)}
-          </select>
-        </label>
+        ${this.#form.field({name: 'photo_license'}, field => html`
+          <label>
+            <span class="label">Photo license</span>
+            <select @change=${this.onLicenseChange} name="${field.name}" .value=${field.state.value} @change=${(e: Event) => field.handleChange((e.target as HTMLSelectElement).value)}>
+              ${Object.entries(licenseCodes).map(([code, description]) => html`
+                <option value=${code}>${description}</option>
+              `)}
+            </select>
+          </label>
+        `)}
         <div class="actions">
           ${this._saveTask.render({
             initial: () => html`
@@ -354,13 +431,6 @@ export default class AddSighting extends LitElement {
       throw `onLicenseChange is broken`;
     const licenseCode = e.target.value;
     localStorage.setItem('photoLicenseCode', licenseCode);
-  }
-
-  private onTaxonChange(e: Event) {
-    if (!(e.target instanceof HTMLSelectElement))
-      throw `onTaxonChange is broken`;
-    const taxon = e.target.value;
-    localStorage.setItem('lastTaxon', taxon);
   }
 
   private onUploadClicked() {
@@ -436,34 +506,6 @@ export default class AddSighting extends LitElement {
     }
   }
 
-  private async onSubmit(e: Event) {
-    e.preventDefault();
-    const form = this.shadowRoot!.querySelector('form') as HTMLFormElement;
-    const formData = new FormData(form);
-    const data: {[k: string]: unknown} = Object.fromEntries(formData);
-    data.count = parseInt(formData.get('count') as string, 10);
-    const observedAt = Temporal.PlainDate.from(this.date)
-      .toZonedDateTime({timeZone: 'PST8PDT', plainTime: data.observed_time as string});
-    if (Temporal.ZonedDateTime.compare(observedAt, Temporal.Now.zonedDateTimeISO()) > 0) {
-      alert("Please ensure you've entered a time in the past");
-      return;
-    }
-    data.observed_at = observedAt.epochMilliseconds / 1000;
-    data.photo = formData.getAll('photo');
-    const observerCoords = toLonLat(this.#observerPoint.getCoordinates())
-    data.observer_location = observerCoords.length ? observerCoords : null;
-    data.subject_location = toLonLat(this.#subjectPoint.getCoordinates());
-    const request = new Request(form.action, {
-      body: JSON.stringify(data),
-      headers: {
-        'Authorization': `Bearer ${this.token}`,
-        'Content-Type': 'application/json',
-      },
-      method: 'PUT',
-    });
-    this._saveTask.run([request]);
-  }
-
   protected firstUpdated(_changedProperties: PropertyValues): void {
     const sightingProperties: SightingStyleProperties = {
       direction: null,
@@ -487,6 +529,10 @@ export default class AddSighting extends LitElement {
     this.#observerPoint.on('change', this.onCoordinatesChanged.bind(this));
     this.#subjectPoint.on('change', this.onCoordinatesChanged.bind(this));
   }
+
+  // public setProperties(props: Partial<SightingForm>) {
+  //   // this.
+  // }
 
   disconnectedCallback(): void {
     this.reset();

--- a/src/frontend/obs-map.ts
+++ b/src/frontend/obs-map.ts
@@ -153,19 +153,10 @@ export class ObsMap extends LitElement {
       const evt = new CustomEvent('focus-sighting', {bubbles: true, composed: true, detail: id});
       this.dispatchEvent(evt);
     });
-    this.map.on('click', (evt: MapBrowserEvent) => {
-      const feature = this.map.getFeaturesAtPixel(evt.pixel).filter(f => f.get('kind') === 'Hydrophone')[0];
-      if (!feature)
-        return;
-      window.open(feature.get('url'), '_blank')
-    });
-    this.map.on('moveend', () => {
-      const detail: MapMoveDetail = {
-        center: this.view.getCenter() as [number, number],
-        zoom: this.view.getZoom()!
-      };
-      const evt = new CustomEvent('map-move', {bubbles: true, composed: true, detail});
-      this.dispatchEvent(evt);
+    this.map.on('singleclick', this.onClick.bind(this));
+    this.map.on('moveend', this.onMoveEnd.bind(this));
+    this.view.addEventListener('contextmenu', (evt) => {
+      evt.preventDefault();
     });
   }
 
@@ -176,9 +167,41 @@ export class ObsMap extends LitElement {
     `;
   }
 
+  protected onClick(evt: MapBrowserEvent<PointerEvent>) {
+    if (evt.originalEvent.altKey) {
+      // Prevent the Select from getting this click.
+      return false;
+    }
+
+    const feature = this.map.getFeaturesAtPixel(evt.pixel).filter(f => f.get('kind') === 'Hydrophone')[0];
+    if (!feature)
+      return;
+    window.open(feature.get('url'), '_blank')
+  }
+
+  protected onMoveEnd() {
+    const detail: MapMoveDetail = {
+      center: this.view.getCenter() as [number, number],
+      zoom: this.view.getZoom()!
+    };
+    const evt = new CustomEvent('map-move', {bubbles: true, composed: true, detail});
+    this.dispatchEvent(evt);
+  }
+
   public firstUpdated(_changedProperties: PropertyValues): void {
     this.view.setCenter([this.centerX, this.centerY, this.zoom]);
     this.map.setTarget(this.mapElement);
+    this.mapElement.addEventListener('pointerdown', evt => {
+      if (! evt.altKey)
+        return;
+
+      const pixel = this.map.getEventPixel(evt);
+      const sighting = this.map.getFeaturesAtPixel(pixel).filter(f => f.get('kind') === 'Sighting')[0];
+      if (sighting) {
+        const event = new CustomEvent('clone-sighting', {bubbles: true, composed: true, detail: sighting});
+        this.dispatchEvent(event);
+      }
+    });
   }
 
   public setFeatures(features: FeatureCollection) {

--- a/src/frontend/obs-map.ts
+++ b/src/frontend/obs-map.ts
@@ -155,9 +155,6 @@ export class ObsMap extends LitElement {
     });
     this.map.on('singleclick', this.onClick.bind(this));
     this.map.on('moveend', this.onMoveEnd.bind(this));
-    this.view.addEventListener('contextmenu', (evt) => {
-      evt.preventDefault();
-    });
   }
 
   public render() {

--- a/src/frontend/obs-panel.ts
+++ b/src/frontend/obs-panel.ts
@@ -62,7 +62,7 @@ export class ObsPanel extends LitElement {
     }
   `;
 
-  @property({attribute: true, type: Boolean})
+  @property({attribute: true, reflect: true, type: Boolean})
   public showForm: boolean = false
 
   @property({type: String, reflect: true})
@@ -118,11 +118,14 @@ export class ObsPanel extends LitElement {
 
   private async doShowForm() {
     if (!this.token) {
-      if (! (await this.logIn()))
+      const success = await this.logIn();
+      if (!success)
         return;
+      // Allow context subscription a microtask to propagate the token.
+      await Promise.resolve();
     }
     if (!this.token)
-      throw "Tried to submit without a token";
+      throw new Error("Login succeeded but token was not available");
 
     this.showForm = true;
   }

--- a/src/frontend/obs-panel.ts
+++ b/src/frontend/obs-panel.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement} from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { customElement, property } from "lit/decorators.js";
 import { live } from 'lit/directives/live.js';
 import { when } from 'lit/directives/when.js';
 import { Temporal } from "temporal-polyfill";
@@ -62,8 +62,8 @@ export class ObsPanel extends LitElement {
     }
   `;
 
-  @state()
-  private _showForm: boolean = false
+  @property({attribute: true, type: Boolean})
+  public showForm: boolean = false
 
   @property({type: String, reflect: true})
   private date!: string;
@@ -84,10 +84,10 @@ export class ObsPanel extends LitElement {
           <input @change=${this.onDateChange} max=${today} min="2000-01-01" type="date" .value=${live(this.date)}>
         </form>
       </header>
-      ${when(this._showForm, () => html`
-        <add-sighting class="full-bleed" .cancel=${this.hideForm.bind(this)} date=${this.date}></add-sighting>
+      ${when(this.showForm, () => html`
+        <add-sighting class="full-bleed" .cancel=${() => this.showForm = false} date=${this.date}></add-sighting>
       `, () => html`
-        <button @click=${this.showForm} type="button" name="show">
+        <button @click=${this.doShowForm} type="button" name="show">
           <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px">${cameraAddIcon}</svg>
           <span>Add a Sighting</span>
         </button>
@@ -116,11 +116,7 @@ export class ObsPanel extends LitElement {
     }
   }
 
-  private hideForm() {
-    this._showForm = false;
-  }
-
-  private async showForm() {
+  private async doShowForm() {
     if (!this.token) {
       if (! (await this.logIn()))
         return;
@@ -128,7 +124,7 @@ export class ObsPanel extends LitElement {
     if (!this.token)
       throw "Tried to submit without a token";
 
-    this._showForm = true;
+    this.showForm = true;
   }
 }
 

--- a/src/frontend/photo-uploader.ts
+++ b/src/frontend/photo-uploader.ts
@@ -60,6 +60,7 @@ export default class PhotoUploader extends LitElement {
       await fetch(signedRequest);
       for (const input of this.inputs) {
         input.value = signedUrl.pathname;
+        input.dispatchEvent(new Event('change'));
       }
       return signedUrl.pathname;
     },

--- a/src/frontend/photo-uploader.ts
+++ b/src/frontend/photo-uploader.ts
@@ -40,6 +40,8 @@ export default class PhotoUploader extends LitElement {
         contentType: file.type,
         fileName: file.name,
       });
+      if (!this.token)
+        throw new Error('Not authenticated, cannot upload photo.');
       const request = new Request(endpoint, {
         headers: {
           Authorization: `Bearer ${this.token}`,
@@ -57,10 +59,14 @@ export default class PhotoUploader extends LitElement {
         },
         method: 'PUT',
       });
-      await fetch(signedRequest);
+      const uploadResponse = await fetch(signedRequest);
+      if (!uploadResponse.ok) {
+        throw new Error(`Upload failed: ${uploadResponse.status} ${uploadResponse.statusText}`);
+      }
       for (const input of this.inputs) {
         input.value = signedUrl.pathname;
-        input.dispatchEvent(new Event('change'));
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.dispatchEvent(new Event('change', { bubbles: true }));
       }
       return signedUrl.pathname;
     },

--- a/src/frontend/salish-sea.ts
+++ b/src/frontend/salish-sea.ts
@@ -185,6 +185,7 @@ export default class SalishSea extends LitElement {
       const {center: [x, y], zoom} = (evt as CustomEvent<MapMoveDetail>).detail;
       setQueryParams({x: x.toFixed(), y: y.toFixed(), z: zoom.toFixed()});
     });
+    // TODO
     // this.addEventListener('clone-sighting', async (evt) => {
     //   const sighting = (evt as CustomEvent<Feature<Point>>).detail;
     //   await this.shadowRoot!.querySelector('obs-panel')!.editSighting(sighting.getProperties());

--- a/src/frontend/salish-sea.ts
+++ b/src/frontend/salish-sea.ts
@@ -184,7 +184,11 @@ export default class SalishSea extends LitElement {
     this.addEventListener('map-move', (evt) => {
       const {center: [x, y], zoom} = (evt as CustomEvent<MapMoveDetail>).detail;
       setQueryParams({x: x.toFixed(), y: y.toFixed(), z: zoom.toFixed()});
-    })
+    });
+    // this.addEventListener('clone-sighting', async (evt) => {
+    //   const sighting = (evt as CustomEvent<Feature<Point>>).detail;
+    //   await this.shadowRoot!.querySelector('obs-panel')!.editSighting(sighting.getProperties());
+    // });
   }
 
   protected render(): unknown {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -69,7 +69,7 @@ api.put(
 
       upsertSighting(id, validatedData, updatedAt, user);
       const response: UpsertSightingResponse = {id};
-      res.status(201).json(response);
+      res.status(200).json(response);
     } catch (error) {
       if (error instanceof z.ZodError) {
         res.status(400).json({ errors: error.issues });

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -60,7 +60,7 @@ api.put(
   (req: Request, res: Response) => {
     try {
       const validatedData = sightingSchema.parse(req.body);
-      const updatedAt = new Date().valueOf();
+      const updatedAt = new Date();
       const user = req.auth!.payload.sub!;
 
       const id = req.params.sightingId;

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -4,7 +4,7 @@ import { query, matchedData, validationResult } from 'express-validator';
 import { z } from "zod";
 import { collectFeatures } from "./temporal-features.ts";
 import type { TemporalFeaturesResponse, UpsertSightingResponse } from "../types.ts";
-import { deleteSighting, sightingSchema, upsertSighting } from "./sighting.ts";
+import { deleteSighting, upsertSighting } from "./sighting.ts";
 import { getPresignedUserObjectURL } from "./storage.ts";
 import { v7 } from "uuid";
 import {auth} from 'express-oauth2-jwt-bearer';
@@ -12,6 +12,7 @@ import { storeUser } from "./user.ts";
 import { Temporal } from "temporal-polyfill";
 import './instrument.ts';
 import * as Sentry from '@sentry/node';
+import { sightingSchema } from "../api.ts";
 
 export const app = express();
 

--- a/src/server/sighting.ts
+++ b/src/server/sighting.ts
@@ -13,7 +13,7 @@ type SightingRow = {
   created_at: number; // unix epoch time in milliseconds
   updated_at: number; // unix epoch time in milliseconds
   user: string;
-  observed_at: string; // RFC-3339
+  observed_at: number; // unix epoch time in seconds
   longitude: number;
   latitude: number;
   observer_longitude: number | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,20 +11,6 @@ export type FeatureProperties = FerryLocationProperties | SightingProperties | T
 // [minx, miny, maxx, maxy]
 export type Extent = [number, number, number, number];
 
-export type SightingForm = {
-  id: string; // uuid
-  body?: string | null;
-  count?: number | null;
-  direction: string | null;
-  license_code: string;
-  observed_at: number; // unix epoch time
-  observer_location: null | [number, number]; // lon, lat
-  photo: string[];
-  subject_location: [number, number]; // lon, lat
-  taxon: string;
-  url?: string | null;
-}
-
 export type UpsertSightingResponse = {
   id: string;
 }


### PR DESCRIPTION
This PR formalizes the handling of data and definition of fields presented by the "add sighting" form. Previously, the data was mastered partly in the DOM and partly in OpenLayers features, and handled by various event handlers. This worked, and was somewhat simple, but using a form controller should make it easier and cleaner to:
- do form validation and present errors
- understand the data flow (hopefully)
- clone existing sightings (#82)
- edit existing sightings (#41)

I picked https://github.com/TanStack/form without doing much research, based on its support for Lit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced "Add Sighting" form with structured fields, smarter date/time handling, persistent taxon/license, and multi-photo support with captured URLs.
  - Map improvements: Alt+click to initiate cloning, hydrophone links open only when intended, and map-move events emitted for smoother navigation.

- **Bug Fixes**
  - Stronger photo upload error handling and authentication checks; form inputs reliably emit updates after uploads.

- **Chores**
  - Added UI form library dependency to support the new form experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->