### PR TITLE
Lazy-load Google GSI script on sign-in click

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,6 @@
     <!-- The hash in the CSP must be updated when this code is updated. Run `npm run verify-csp` to check or find out the new hash. -->
     <script id="gsi-init">!function(){const e=window;e.handleSignInWithGoogle=async({credential:n})=>{const s=e.__pendingGSIResponses=e.__pendingGSIResponses||[],o=document.querySelector("salish-sea");if(o&&o.isConnected)try{return await o.receiveIdToken(n)}catch(e){throw s.push(n),e}else s.push(n)}}()</script>
     <script type="module" src="src/salish-sea.ts"></script>
-    <script src="https://accounts.google.com/gsi/client" async></script>
   </head>
   <body>
 

--- a/src/salish-sea.ts
+++ b/src/salish-sea.ts
@@ -337,7 +337,14 @@ export default class SalishSea extends LitElement {
   }
 
   doLogIn() {
-    google.accounts.id.prompt();
+    if (window.google?.accounts?.id) {
+      google.accounts.id.prompt();
+    } else {
+      const script = document.createElement('script');
+      script.src = 'https://accounts.google.com/gsi/client';
+      script.onload = () => google.accounts.id.prompt();
+      document.head.appendChild(script);
+    }
   }
 
   async doLogOut() {

--- a/src/salish-sea.ts
+++ b/src/salish-sea.ts
@@ -61,6 +61,19 @@ function parseUrlParams(searchParams: URLSearchParams) {
 
 const initialParams = parseUrlParams(new URLSearchParams(document.location.search));
 
+let gsiReady: Promise<void> | null = null;
+function loadGSI(): Promise<void> {
+  if (!gsiReady) {
+    gsiReady = new Promise((resolve) => {
+      const script = document.createElement('script');
+      script.src = 'https://accounts.google.com/gsi/client';
+      script.onload = () => resolve();
+      document.head.appendChild(script);
+    });
+  }
+  return gsiReady;
+}
+
 @customElement('salish-sea')
 export default class SalishSea extends LitElement {
   static styles = css`
@@ -337,14 +350,7 @@ export default class SalishSea extends LitElement {
   }
 
   doLogIn() {
-    if (window.google?.accounts?.id) {
-      google.accounts.id.prompt();
-    } else {
-      const script = document.createElement('script');
-      script.src = 'https://accounts.google.com/gsi/client';
-      script.onload = () => google.accounts.id.prompt();
-      document.head.appendChild(script);
-    }
+    loadGSI().then(() => google.accounts.id.prompt());
   }
 
   async doLogOut() {


### PR DESCRIPTION
Saves ~95 KB on initial page load — the script is now injected only when the user clicks Sign In, rather than fetched eagerly on every visit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved initial page load by removing the immediately loaded external Google sign-in script and loading it only when a user initiates sign-in. Sign-in behavior is unchanged from the user perspective: signing in still triggers the provider prompt after the client finishes loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->