### PR TITLE
fix(share): stamp the resolved date into the URL on load

### DIFF
--- a/src/salish-sea.ts
+++ b/src/salish-sea.ts
@@ -62,6 +62,7 @@ function parseUrlParams(searchParams: URLSearchParams) {
 }
 
 const initialParams = parseUrlParams(new URLSearchParams(document.location.search));
+const hadDateParam = new URLSearchParams(document.location.search).has('d');
 
 let gsiReady: Promise<void> | null = null;
 function loadGSI(): Promise<void> {
@@ -318,6 +319,11 @@ export default class SalishSea extends LitElement {
   async connectedCallback(): Promise<void> {
     super.connectedCallback();
     window.addEventListener('popstate', this.#handlePopState);
+    // Reflect the resolved date in the URL so a link shared while viewing the default
+    // (today) is a permalink to that day, the way map coordinates already are. replaceState
+    // adds no history entry; skip when an occurrence permalink (?o=) already pins context.
+    if (!hadDateParam && !initialParams.occurrenceId)
+      setQueryParams({d: this.#date}, {replace: true});
     // If any credentials arrived before the component was defined, process them now.
     let token: string | undefined;
     while (token = window.__pendingGSIResponses?.shift()) {


### PR DESCRIPTION
## Problem

Links shared while viewing the default day lost their date. The `d` query param was only written to the URL by the `date` **setter** ([`src/salish-sea.ts:208`](../blob/fix-share-date-in-url/src/salish-sea.ts)), and only when the date actually *changed*. Initial load defaults the date to today ([`parseUrlParams`, :37](../blob/fix-share-date-in-url/src/salish-sea.ts)) **without** writing it back — so viewing today left the URL bare (`/`).

Result: a link copied while viewing today resolved to the **clicker's** today, not the day it was posted. Posts about a specific day's sightings silently pointed at the wrong day later. This also matches what the CloudFront logs show — nearly all referred visits land on `/` with no date.

## Fix

Mirror what map coordinates already do (`map-move` handler writes `x/y/z` immediately via `replaceState`, [:289](../blob/fix-share-date-in-url/src/salish-sea.ts)). On first load, if no `d` was supplied — and no `?o=` occurrence permalink already pins context — stamp the resolved date into the URL with `replaceState`:

- No history entry (back button unaffected).
- No extra fetch (writes the URL directly, doesn't go through the date setter).
- Every copied URL becomes a permalink to that calendar day.

## Behaviour change to be aware of

A link shared while viewing "today" now **pins to that date** forever (intended — it's the whole point for sighting shares), rather than always showing the latest. Minor cosmetic effect: the address bar shows `?d=YYYY-MM-DD` on every visit, consistent with how `x/y/z` already appear.

## Testing

`npm run build` (typecheck + CSP hash) and the full vitest suite pass (191 passed). Not adding an automated test here — exercising this path means mounting the full `salish-sea` component (Supabase/Sentry/map/GSI); happy to add one if you'd like. Manual check: load `/` → URL gains `?d=<today>`; load `/?o=<id>` → no spurious `d`; back/forward unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)