### PR TITLE
feat(infra): CloudFront access-log analytics for site monitoring

### DIFF
--- a/.planning/quick/260526-scf-add-taxon-id-526556-lutrinae-to-inatural/260526-scf-SUMMARY.md
+++ b/.planning/quick/260526-scf-add-taxon-id-526556-lutrinae-to-inatural/260526-scf-SUMMARY.md
@@ -1,6 +1,7 @@
 ---
 phase: quick-260526-scf-add-taxon-id-526556-lutrinae-to-inatural
 plan: "01"
+status: complete
 subsystem: supabase/inaturalist
 tags: [migration, inaturalist, lutrinae, otters]
 dependency_graph:

--- a/infra/athena/01_summary_all.sql
+++ b/infra/athena/01_summary_all.sql
@@ -3,6 +3,6 @@ SELECT count(*)                                              AS all_requests,
        count_if(sc_content_type LIKE 'text/html%')           AS html_requests,
        count(DISTINCT request_ip)                            AS distinct_ips,
        count_if(status >= 400)                               AS error_responses,
-       round(100.0 * count_if(status >= 400) / count(*), 2)  AS error_pct
+       coalesce(round(100.0 * count_if(status >= 400) / nullif(count(*), 0), 2), 0.0) AS error_pct
 FROM salishsea_logs.cloudfront_logs
 WHERE date >= current_date - interval '30' day;

--- a/infra/athena/01_summary_all.sql
+++ b/infra/athena/01_summary_all.sql
@@ -1,0 +1,8 @@
+-- 30-day totals across ALL traffic (humans + bots + scanners). Shows how bot-dominated the raw logs are.
+SELECT count(*)                                              AS all_requests,
+       count_if(sc_content_type LIKE 'text/html%')           AS html_requests,
+       count(DISTINCT request_ip)                            AS distinct_ips,
+       count_if(status >= 400)                               AS error_responses,
+       round(100.0 * count_if(status >= 400) / count(*), 2)  AS error_pct
+FROM salishsea_logs.cloudfront_logs
+WHERE date >= current_date - interval '30' day;

--- a/infra/athena/02_summary_human.sql
+++ b/infra/athena/02_summary_human.sql
@@ -2,6 +2,6 @@
 SELECT count(*)                                       AS human_page_views,
        count(DISTINCT request_ip)                     AS human_visitors,
        count(DISTINCT date)                           AS active_days,
-       round(1.0 * count(*) / count(DISTINCT date), 1) AS avg_views_per_day
+       round(1.0 * count(*) / nullif(count(DISTINCT date), 0), 1) AS avg_views_per_active_day
 FROM salishsea_logs.human_pageviews
 WHERE date >= current_date - interval '30' day;

--- a/infra/athena/02_summary_human.sql
+++ b/infra/athena/02_summary_human.sql
@@ -1,0 +1,7 @@
+-- 30-day human usage summary: the headline "are people using this" numbers.
+SELECT count(*)                                       AS human_page_views,
+       count(DISTINCT request_ip)                     AS human_visitors,
+       count(DISTINCT date)                           AS active_days,
+       round(1.0 * count(*) / count(DISTINCT date), 1) AS avg_views_per_day
+FROM salishsea_logs.human_pageviews
+WHERE date >= current_date - interval '30' day;

--- a/infra/athena/03_daily_human.sql
+++ b/infra/athena/03_daily_human.sql
@@ -1,0 +1,8 @@
+-- Daily human page views and visitors over the last 30 days. Spot spikes (e.g. a social post landing).
+SELECT date,
+       count(*)                   AS page_views,
+       count(DISTINCT request_ip) AS visitors
+FROM salishsea_logs.human_pageviews
+WHERE date >= current_date - interval '30' day
+GROUP BY date
+ORDER BY date;

