### PR TITLE
Fix restoring zoom from query string

### DIFF
--- a/src/obs-map.ts
+++ b/src/obs-map.ts
@@ -192,7 +192,8 @@ export class ObsMap extends LitElement {
   }
 
   public firstUpdated(_changedProperties: PropertyValues): void {
-    this.view.setCenter([this.centerX, this.centerY, this.zoom]);
+    this.view.setCenter([this.centerX, this.centerY]);
+    this.view.setZoom(this.zoom);
     this.map.setTarget(this.mapElement);
     this.mapElement.addEventListener('pointerdown', evt => {
       if (! evt.altKey)


### PR DESCRIPTION
We weren't properly calling `setZoom` on the map view with the value in the URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved map initialization to set the starting location and zoom more consistently, preventing sporadic mismatches between center and zoom on first render.
  - Reduces flicker and unexpected jumps when the map loads, resulting in a smoother initial view.
  - Ensures that the initial zoom level is applied correctly after setting the map center, improving reliability across devices and slower connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->