### PR TITLE
Phase 14: DwC-A build pre-prod gate (seeded local DB)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           version: 2.53.6
       - run: supabase db start
+      - name: Apply CI seed fixture
+        run: psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -v ON_ERROR_STOP=1 -f supabase/ci-seed.sql
       - name: Verify generated types match Postgres schema
         run: |
           npm run gen-types
@@ -37,7 +39,10 @@ jobs:
           fi
 
       - run: npm run build
-      - run: npm test
+      - name: Run tests
+        run: npm test
+        env:
+          SUPABASE_DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
 
       - name: Install infra dependencies
         run: npm ci

--- a/database.types.ts
+++ b/database.types.ts
@@ -34,6 +34,38 @@ export type Database = {
   }
   public: {
     Tables: {
+      collections: {
+        Row: {
+          id: number
+          kind: Database["public"]["Enums"]["collection_kind"] | null
+          name: string
+          organization_id: number | null
+          slug: string
+        }
+        Insert: {
+          id?: number
+          kind?: Database["public"]["Enums"]["collection_kind"] | null
+          name: string
+          organization_id?: number | null
+          slug: string
+        }
+        Update: {
+          id?: number
+          kind?: Database["public"]["Enums"]["collection_kind"] | null
+          name?: string
+          organization_id?: number | null
+          slug?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "collections_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       contributor_email_addresses: {
         Row: {
           contributor_id: number
@@ -62,21 +94,27 @@ export type Database = {
           editor: boolean
           entity_id: string
           id: number
+          inat_login: string | null
           name: string
+          orcid: string | null
           picture: string | null
         }
         Insert: {
           editor?: boolean
           entity_id?: string
           id?: number
+          inat_login?: string | null
           name: string
+          orcid?: string | null
           picture?: string | null
         }
         Update: {
           editor?: boolean
           entity_id?: string
           id?: number
+          inat_login?: string | null
           name?: string
+          orcid?: string | null
           picture?: string | null
         }
         Relationships: []
@@ -117,13 +155,16 @@ export type Database = {
         Row: {
           accuracy: number | null
           body: string | null
-          contributor_id: number
+          collection_id: number | null
+          contributor_id: number | null
           count: number | null
           created_at: string
           direction: Database["public"]["Enums"]["travel_direction"] | null
           id: string
           observed_at: string
           observer_location: unknown
+          provider_id: number
+          source_url: string | null
           subject_location: unknown
           taxon_id: number
           updated_at: string
@@ -133,13 +174,16 @@ export type Database = {
         Insert: {
           accuracy?: number | null
           body?: string | null
-          contributor_id: number
+          collection_id?: number | null
+          contributor_id?: number | null
           count?: number | null
           created_at: string
           direction?: Database["public"]["Enums"]["travel_direction"] | null
           id: string
           observed_at: string
           observer_location?: unknown
+          provider_id?: number
+          source_url?: string | null
           subject_location: unknown
           taxon_id: number
           updated_at: string
@@ -149,13 +193,16 @@ export type Database = {
         Update: {
           accuracy?: number | null
           body?: string | null
-          contributor_id?: number
+          collection_id?: number | null
+          contributor_id?: number | null
           count?: number | null
           created_at?: string
           direction?: Database["public"]["Enums"]["travel_direction"] | null
           id?: string
           observed_at?: string
           observer_location?: unknown
+          provider_id?: number
+          source_url?: string | null
           subject_location?: unknown
           taxon_id?: number
           updated_at?: string
@@ -164,13 +211,69 @@ export type Database = {
         }
         Relationships: [
           {
+            foreignKeyName: "observations_collection_id_fkey"
+            columns: ["collection_id"]
+            isOneToOne: false
+            referencedRelation: "collections"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "observations_contributor_id_fkey"
             columns: ["contributor_id"]
             isOneToOne: false
             referencedRelation: "contributors"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "observations_provider_id_fkey"
+            columns: ["provider_id"]
+            isOneToOne: false
+            referencedRelation: "providers"
+            referencedColumns: ["id"]
+          },
         ]
+      }
+      organizations: {
+        Row: {
+          id: number
+          name: string
+          rights_holder_text: string
+          slug: string
+          url: string
+        }
+        Insert: {
+          id?: number
+          name: string
+          rights_holder_text: string
+          slug: string
+          url: string
+        }
+        Update: {
+          id?: number
+          name?: string
+          rights_holder_text?: string
+          slug?: string
+          url?: string
+        }
+        Relationships: []
+      }
+      providers: {
+        Row: {
+          id: number
+          name: string
+          slug: string
+        }
+        Insert: {
+          id?: number
+          name: string
+          slug: string
+        }
+        Update: {
+          id?: number
+          name?: string
+          slug?: string
+        }
+        Relationships: []
       }
       user_contributor: {
         Row: {
@@ -243,6 +346,12 @@ export type Database = {
       }
     }
     Enums: {
+      collection_kind:
+        | "facebook_group"
+        | "research_dataset"
+        | "acoustic_feed"
+        | "detector"
+        | "direct_app"
       license:
         | "cc0"
         | "cc-by"
@@ -415,6 +524,13 @@ export const Constants = {
   },
   public: {
     Enums: {
+      collection_kind: [
+        "facebook_group",
+        "research_dataset",
+        "acoustic_feed",
+        "detector",
+        "direct_app",
+      ],
       license: [
         "cc0",
         "cc-by",

--- a/scripts/dwca/guard.test.ts
+++ b/scripts/dwca/guard.test.ts
@@ -189,8 +189,14 @@ describe('guard', () => {
             // so the real row count (from the live DB) trips the floor.
             vi.mocked(fsPromises.stat).mockImplementation(makeStatMock(204_800, 51_200));
 
-            // Restore real DuckDB for this DSN-gated test.
-            vi.mocked(duckdbModule.DuckDBInstance.create).mockRestore();
+            // Wire real DuckDB for this DSN-gated test. mockRestore() only works on
+            // vi.spyOn() mocks; this module uses vi.fn(), so we importActual and
+            // delegate via mockImplementation instead.
+            const { DuckDBInstance: RealDuckDBInstance } =
+                await vi.importActual<typeof import('@duckdb/node-api')>('@duckdb/node-api');
+            vi.mocked(duckdbModule.DuckDBInstance.create).mockImplementation(
+                RealDuckDBInstance.create.bind(RealDuckDBInstance),
+            );
 
             const origFloor = process.env['ROW_FLOOR'];
             process.env['ROW_FLOOR'] = '9999999999'; // above any real row count

--- a/supabase/ci-seed.sql
+++ b/supabase/ci-seed.sql
@@ -1,0 +1,157 @@
+-- =====================================================================
+-- CI-only static fixture for DwC-A build pre-prod gate (Phase 14).
+--
+-- Applied via:
+--   supabase db query --local --file supabase/ci-seed.sql
+-- AFTER migrations have been applied (supabase db start or supabase db reset).
+--
+-- This file is NOT in supabase/config.toml [db.seed].sql_paths and is NOT
+-- run by `supabase db start` or `supabase db reset`. It must be applied
+-- explicitly (e.g., from build.yml after supabase db start).
+--
+-- Reference rows (providers, organizations, collections) are already seeded
+-- by migration 20260619184037_reference_tables.sql. This fixture inserts
+-- ONLY source rows referencing those existing IDs.
+--
+-- Safe to re-run ONLY on a freshly-reset local DB. The Maplify INSERTs use
+-- ON CONFLICT DO NOTHING as belt-and-suspenders, but primary key conflicts
+-- on the auth.users and observations rows will error if re-run.
+--
+-- No real PII, no production credentials, no prod DSN. All data is synthetic.
+-- =====================================================================
+
+-- =====================================================================
+-- Section 1 — Native observations (dwc._native_occurrences + dwc.multimedia)
+-- =====================================================================
+
+-- Insert a minimal auth.users row. The create_contributor_on_sign_in trigger
+-- fires synchronously AFTER INSERT ON auth.users and creates:
+--   - a public.contributors row named 'CI Gate Test'
+--   - a public.user_contributor row mapping this UUID to that contributor
+-- (migration 20260203234153_individuals.sql)
+INSERT INTO auth.users (
+    id,
+    email,
+    created_at,
+    updated_at,
+    raw_user_meta_data
+) VALUES (
+    '00000000-0000-0000-0000-000000000001',
+    'ci-gate@example.com',
+    NOW(),
+    NOW(),
+    '{"name": "CI Gate Test"}'::jsonb
+);
+
+-- Use the trigger-created contributor_id to insert a native observation.
+-- collection_id omitted → DEFAULT 10 (salishsea-direct); the native view
+-- INNER JOINs public.collections so the default satisfies the JOIN.
+-- provider_id omitted → DEFAULT 1 (direct).
+DO $$
+DECLARE
+    v_contrib_id INTEGER;
+    v_obs_id UUID := '00000000-0000-4000-a000-000000000001';
+BEGIN
+    SELECT contributor_id INTO v_contrib_id
+      FROM public.user_contributor
+     WHERE user_uuid = '00000000-0000-0000-0000-000000000001';
+
+    INSERT INTO public.observations (
+        id,
+        observed_at,
+        subject_location,
+        taxon_id,
+        count,
+        contributor_id,
+        user_uuid,
+        created_at,
+        updated_at
+        -- provider_id defaults to 1 (direct)
+        -- collection_id defaults to 10 (salishsea-direct, satisfies INNER JOIN)
+    ) VALUES (
+        v_obs_id,
+        NOW() - INTERVAL '1 day',
+        gis.ST_Point(-123.3, 48.4)::gis.geography,
+        41521,   -- Orcinus orca (confirmed in inaturalist.taxa)
+        2,
+        v_contrib_id,
+        '00000000-0000-0000-0000-000000000001',
+        NOW(),
+        NOW()
+    );
+
+    -- One photo so dwc.multimedia is non-empty (DWCA-03 coverage).
+    -- license_code = 'cc-by' (not 'none'/NULL) → included in dwc.multimedia.
+    -- id is GENERATED ALWAYS AS IDENTITY — omit to use auto-assigned value.
+    INSERT INTO public.observation_photos (
+        observation_id,
+        seq,
+        href,
+        license_code
+    ) VALUES (
+        v_obs_id,
+        1,
+        'https://example.com/ci-gate-test-photo.jpg',
+        'cc-by'
+    );
+END $$;
+
+-- =====================================================================
+-- Section 2 — Maplify sightings (dwc._maplify_occurrences + Step 15.5)
+-- =====================================================================
+-- All three rows use ON CONFLICT DO NOTHING (belt-and-suspenders for local re-runs).
+-- provider_id omitted → DEFAULT 2 (maplify).
+
+-- Row A: trusted=TRUE, bracket-tagged comment → recordedBy='Jane Smith'.
+--   collection_id=1 (orca-network, organization_id=1) → Row A appears in
+--   Step 15.5 associated-parties result ('Orca Network').
+INSERT INTO maplify.sightings (
+    id, project_id, trip_id, scientific_name,
+    location, number_sighted, created_at,
+    in_ocean, moderated, trusted, is_test,
+    source, comments, taxon_id, collection_id
+) VALUES (
+    1, 100, 200, 'Orcinus orca',
+    gis.ST_Point(-122.9, 48.5)::gis.geography,
+    3, NOW() - INTERVAL '2 days',
+    TRUE, 1, TRUE, FALSE,
+    'whale_alert',
+    '[Orca Network] 3 orcas heading north (Jane Smith)<br>All adults.',
+    41521,  -- Orcinus orca
+    1       -- orca-network collection (organization_id=1)
+) ON CONFLICT (id) DO NOTHING;
+
+-- Row B: trusted=FALSE → EXCLUDED from dwc.occurrences by WHERE s.trusted.
+--   Exercises the trust-filter branch: row is present in maplify.sightings
+--   but MUST NOT appear in dwc.occurrences (occurrenceID='maplify:2' count=0).
+INSERT INTO maplify.sightings (
+    id, project_id, trip_id, scientific_name,
+    location, number_sighted, created_at,
+    in_ocean, moderated, trusted, is_test,
+    source, taxon_id
+) VALUES (
+    2, 100, 200, 'Orcinus orca',
+    gis.ST_Point(-123.1, 48.6)::gis.geography,
+    1, NOW() - INTERVAL '3 days',
+    TRUE, 0, FALSE, FALSE,
+    'whale_alert',
+    41521
+) ON CONFLICT (id) DO NOTHING;
+
+-- Row C: trusted=TRUE, no bracket tag → recordedBy=NULL (regex returns NULL).
+--   collection_id=NULL (no org) → LEFT JOIN falls through to COALESCE fallback;
+--   Row C appears in dwc.occurrences but NOT in Step 15.5 associated-parties.
+INSERT INTO maplify.sightings (
+    id, project_id, trip_id, scientific_name,
+    location, number_sighted, created_at,
+    in_ocean, moderated, trusted, is_test,
+    source, comments, taxon_id
+) VALUES (
+    3, 100, 200, 'Orcinus orca',
+    gis.ST_Point(-123.0, 48.7)::gis.geography,
+    2, NOW() - INTERVAL '4 days',
+    TRUE, 1, TRUE, FALSE,
+    'whale_alert',
+    'Three orcas spotted near the rocks.',
+    41521
+) ON CONFLICT (id) DO NOTHING;

--- a/supabase/ci-seed.sql
+++ b/supabase/ci-seed.sql
@@ -1,8 +1,11 @@
 -- =====================================================================
 -- CI-only static fixture for DwC-A build pre-prod gate (Phase 14).
 --
--- Applied via:
---   supabase db query --local --file supabase/ci-seed.sql
+-- Applied via psql (CI and local). NOTE: `supabase db query --file` cannot run
+-- this file — it has multiple top-level statements and that command sends the
+-- file as a single prepared statement (fails with SQLSTATE 42601). Use:
+--   psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" \
+--     -v ON_ERROR_STOP=1 -f supabase/ci-seed.sql
 -- AFTER migrations have been applied (supabase db start or supabase db reset).
 --
 -- This file is NOT in supabase/config.toml [db.seed].sql_paths and is NOT
@@ -65,9 +68,13 @@ BEGIN
         contributor_id,
         user_uuid,
         created_at,
-        updated_at
+        updated_at,
+        -- collection_id resolved by slug, NOT the surrogate id: collections.id
+        -- is GENERATED AS IDENTITY (insertion-order artifact), so the migration
+        -- says key on the slug (Pitfall 4). The native view INNER-JOINs
+        -- collections, so this must resolve to a real row.
+        collection_id
         -- provider_id defaults to 1 (direct)
-        -- collection_id defaults to 10 (salishsea-direct, satisfies INNER JOIN)
     ) VALUES (
         v_obs_id,
         NOW() - INTERVAL '1 day',
@@ -77,7 +84,8 @@ BEGIN
         v_contrib_id,
         '00000000-0000-0000-0000-000000000001',
         NOW(),
-        NOW()
+        NOW(),
+        (SELECT id FROM public.collections WHERE slug = 'salishsea-direct')
     );
 
     -- One photo so dwc.multimedia is non-empty (DWCA-03 coverage).
@@ -103,8 +111,10 @@ END $$;
 -- provider_id omitted → DEFAULT 2 (maplify).
 
 -- Row A: trusted=TRUE, bracket-tagged comment → recordedBy='Jane Smith'.
---   collection_id=1 (orca-network, organization_id=1) → Row A appears in
---   Step 15.5 associated-parties result ('Orca Network').
+--   collection_id resolved by slug 'orca-network' (org 'Orca Network') → Row A
+--   appears in the Step 15.5 associated-parties result. Resolved by slug, not a
+--   hardcoded surrogate id, because collections.id is GENERATED AS IDENTITY
+--   (Pitfall 4 — see the reference-tables migration).
 INSERT INTO maplify.sightings (
     id, project_id, trip_id, scientific_name,
     location, number_sighted, created_at,
@@ -118,7 +128,7 @@ INSERT INTO maplify.sightings (
     'whale_alert',
     '[Orca Network] 3 orcas heading north (Jane Smith)<br>All adults.',
     41521,  -- Orcinus orca
-    1       -- orca-network collection (organization_id=1)
+    (SELECT id FROM public.collections WHERE slug = 'orca-network')
 ) ON CONFLICT (id) DO NOTHING;
 
 -- Row B: trusted=FALSE → EXCLUDED from dwc.occurrences by WHERE s.trusted.


### PR DESCRIPTION
## What & why

Turns the `SUPABASE_DB_URL`-gated DwC-A integration suite (`scripts/dwca/build.test.ts`) — previously `describe.skip`'d in CI — into a true **pre-merge gate**. Build-time SQL/query/wiring bugs (e.g. the bare-schema-ref bug fixed in `aad63dd`, which only surfaced in the nightly post-deploy run) are now caught on every PR.

This PR exists in part to **observe the new gate running on a real CI runner** — the one item that couldn't be verified locally. It changes no migrations, no frontend, and no production data.

## Changes (3 files)

- **`supabase/ci-seed.sql`** (new) — CI-only static fixture: 3 `maplify.sightings` (trusted+tagged, untrusted, trusted+untagged), 1 native `public.observations` + 1 `public.observation_photos`. References migration-seeded provider/org/collection IDs; inserts only source rows. Makes `dwc.occurrences`/`dwc.multimedia` non-empty and exercises trust-filtering, the `recordedBy` regex, and the Step 15.5 associated-parties join.
- **`.github/workflows/build.yml`** — adds an `Apply CI seed fixture` step (via `psql -f`, after `supabase db start`) and a **step-scoped** `SUPABASE_DB_URL` on the test step, so `build.test.ts` un-skips and the DWCA-01..04/06 assertions run on every PR.
- **`scripts/dwca/guard.test.ts`** — repairs a latent DSN-gated test that broke once the suite runs with a DSN (`mockRestore()` on a `vi.fn()` → `importActual` + `mockImplementation`). `guard.ts` logic / `ROW_FLOOR` are unchanged.

## Verified locally

- Full seeded `SUPABASE_DB_URL=… npm test -- run` → **20 files / 197 tests green**, `build.test.ts` activated.
- No-DSN `npm test` still green (suite skips cleanly — fast-unit contract preserved).
- Red-test: a bare-schema-ref regression makes the suite exit non-zero with a DuckDB `Catalog Error`; clean restore; no permanent negative test committed.

## Notes

- The local-dev DSN (`postgresql://postgres:postgres@127.0.0.1:54322/postgres`) is the well-known Supabase local default, not a secret.
- Follow-up (not blocking): the fixture hardcodes `collection_id` 1/10, which are insertion-order artifacts of an IDENTITY column — resolving by slug would be more robust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded the database schema to support new concepts and metadata, including collections, organizations, providers, and a new collection kind enum, with updated contributor and observation fields.

* **Chores**
  * Improved CI reliability by applying a CI-only database seed fixture before build checks and running tests against the seeded local database via an explicit environment setting.

* **Tests**
  * Updated a DSN-gated test to use the real implementation for more accurate, repeatable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->