--- a/infra/athena/04_referrer_hosts.sql
+++ b/infra/athena/04_referrer_hosts.sql
@@ -1,0 +1,12 @@
+-- Top external referrer HOSTS over 30 days (where human visitors come from). Self-referrals excluded.
+SELECT url_extract_host(url_decode(referrer)) AS referrer_host,
+       count(*)                               AS page_views,
+       count(DISTINCT request_ip)             AS visitors
+FROM salishsea_logs.human_pageviews
+WHERE date >= current_date - interval '30' day
+  AND referrer <> '-'
+  AND lower(coalesce(url_extract_host(url_decode(referrer)), ''))
+      NOT IN ('salishsea.io', 'www.salishsea.io', 'dev.salishsea.io')
+GROUP BY 1
+ORDER BY page_views DESC
+LIMIT 30;

--- a/infra/athena/05_referrer_urls.sql
+++ b/infra/athena/05_referrer_urls.sql
@@ -1,0 +1,12 @@
+-- Top external referrer URLs (full path) over 30 days. Finer-grained than hosts. Self-referrals excluded.
+SELECT url_decode(referrer)        AS referrer,
+       count(*)                    AS hits,
+       count(DISTINCT request_ip)  AS visitors
+FROM salishsea_logs.human_pageviews
+WHERE date >= current_date - interval '30' day
+  AND referrer <> '-'
+  AND lower(coalesce(url_extract_host(url_decode(referrer)), ''))
+      NOT IN ('salishsea.io', 'www.salishsea.io', 'dev.salishsea.io')
+GROUP BY 1
+ORDER BY hits DESC
+LIMIT 30;

--- a/infra/athena/06_top_pages.sql
+++ b/infra/athena/06_top_pages.sql
@@ -1,0 +1,11 @@
+-- Most-requested paths among human page views (30 days).
+-- NOTE: salishsea.io is a single-page app, so CloudFront sees nearly every page view as "/".
+-- Per-view/feature usage needs client-side analytics (Sentry, or a tool like Plausible), not edge logs.
+SELECT uri,
+       count(*)                   AS page_views,
+       count(DISTINCT request_ip) AS visitors
+FROM salishsea_logs.human_pageviews
+WHERE date >= current_date - interval '30' day
+GROUP BY uri
+ORDER BY page_views DESC
+LIMIT 30;

--- a/infra/athena/07_user_agents.sql
+++ b/infra/athena/07_user_agents.sql
@@ -1,0 +1,11 @@
+-- Top user agents among HTML requests (30 days), bots INCLUDED. Use this to see the human/bot split
+-- and to discover new bots that should be added to the human_pageviews filter.
+SELECT url_decode(user_agent)     AS user_agent,
+       count(*)                   AS requests,
+       count(DISTINCT request_ip) AS ips
+FROM salishsea_logs.cloudfront_logs
+WHERE date >= current_date - interval '30' day
+  AND sc_content_type LIKE 'text/html%'
+GROUP BY 1
+ORDER BY requests DESC
+LIMIT 30;

--- a/infra/athena/08_status.sql
+++ b/infra/athena/08_status.sql
@@ -1,0 +1,9 @@
+-- HTTP status-code breakdown over 30 days (all traffic). High 403/301 counts are normally bot/scanner
+-- noise and HTTP->HTTPS redirects, not user-facing breakage.
+SELECT status,
+       count(*)                                             AS n,
+       round(100.0 * count(*) / sum(count(*)) OVER (), 2)   AS pct
+FROM salishsea_logs.cloudfront_logs
+WHERE date >= current_date - interval '30' day
+GROUP BY status
+ORDER BY n DESC;

--- a/infra/athena/09_hourly_human.sql
+++ b/infra/athena/09_hourly_human.sql
@@ -1,0 +1,8 @@
+-- Human activity by hour of day (UTC) over 30 days. Pacific time = UTC - 7 (PDT) / - 8 (PST).
+SELECT substr(time, 1, 2)         AS hour_utc,
+       count(*)                   AS page_views,
+       count(DISTINCT request_ip) AS visitors
+FROM salishsea_logs.human_pageviews
+WHERE date >= current_date - interval '30' day
+GROUP BY 1
+ORDER BY 1;

