### PR TITLE
ci(deploy): serialize production deploys (concurrency group)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,13 @@ on:
   push:
     branches:
       - main
+# Serialize production deploys. Several PRs merging in quick succession otherwise
+# run overlapping `cdk deploy`s against the same CloudFormation stacks, which fails
+# with "stack ... in UPDATE_COMPLETE_CLEANUP_IN_PROGRESS". Queue instead of cancel:
+# never interrupt an in-flight deploy mid `supabase db push` / `cdk deploy`.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Adds a workflow-level `concurrency` group to `deploy.yml` so production deploys **queue** instead of overlapping.

Today's incident: #283/#284/#285/#287 merged within ~80 seconds, so their `cdk deploy`s ran simultaneously against the same CloudFormation stacks and one failed with `stack … in UPDATE_COMPLETE_CLEANUP_IN_PROGRESS`.

```yaml
concurrency:
  group: deploy-production
  cancel-in-progress: false
```

`cancel-in-progress: false` is deliberate — a queued deploy waits rather than interrupting an in-flight one mid `supabase db push` / `cdk deploy`.

YAML validated. Once this is in, rapid merges are safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)