### PR TITLE
perf(build): inline global stylesheet (remove render-blocking CSS)

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -26,6 +26,30 @@ export default defineConfig({
         return html.replace(/\s*upgrade-insecure-requests;?/g, '');
       },
     },
+    {
+      // Inline the tiny global stylesheet into <style> so it isn't a render-blocking
+      // request. CSP allows it (style-src has 'unsafe-inline'). Only touches CSS that
+      // has a <link> in index.html (main.css); JS-loaded CSS like OpenLayers' is untouched.
+      name: 'inline-critical-css',
+      apply: 'build',
+      enforce: 'post',
+      transformIndexHtml(html, ctx) {
+        if (!ctx?.bundle) return html;
+        let out = html;
+        for (const [fileName, asset] of Object.entries(ctx.bundle)) {
+          if (asset.type !== 'asset' || !fileName.endsWith('.css')) continue;
+          const escaped = fileName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+          const linkRE = new RegExp(`<link[^>]*href="[^"]*${escaped}"[^>]*>`);
+          if (!linkRE.test(out)) continue;
+          const css = typeof asset.source === 'string'
+            ? asset.source
+            : Buffer.from(asset.source).toString('utf8');
+          out = out.replace(linkRE, `<style>${css}</style>`);
+          delete ctx.bundle[fileName];
+        }
+        return out;
+      },
+    },
     sentryVitePlugin({
       bundleSizeOptimizations: {
         excludeReplayShadowDom: true,


### PR DESCRIPTION
PageSpeed flags `main.css` (~0.4 kB of global styles) as a render-blocking request. This inlines it.

A build-only `transformIndexHtml` Vite plugin inlines any CSS asset that has a `<link>` in `index.html` (just `main.css`) into a `<style>` tag and removes the now-redundant file from the bundle. `src/index.css` stays the source of truth.

- **CSP-safe:** `style-src` already has `'unsafe-inline'` (no hash/nonce), so inline styles are permitted; the CSP hash check only covers the inline *script*.
- **Scoped:** only CSS with a matching `<link>` is inlined. JS-loaded CSS (OpenLayers') has no `<link>`, so it's untouched and still code-split.

Verified `npm run build`: built `index.html` has no stylesheet `<link>`, a populated `<style>`, `main.css` no longer emitted, and html-validate + CSP-hash checks pass.

Note: this is a small, real win (removes one render-blocking request) but won't move the score much — the dominant factor is the ~1 MB (305 kB gzip) JS bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)