--- a/infra/athena/README.md
+++ b/infra/athena/README.md
@@ -1,0 +1,32 @@
+# Site monitoring — CloudFront access logs
+
+Basic traffic/referrer/health analytics for salishsea.io, derived from CloudFront standard access
+logs. Answers "are people using this, how do they arrive, and is it healthy" — **not** in-app
+behaviour (the site is a single-page app, so the edge logs see almost every page view as `/`; use
+Sentry or a client-side analytics tool for per-view usage).
+
+## How it's wired
+
+All defined in [`../lib/infra-stack.ts`](../lib/infra-stack.ts):
+
+- CloudFront access logging → `logBucket` under `cloudfront/` (already existed; legacy standard logs).
+- A Glue database `salishsea_logs` + external table `cloudfront_logs` over those logs.
+- An Athena workgroup `salishsea-monitoring` that writes query results to a dedicated, 30-day-expiry
+  results bucket.
+- Every `*.sql` file in this directory, saved as an Athena **named query** (the `.sql` files are the
+  source of truth; CDK loads them at synth time).
+
+## Usage
+
+1. Select the **`salishsea-monitoring`** workgroup in the Athena console (results location is preset).
+2. Run **`human_pageviews_view`** once to (re)create the `human_pageviews` view — it filters out bots,
+   scanners, and non-HTML assets. Re-run it whenever you adjust the bot filter.
+3. Run any of the numbered queries. All use a rolling 30-day window.
+
+Bots dominate the raw logs (uptime monitors + scanners are the large majority of requests), so the
+"human" queries read from the view, while `07_user_agents` and `08_status` read the raw table to keep
+the bot/health picture visible. When `07_user_agents` surfaces a new bot, add it to the filter in
+`human_pageviews_view.sql`.
+
+"Visitors" = distinct client IP — a rough proxy that overcounts roaming IPs and undercounts shared
+NAT. Geo/country is not available in legacy CloudFront logs.

--- a/infra/athena/human_pageviews_view.sql
+++ b/infra/athena/human_pageviews_view.sql
@@ -1,0 +1,26 @@
+-- View: human page views to salishsea.io, with bots/monitors/scanners and non-HTML assets filtered out.
+-- Run this once after the Glue table exists (it is also saved as an Athena named query by the CDK stack).
+-- "Page view" = a GET that returned an HTML document (200/304); CloudFront cannot see client-side SPA routes.
+CREATE OR REPLACE VIEW salishsea_logs.human_pageviews AS
+SELECT date, time, request_ip, uri, query_string, referrer, user_agent, status
+FROM salishsea_logs.cloudfront_logs
+WHERE sc_content_type LIKE 'text/html%'
+  AND method = 'GET'
+  AND status IN (200, 304)
+  AND user_agent <> '-'
+  AND lower(user_agent) NOT LIKE '%bot%'
+  AND lower(user_agent) NOT LIKE '%spider%'
+  AND lower(user_agent) NOT LIKE '%crawl%'
+  AND lower(user_agent) NOT LIKE '%uptime%'
+  AND lower(user_agent) NOT LIKE '%monitor%'
+  AND lower(user_agent) NOT LIKE '%headless%'
+  AND lower(user_agent) NOT LIKE '%slurp%'
+  AND lower(user_agent) NOT LIKE '%python%'
+  AND lower(user_agent) NOT LIKE '%curl%'
+  AND lower(user_agent) NOT LIKE '%wget%'
+  AND lower(user_agent) NOT LIKE '%go-http%'
+  AND lower(user_agent) NOT LIKE '%java/%'
+  AND lower(user_agent) NOT LIKE '%okhttp%'
+  AND lower(user_agent) NOT LIKE '%scrapy%'
+  AND lower(user_agent) NOT LIKE '%facebookexternalhit%'
+  AND lower(user_agent) NOT LIKE '%preview%';

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -7,8 +7,11 @@ import * as logs from 'aws-cdk-lib/aws-logs';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as acm from 'aws-cdk-lib/aws-certificatemanager';
+import * as glue from 'aws-cdk-lib/aws-glue';
+import * as athena from 'aws-cdk-lib/aws-athena';
 import { Construct } from 'constructs';
 import * as path from 'path';
