### PR TITLE
fix(a11y): accessible names for observation-panel controls

### DIFF
--- a/src/obs-panel.ts
+++ b/src/obs-panel.ts
@@ -127,10 +127,10 @@ export class ObsPanel extends LitElement {
       <header>
         <h2>Marine Mammal Observations</h2>
         <form>
-          <input @click=${this.onGotoYesterday} type="button" name="yesterday" value="◀">
-          <input @click=${this.onGotoTomorrow}  type="button" name="tomorrow" value="▶" ?disabled=${this.date === today}>
-          <input @change=${this.onDateChange} max=${today} min="2000-01-01" type="date" .value=${live(this.date)}>
-          <select @change=${this.onGoTo} name="go-to">
+          <input @click=${this.onGotoYesterday} type="button" name="yesterday" value="◀" aria-label="Previous day">
+          <input @click=${this.onGotoTomorrow}  type="button" name="tomorrow" value="▶" ?disabled=${this.date === today} aria-label="Next day">
+          <input @change=${this.onDateChange} max=${today} min="2000-01-01" type="date" .value=${live(this.date)} aria-label="Observation date">
+          <select @change=${this.onGoTo} name="go-to" aria-label="Go to a place">
             <option value='' selected disabled>Go to…</option>
             <option value=${pugetSoundExtent.join(',')}>Puget Sound</option>
             <option value=${salishSRKWExtent.join(',')}>Salish Sea</option>


### PR DESCRIPTION
PageSpeed/Lighthouse a11y flags on the observation panel (`src/obs-panel.ts`):
- the date `<input type="date">` had **no label**
- the "Go to…" `<select>` had **no accessible name** (the disabled placeholder option doesn't name the control)

Added `aria-label`s, and while there labeled the symbol-only day-step buttons too (their only accessible name was the `◀`/`▶` glyph):

| Control | aria-label |
|---|---|
| date input | Observation date |
| go-to select | Go to a place |
| ◀ button | Previous day |
| ▶ button | Next day |

`npm run build` + 191 tests pass.

Note: this should also clear the "accessibility tree is not well-formed" item if it stemmed from these unnamed form controls. If PageSpeed still reports it after deploy, it's coming from elsewhere (likely the map canvas or a custom-element role) — ping me and I'll trace it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility by adding descriptive labels to the date navigation buttons and the go-to dropdown.
  * Preserved existing date selection behavior and button disabling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->