### PR TITLE
Individuals and identifiers wip

### DIFF
--- a/supabase/migrations/20251024193037_happywhale_field_lengths.sql
+++ b/supabase/migrations/20251024193037_happywhale_field_lengths.sql
@@ -1,0 +1,1 @@
+ALTER TABLE happywhale.individuals ALTER COLUMN nickname TYPE VARCHAR(200);

--- a/supabase/migrations/20251024193327_individuals.sql
+++ b/supabase/migrations/20251024193327_individuals.sql
@@ -1,0 +1,33 @@
+-- regexp_matches(body, E'\\m(j|k|l|t|crc)[- ]?0*(\\d[\\da-f]+)(s?)\\M', 'gi')
+CREATE FUNCTION public.normalize_identifier(identifier VARCHAR) LANGUAGE SQL IMMUTABLE SET search_path='' AS $$
+  SELECT 
+$$;
+
+CREATE TABLE public.individuals (
+  id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  taxon_id INTEGER NOT NULL REFERENCES inaturalist.taxa (id),
+  identifier VARCHAR(50) NOT NULL,
+  sex public.sex,
+  born date,
+  died date
+);
+
+INSERT INTO public.individuals (taxon_id, identifier, sex)
+SELECT taxa.id, primary_id, sex
+FROM happywhale.individuals AS ind
+JOIN happywhale.species ON ind.species = species.id
+JOIN inaturalist.taxa ON species.scientific = taxa.scientific_name;
+
+CREATE TABLE public.pod_identifiers (
+  id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  taxon_id INTEGER NOT NULL REFERENCES inaturalist.taxa (id),
+  identifier CHAR NOT NULL
+);
+
+
+CREATE OR REPLACE VIEW public.identifiers AS
+SELECT identifier, 'individual' AS "type", id FROM public.individuals
+
+UNION ALL
+
+SELECT identifier, 'group', null FROM public.group_identifiers;


### PR DESCRIPTION
Information about individuals currently comes to us via Happywhale, but might come from other sources in the future, or be inputted manually by us. There are often multiple, competing authorities, each with its (often overlapping) turf. Happywhale vends identifiers annotated with their issuing authority, where sometimes that authority is Happywhale itself. Like Happywhale, this project must choose an identifier to display from among those available.

Happywhale appears to use hyphens only to attach the authority to the beginning of an identifier. So `J38` is an identifier, while `RSL-13` is effectively an identifier in a namespace. Examples of identifiers as they appear on their site, the parenthesized string appearing in a tool tip on hover:
- BCY0885 (Canadian Pacific Humpback Collaboration)
- BCY0885 calf 2023 (Canadian Pacific Humpback Collaboration)
- HW-MN0510826 (Happywhale)
- IBJ-1266 (Instituto Baleia Jubarte)
- RSL-13 (RSL-Laboratory of Bioacoustics Brazil)
- J38 (Southern Resident Killer )

Requirements:

**Cardinality**. Every individual should have one or more identifiers, all of which are unique to it.

**Priority**. The identifiers for an individual have a priority ordering that allows the most "canonical" identifier to be used for display. For example, the derived identifier `BCY0885 calf 2023` would have lower priority than the `BCY` identifier issued specifically for that individual.

**Mutability**. An individual should only gain identifiers. I don't know whether Happywhale considers some of its identifiers temporary, or whether identifiers are ever removed from an individual.

**Format**. We might as well stick mostly with what Happywhale does: all caps, hyphens only to namespace an identifier that would not otherwise be unique. I am undecided on leading zeros, e.g. `BCY0885` (per Happywhale) vs `BCY885`. When extracting identifiers from text, we should normalize potential matches to this form. We will probably never match `BCY0885 calf 2023` in upstream text, but could present it as an option in our own UI.

**Availability**. This work must make it possible to list all occurrences of an individual. Occurrences should therefore be indexed by individuals present. The system should be convergent: where the individuals present in an occurrence record are extracted from text, that association should always be current given the latest changes to the extraction function.