+import * as fs from 'fs';
 
 const ACCOUNT_ID = '648183724555';
 
@@ -95,5 +98,97 @@ export class InfraStack extends cdk.Stack {
         ],
       },
     });
+
+    // --- Site-monitoring analytics over the CloudFront access logs (Glue + Athena) ---
+    // Ad-hoc analysis layer: a Glue catalog table over the access logs in `logBucket`, plus
+    // saved Athena queries. Query source of truth is infra/athena/*.sql; usage in infra/athena/README.md.
+
+    const athenaResultsBucket = new s3.Bucket(this, 'AthenaResults', {
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      enforceSSL: true,
+      lifecycleRules: [{ expiration: cdk.Duration.days(30) }],
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    const LOGS_DB = 'salishsea_logs';
+
+    const logsDatabase = new glue.CfnDatabase(this, 'LogsDatabase', {
+      catalogId: ACCOUNT_ID,
+      databaseInput: {
+        name: LOGS_DB,
+        description: 'CloudFront access-log analytics for salishsea.io',
+      },
+    });
+
+    // External table over the CloudFront standard (legacy) access logs. Field order is fixed
+    // by the CloudFront log format — see the #Fields header line in any log file.
+    const cloudfrontLogColumns: glue.CfnTable.ColumnProperty[] = [
+      { name: 'date', type: 'date' }, { name: 'time', type: 'string' },
+      { name: 'location', type: 'string' }, { name: 'sc_bytes', type: 'bigint' },
+      { name: 'request_ip', type: 'string' }, { name: 'method', type: 'string' },
+      { name: 'host', type: 'string' }, { name: 'uri', type: 'string' },
+      { name: 'status', type: 'int' }, { name: 'referrer', type: 'string' },
+      { name: 'user_agent', type: 'string' }, { name: 'query_string', type: 'string' },
+      { name: 'cookie', type: 'string' }, { name: 'result_type', type: 'string' },
+      { name: 'request_id', type: 'string' }, { name: 'host_header', type: 'string' },
+      { name: 'request_protocol', type: 'string' }, { name: 'cs_bytes', type: 'bigint' },
+      { name: 'time_taken', type: 'float' }, { name: 'xforwarded_for', type: 'string' },
+      { name: 'ssl_protocol', type: 'string' }, { name: 'ssl_cipher', type: 'string' },
+      { name: 'response_result_type', type: 'string' }, { name: 'http_version', type: 'string' },
+      { name: 'fle_status', type: 'string' }, { name: 'fle_encrypted_fields', type: 'int' },
+      { name: 'c_port', type: 'int' }, { name: 'time_to_first_byte', type: 'float' },
+      { name: 'x_edge_detailed_result_type', type: 'string' }, { name: 'sc_content_type', type: 'string' },
+      { name: 'sc_content_len', type: 'bigint' }, { name: 'sc_range_start', type: 'bigint' },
+      { name: 'sc_range_end', type: 'bigint' },
+    ];
+
+    const cloudfrontLogsTable = new glue.CfnTable(this, 'CloudFrontLogsTable', {
+      catalogId: ACCOUNT_ID,
+      databaseName: LOGS_DB,
+      tableInput: {
+        name: 'cloudfront_logs',
+        description: 'CloudFront standard (legacy) access logs for salishsea.io',
+        tableType: 'EXTERNAL_TABLE',
+        parameters: { EXTERNAL: 'TRUE', 'skip.header.line.count': '2' },
+        storageDescriptor: {
+          columns: cloudfrontLogColumns,
+          location: `s3://${logBucket.bucketName}/cloudfront/`,
+          inputFormat: 'org.apache.hadoop.mapred.TextInputFormat',
+          outputFormat: 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat',
+          serdeInfo: {
+            serializationLibrary: 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe',
+            parameters: { 'field.delim': '\t' },
+          },
+        },
+      },
+    });
+    cloudfrontLogsTable.addDependency(logsDatabase);
+
+    // Dedicated workgroup so monitoring queries write results to the bucket above by default.
+    const workgroup = new athena.CfnWorkGroup(this, 'MonitoringWorkGroup', {
+      name: 'salishsea-monitoring',
+      recursiveDeleteOption: true,
+      workGroupConfiguration: {
+        enforceWorkGroupConfiguration: true,
+        publishCloudWatchMetricsEnabled: false,
+        resultConfiguration: {
+          outputLocation: `s3://${athenaResultsBucket.bucketName}/`,
+        },
+      },
+    });
+
+    // Save every infra/athena/*.sql file as a named query (source of truth = the .sql files).
+    // human_pageviews_view.sql is one of these — run it once after deploy to (re)create the view.
+    const athenaDir = path.join(__dirname, '..', 'athena');
+    for (const file of fs.readdirSync(athenaDir).filter((f) => f.endsWith('.sql')).sort()) {
+      const slug = file.replace(/\.sql$/, '');
+      const namedQuery = new athena.CfnNamedQuery(this, 'NamedQuery' + slug.replace(/[^a-zA-Z0-9]/g, ''), {
+        name: slug,
+        database: LOGS_DB,
+        queryString: fs.readFileSync(path.join(athenaDir, file), 'utf8'),
+        workGroup: workgroup.name,
+      });
+      namedQuery.addDependency(workgroup);
+    }
   }
 }


