### PR TITLE
Fix upserting inaturalist observation photo

### DIFF
--- a/supabase/migrations/20251025153945_fix_inat_upsert.sql
+++ b/supabase/migrations/20251025153945_fix_inat_upsert.sql
@@ -43,7 +43,7 @@ BEGIN ATOMIC
       observed_at = v.observed_at,
       license_code = v.license_code,
       username = v.username,
-      taxon_Id = v.taxon_id,
+      taxon_id = v.taxon_id,
       fetched_at = v.fetched_at,
       public_positional_accuracy = v.public_positional_accuracy,
       updated_at = v.updated_at


### PR DESCRIPTION
I was doing a weird thing when matching photos in existing observations to fetched photos. I stopped doing that and things seem better.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add atomic import/upsert of observation pages, including associated photos, from structured JSON payloads.
* **Bug Fixes**
  * Improved data synchronization and consistency for observations and media, including handling of deleted photos and timestamp-based updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->