### PR TITLE
feat(seo): descriptive title/description + richer homepage social card

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,15 @@
       form-action 'none';
       upgrade-insecure-requests;
     ">
-    <title>SalishSea.io</title>
+    <title>Salish Sea — Whale &amp; Orca Sightings Map</title>
+    <meta name="description" content="An interactive map of whale and marine-mammal sightings across the Salish Sea, gathered from community sources like Whale Alert, Orca Network, and HappyWhale.">
+    <meta property="og:site_name" content="SalishSea.io">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://salishsea.io/">
+    <meta property="og:title" content="Salish Sea — Whale &amp; Orca Sightings Map">
+    <meta property="og:description" content="An interactive map of whale and marine-mammal sightings across the Salish Sea, gathered from community sources like Whale Alert, Orca Network, and HappyWhale.">
+    <meta property="og:image" content="https://salishsea.io/preview.jpg">
+    <meta name="twitter:card" content="summary_large_image">
     <link href="src/assets/favicon.ico" rel="icon" type="image/x-icon">
     <link rel="stylesheet" href="src/index.css" />
     <!-- The hash in the CSP must be updated when this code is updated. Run `npm run verify-csp` to check or find out the new hash. -->

--- a/infra/lib/edge-handler/index.test.ts
+++ b/infra/lib/edge-handler/index.test.ts
@@ -89,9 +89,11 @@ describe('Lambda@Edge OG meta handler', () => {
     const result = await handler(event) as { status: string; body: string };
     expect(result.status).toBe('200');
     expect(result.body).toContain('SalishSea.io');
-    // Generic preview must NOT have og:description or og:image
-    expect(result.body).not.toContain('og:description');
-    expect(result.body).not.toContain('og:image');
+    // Generic homepage preview now carries a description, fallback image, and a real <title>
+    expect(result.body).toContain('og:description');
+    expect(result.body).toContain('og:image');
+    expect(result.body).toContain('https://salishsea.io/preview.jpg');
+    expect(result.body).toContain('<title>');
   });
 
   it('returns occurrence-specific OG tags with correct title, description, and image for cc0 photo', async () => {
@@ -166,7 +168,8 @@ describe('Lambda@Edge OG meta handler', () => {
     const result = await handler(event) as { status: string; body: string };
     expect(result.status).toBe('200');
     expect(result.body).toContain('SalishSea.io');
-    expect(result.body).not.toContain('og:description');
+    // Falls back to the generic homepage preview, which now includes a description
+    expect(result.body).toContain('og:description');
   });
 
   it('returns request (fail-open) when Supabase fetch throws an error', async () => {

--- a/infra/lib/edge-handler/index.ts
+++ b/infra/lib/edge-handler/index.ts
@@ -62,15 +62,29 @@ function buildOgHtml(tags: OgTags): string {
       return `  <meta property="${prop}" content="${escapeHtml(content)}">`;
     })
     .join('\n');
-  return `<!DOCTYPE html><html><head>\n${metaTags}\n</head><body></body></html>`;
+  // Mirror og:title/og:description into a real <title> and meta description so the
+  // synthesized page is also useful to search snippet crawlers, not just social cards.
+  const titleTag = tags['og:title'] ? `  <title>${escapeHtml(tags['og:title'])}</title>\n` : '';
+  const descTag = tags['og:description']
+    ? `  <meta name="description" content="${escapeHtml(tags['og:description'])}">\n`
+    : '';
+  return `<!DOCTYPE html><html><head>\n${titleTag}${descTag}${metaTags}\n</head><body></body></html>`;
 }
+
+const SITE_TITLE = 'Salish Sea — Whale & Orca Sightings Map';
+const SITE_DESCRIPTION =
+  'An interactive map of whale and marine-mammal sightings across the Salish Sea, ' +
+  'gathered from community sources like Whale Alert, Orca Network, and HappyWhale.';
 
 function genericPreviewTags(): OgTags {
   return {
     'og:site_name': 'SalishSea.io',
     'og:type': 'website',
     'og:url': 'https://salishsea.io/',
-    'og:title': 'SalishSea.io',
+    'og:title': SITE_TITLE,
+    'og:description': SITE_DESCRIPTION,
+    'og:image': FALLBACK_IMAGE,
+    'twitter:card': 'summary_large_image',
   };
 }
 


### PR DESCRIPTION
## Why

Search Console shows impressions but ~no clicks. Root cause: Googlebot **isn't** in the edge handler's `BOT_AGENTS` list (only social crawlers + `google-snippet` are), so Google reads `index.html` directly — where the title was the bare brand `SalishSea.io` and there was **no meta description**. That produces an unenticing snippet regardless of rank.

Separately, the homepage social card (`genericPreviewTags()`) had **no `og:description` and no `og:image`**, so sharing `salishsea.io` on Bluesky/Facebook (which the logs show happens) produced a bare card.

## Changes

- **`index.html`** — descriptive `<title>` ("Salish Sea — Whale & Orca Sightings Map"), a `<meta name="description">`, and default OpenGraph/Twitter tags.
- **`edge-handler` `genericPreviewTags()`** — add `og:description`, `og:image` (existing `preview.jpg` fallback), and `twitter:card`.
- **`buildOgHtml()`** — also emit a real `<title>` and meta description (derived from `og:*`) so the synthesized bot page helps snippet crawlers, not just social unfurlers.
- **Tests** — updated the two cases that asserted the homepage card had *no* description/image; that was a deliberate prior decision now being reversed on purpose.

## Notes / accuracy

- Copy is drawn from the project's own description (sightings aggregated from Whale Alert, Orca Network, HappyWhale) — no overclaiming (e.g. didn't assert "live hydrophones").
- `og:image` currently points at the existing `preview.jpg` placeholder — **there's no real logo/branded social image yet**; swapping one in later is a one-line change in both `index.html` and `FALLBACK_IMAGE`.
- Verified: `npm run build` (tsc + html-validate + CSP hash) passes; 191 frontend tests + 18 infra tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved preview pages with a real page title and description metadata for better sharing and search visibility.
  * Updated homepage and fallback preview content to show richer social preview information, including a default image.

* **Bug Fixes**
  * Fixed missing metadata in preview responses so generic and “not found” cases now render consistent Open Graph and Twitter card details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->