### PR DESCRIPTION
## What

Codifies an Athena/Glue analytics layer over the **existing** CloudFront access logs (already shipped to the CDK-managed log bucket under `cloudfront/`), so we can answer "are people using salishsea.io, how do they arrive, and is it healthy."

Added to `InfraStack` ([infra/lib/infra-stack.ts](../blob/athena-site-monitoring/infra/lib/infra-stack.ts)):

- **Glue database** `salishsea_logs` + **external table** `cloudfront_logs` over the legacy standard logs (33-column CloudFront format, tab-delimited, 2 header lines skipped).
- **Athena workgroup** `salishsea-monitoring` writing to a dedicated results bucket (30-day lifecycle, public access blocked).
- A **`human_pageviews` view** (bots/scanners/non-HTML assets filtered out) plus monitoring queries — kept as `infra/athena/*.sql` (source of truth) and loaded into Athena **named queries** at synth time.

## Why this shape

The queries were first prototyped ad-hoc via the CLI to get immediate answers; this PR makes the durable pieces reproducible IaC rather than console clickops. The view + queries live as `.sql` (readable, diffable) instead of a brittle Glue `VIRTUAL_VIEW` resource.

## Deploy notes

- Merging to `main` auto-deploys (`cdk deploy --all`), creating the Glue/Athena resources in prod. The out-of-band CLI prototypes have already been deleted, so there's no name collision.
- **One manual post-deploy step:** in the Athena `salishsea-monitoring` workgroup, run the `human_pageviews_view` named query once to create the view (named queries are saved, not auto-executed). Then run the numbered queries.
- See [infra/athena/README.md](../blob/athena-site-monitoring/infra/athena/README.md) for usage.

## Caveats (documented in-repo)

- salishsea.io is an SPA, so CloudFront sees ~every page view as `/` — per-view/feature usage needs client-side analytics (Sentry/Plausible), not edge logs.
- "Visitors" = distinct IP (rough proxy). Geo/country isn't in legacy CloudFront logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a set of ready-to-run Athena queries for traffic, visitors, referrers, top pages, user agents, status codes, and hourly/daily trends over the last 30 days.
  * Added a human pageviews view to separate likely human browsing from automated traffic.
  * Added support for site monitoring analytics in Athena, including query results storage and saved queries.

* **Documentation**
  * Added setup and usage guidance for running the monitoring queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->