### PR TITLE
Sidebar provenance link fixes (visibility + Whale Alert → conserve.io)

### DIFF
--- a/src/obs-summary.ts
+++ b/src/obs-summary.ts
@@ -84,6 +84,10 @@ export class ObsSummary extends LitElement {
     }
     cite a {
       color: inherit;
+      text-decoration: underline;
+    }
+    cite a:hover {
+      color: #1976d2;
     }
     cite .observer {
       color: #475569;


### PR DESCRIPTION
Follow-up to #279 / #280. The first commit was pushed to the #280 branch *after* that PR merged, so it never landed in main; the second addresses follow-up feedback.

## 1. Make source links visibly clickable

The provenance line *does* link to the source (e.g. an iNaturalist observation's "iNaturalist" text links to the record), but `cite a { color: inherit }` painted the link the same muted gray as the surrounding `<cite>` text, and the app's base `a` has no underline — so the link read as plain text. Give `cite` links an underline + blue hover. Also fixes the direct-sighting case, where the contributor name is the link.

## 2. Link the Whale Alert channel to conserve.io

Whale Alert collections (Global / Alaska / generic) have no org row and no per-record `source_url`, so `via Whale Alert (…)` rendered unlinked. Every Whale Alert record originates from conserve.io's app, so link the channel there regardless of region.

Display-only — deliberately *not* a DB org row, which would also pull conserve.io into the DwC-A export EML (`associatedParty`).

CSS + small render change; no migration. Build (incl. CSP hash verify) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)