### PR TITLE
fix(e2e): align OG smoke tests with new homepage meta

### DIFF
--- a/e2e/og-previews.spec.ts
+++ b/e2e/og-previews.spec.ts
@@ -10,9 +10,9 @@ test('bot UA on homepage receives OG meta tags', async ({ request }) => {
   expect(body).toContain('og:title');
   expect(body).toContain('SalishSea.io');
   expect(body).toContain('og:type');
-  // Homepage should not include og:image or og:description
-  expect(body).not.toContain('og:image');
-  expect(body).not.toContain('og:description');
+  // Homepage card now carries a description and a fallback image
+  expect(body).toContain('og:description');
+  expect(body).toContain('og:image');
 });
 
 test('regular browser UA on homepage receives SPA', async ({ request }) => {
@@ -22,5 +22,7 @@ test('regular browser UA on homepage receives SPA', async ({ request }) => {
 
   expect(response.status()).toBe(200);
   const body = await response.text();
-  expect(body).not.toContain('og:title');
+  // Regular browsers get the real SPA shell (with the <salish-sea> root element),
+  // not the synthesized, empty-body bot preview page.
+  expect(body).toContain('<salish-sea>');
 });


### PR DESCRIPTION
The production smoke suite (`e2e/og-previews.spec.ts`, run against https://salishsea.io after each deploy) broke after #284:

- **bot-UA test** asserted the homepage card has *no* `og:image`/`og:description` — but #284 intentionally added both.
- **regular-browser test** used "body has no `og:title`" as a proxy for "got the SPA" — but #284 added `og:title` to `index.html`.

This updates both to the new intended behavior: assert the homepage card *includes* `og:description`/`og:image`, and detect the SPA via its `<salish-sea>` root element (the synthesized bot page has an empty `<body>`).

Root cause on my side: I ran vitest/jest/build but not the Playwright e2e smoke before the #284 PR.

> **Merge timing:** merge once no other Deploy run is in flight — the earlier failures included a transient `cdk deploy` collision (`stack … in UPDATE_COMPLETE_CLEANUP_IN_PROGRESS`) from several PRs deploying at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)