### PR TITLE
perf(deploy): set Cache-Control on static assets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,8 +77,17 @@ jobs:
           DESTINATION_URL: s3://${{ vars.S3_BUCKET }}/site
           DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}
         run: |
-          aws s3 sync --no-progress dist "${DESTINATION_URL}"
-          aws cloudfront create-invalidation --distribution-id "${DISTRIBUTION_ID}" --paths /
+          # Content-hashed bundles under /assets are immutable — cache them hard so
+          # repeat visits (and PageSpeed) get a long TTL. Uploaded first.
+          aws s3 sync --no-progress dist "${DESTINATION_URL}" \
+            --exclude "*" --include "assets/*" \
+            --cache-control "public, max-age=31536000, immutable"
+          # Everything else (index.html, favicon, preview.jpg, …) is not content-hashed,
+          # so it must revalidate or new deploys won't be picked up.
+          aws s3 sync --no-progress dist "${DESTINATION_URL}" \
+            --exclude "assets/*" \
+            --cache-control "public, max-age=0, must-revalidate"
+          aws cloudfront create-invalidation --distribution-id "${DISTRIBUTION_ID}" --paths "/" "/index.html"
       - name: Setup Node for CDK
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:


### PR DESCRIPTION
## Why

PageSpeed Insights flags the static assets as having no efficient cache policy. The deploy's `aws s3 sync` uploaded everything **without `Cache-Control`**, and CloudFront's managed *CachingOptimized* policy won't synthesize a `Cache-Control` header for the browser when the origin doesn't send one. So the big content-hashed JS/CSS bundles were served to clients with no cache TTL — every visit re-downloads them.

## Fix

Upload in two passes with explicit `Cache-Control`:

- **`/assets/*`** — Vite content-hashes these (`main-<hash>.js`), so they're safe to cache forever: `public, max-age=31536000, immutable`.
- **Everything else** (`index.html`, `favicon.ico`, `preview.jpg`, …) — not content-hashed, so `public, max-age=0, must-revalidate` to guarantee new deploys are picked up. (CloudFront/S3 revalidate cheaply via ETag.)

Also invalidate `/index.html` alongside `/` on deploy.

## Notes

- New hashed filenames each build means the long-cache pass always covers the current bundle; stale assets remain for in-flight users but are unreferenced.
- Validated the workflow YAML parses. No app code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)