### PR TITLE
docs: Orca Network community-uptake exploration

### DIFF
--- a/.planning/notes/community-uptake-orca-network-partnership.md
+++ b/.planning/notes/community-uptake-orca-network-partnership.md
@@ -53,24 +53,40 @@ site.
 
 Initial instinct was that the strongest offer to Orca Network was **#2 — credit
 their data** (their sightings become a named, attributed dataset in GBIF/OBIS
-via the v1.3 provenance graph). The research pass corrected this:
+via the v1.3 provenance graph). The research pass *and a user correction*
+sharpened this into a crucial distinction:
 
-- **Acartia is our own org** (github.com/salish-sea/acartia). Orca Network
-  *already* feeds sightings into Acartia → Ocean Wise's WRAS → Conserve.io.
-  >75% of WA sightings into WRAS (April 2024) came from Orca Network via
-  Acartia. So this is a **warm** relationship, not a cold start — and Orca
-  Network is a proven, culturally pro-open-data cooperative member.
-- Therefore **#2 (data credit) is mostly already solved** — open data isn't
-  their pain, and our DwC-A deliberately *excludes* self-publishing sources.
+- **Data *routing* is solved; data *story* is not.** Acartia is our own org
+  (github.com/salish-sea/acartia), and Orca Network *already* feeds sightings
+  into Acartia → Ocean Wise's WRAS → Conserve.io (>75% of WA sightings into WRAS
+  in April 2024 came from Orca Network via Acartia). So this is a **warm**
+  relationship, not a cold start. **But the plumbing is invisible** — Orca
+  Network is probably completely unaware their sightings ever reach GBIF or feed
+  research. The data moves; nobody *knows or feels* that it does.
+- Therefore **#2 is not "already solved" — it was mis-framed.** The unsolved,
+  differentiated thing is **telling the story**: making the research impact of
+  community/org observations *legible* — "these records, from these people and
+  this organization, are feeding science." That is a narrative/recognition
+  product surface, not a data-pipeline feature, and **nobody else does it.**
+  (Our DwC-A deliberately *excludes* self-publishing sources, so this is about
+  visibility/recognition, not adding another export path.)
+- The same insight collapses **#2 (story to the org/community) and #4 (story to
+  the individual sighter)** into one capability — the same storytelling muscle,
+  pointed at two audiences. This is the "it counts for something" thread the
+  user flagged at the start as one of the two strongest pulls; earlier framing
+  underweighted it.
 - The research **independently named our exact niche as the unfilled one:** "a
   modern, map-first, community-facing sightings UX that **reduces curation
   labor** and surfaces real-time shore sightings — distinct from mariner-alert
   (WRAS/Whale Alert) and photo-ID (Happywhale/iNaturalist) tools."
 
-**Conclusion:** the strongest offer is **#1 (delete their chore — kill the
-manual Facebook-to-report transcription) + #3 (a better field/coordination
-tool).** The data-credit (#2) and contribution-visibility (#4) become
-*reinforcing* benefits layered on top, not the lead.
+**Conclusion:** two distinct, real offers, not one lead + reinforcers:
+- For the shore regular's **moment**: **#1 (delete their chore — kill the manual
+  Facebook-to-report transcription) + #3 (a better field/coordination tool).**
+- For the org and community's **sense of meaning**: **the story** — make it
+  visible and felt that their observations feed real research (#2 to the org/
+  community, #4 to the individual sighter). Not a someday-promise; it leverages
+  the v1.2/v1.3 pipeline that already makes the contribution real.
 
 ## The prize (why it's worth it)
 

--- a/.planning/notes/community-uptake-orca-network-partnership.md
+++ b/.planning/notes/community-uptake-orca-network-partnership.md
@@ -1,0 +1,97 @@
+---
+title: Community uptake — win the shore regular via an Orca Network partnership
+date: 2026-06-29
+context: /gsd-explore session on improving uptake by the whale-sighting community
+related:
+  - .planning/PROJECT.md
+  - .planning/research/questions.md
+  - .planning/seeds/sighter-contribution-visible.md
+---
+
+# Community uptake: win the shore regular via an Orca Network partnership
+
+Captures the strategy that emerged from the 2026-06-29 `/gsd-explore` session.
+The first four milestones were all backend/data plumbing (links, partner-org
+links, DwC-A export, provenance graph). This is the first deliberate look at
+**community uptake** — getting the whale-sighting community to actually use the
+site.
+
+## The reasoning chain (target → persona → competitor → wedge)
+
+1. **Target behavior = first-party submissions.** "Uptake working" means
+   sighters *log on SalishSea.io first* (or here AND Facebook), not just visits
+   or shares. Submissions are the metric.
+
+2. **Primary persona = the shore regular.** The high-value, mission-driven
+   sighter who lives on the water, watches often, and is already in the Orca
+   Network Facebook orbit. Hard to pry from Facebook, but anchors the data and
+   the community. (Deliberately *not* optimizing first for the enthusiast
+   newcomer, naturalist/operator, or accidental tourist.)
+
+3. **The real competitor isn't "Facebook."** It's one specific function that
+   happens to live inside a Facebook group: **Orca Network's real-time
+   sighting-coordination feed.** A post ("orcas northbound past Lime Kiln!")
+   mobilizes the regulars, who reply with updates and track the pod up the
+   strait; later Orca Network staff manually transcribe those posts into the
+   historical record. That delivers both the sighter's reciprocity ("where are
+   they, where headed") and the contribution-to-record motive — crudely, as
+   unstructured text with no map, no trajectory, no search, total lock-in.
+
+4. **The wedge = do that coordination function properly.** A map-first,
+   structured, trajectory-aware real-time sighting tool is a categorically
+   better fit for the job than a Facebook feed. The shore regular won't *abandon*
+   the FB group (community + social reward), so integration must let them keep
+   that audience while the canonical, structured record lives here.
+
+5. **Lead with the relationship, not a scraping hack.** Chosen integration
+   direction: **partner with Orca Network** — make the site the tool Orca
+   Network *uses* to coordinate and record sightings, so the community follows
+   the org they're already loyal to. The shore regular is loyal to Orca Network
+   (Howard Garrett & Susan Berta), not to "Facebook."
+
+## The offer reframe (the important correction)
+
+Initial instinct was that the strongest offer to Orca Network was **#2 — credit
+their data** (their sightings become a named, attributed dataset in GBIF/OBIS
+via the v1.3 provenance graph). The research pass corrected this:
+
+- **Acartia is our own org** (github.com/salish-sea/acartia). Orca Network
+  *already* feeds sightings into Acartia → Ocean Wise's WRAS → Conserve.io.
+  >75% of WA sightings into WRAS (April 2024) came from Orca Network via
+  Acartia. So this is a **warm** relationship, not a cold start — and Orca
+  Network is a proven, culturally pro-open-data cooperative member.
+- Therefore **#2 (data credit) is mostly already solved** — open data isn't
+  their pain, and our DwC-A deliberately *excludes* self-publishing sources.
+- The research **independently named our exact niche as the unfilled one:** "a
+  modern, map-first, community-facing sightings UX that **reduces curation
+  labor** and surfaces real-time shore sightings — distinct from mariner-alert
+  (WRAS/Whale Alert) and photo-ID (Happywhale/iNaturalist) tools."
+
+**Conclusion:** the strongest offer is **#1 (delete their chore — kill the
+manual Facebook-to-report transcription) + #3 (a better field/coordination
+tool).** The data-credit (#2) and contribution-visibility (#4) become
+*reinforcing* benefits layered on top, not the lead.
+
+## The prize (why it's worth it)
+
+- ~1,150 reporters/year, **¾ first-timers** → the *regulars* are the curating
+  core worth winning.
+- **15,000-subscriber email list** + ~140k+ Facebook followers. If Orca
+  Network advocates, uptake is real.
+
+## The one true gap
+
+The whole strategy rests on a partner we don't yet understand well enough.
+**Next move is discovery, not engineering:** talk to Howard Garrett & Susan
+Berta to learn their actual curation workflow, where the pain is, and what
+they'd value. Open questions captured in `research/questions.md`. Picking the
+offer without that is guessing.
+
+## What was explicitly NOT chosen (paths considered and set aside)
+
+- **Cross-post outward / ingest inward / bridge both ways** — set aside in favor
+  of the partnership-led framing (integration becomes a *feature of* the
+  partnership, not the strategy itself).
+- **Make-the-site-welcoming-to-newcomers** — the user's other stated idea;
+  deprioritized relative to winning the shore regular first. Newcomer onboarding
+  matters more once the map is populated and the partnership gives it gravity.

--- a/.planning/research/questions.md
+++ b/.planning/research/questions.md
@@ -59,6 +59,16 @@ Orca Network already feeds Acartia (our own org) → WRAS → Conserve.io. What
 exactly flows, at what granularity/latency, and what does it *not* capture that a
 community-facing surface would? Avoid rebuilding what Acartia already does.
 
+### Does the research-impact story land — and do they even know it's happening?
+
+Hypothesis: Orca Network is probably unaware their sightings already reach
+GBIF/research (the Acartia → WRAS plumbing is invisible). Would making that
+impact *visible and felt* — "the observations from your organization and your
+community are feeding science" — be meaningful recognition they'd value, and
+would it motivate their members? This tests whether storytelling/legibility (not
+data routing, which is solved) is a primary partnership hook. See the strategy
+note's "offer reframe."
+
 ### What would make them say no?
 
 Threat perception (competitor vs. amplifier), data ownership/control concerns,

--- a/.planning/research/questions.md
+++ b/.planning/research/questions.md
@@ -23,3 +23,50 @@ needs to be final.
 - [GBIF EIA best practices](https://docs.gbif.org/eia-best-practices/1.0/en/)
 - [Happywhale on OBIS-SEAMAP IPT (zd_1764)](https://ipt.env.duke.edu/resource?r=zd_1764)
 - [Darwin Core Quick Reference](https://dwc.tdwg.org/terms/)
+
+---
+
+## Community uptake / Orca Network partnership
+
+**Surfaced:** 2026-06-29 (`/gsd-explore` session on community uptake — see
+`.planning/notes/community-uptake-orca-network-partnership.md`)
+
+**Why these matter:** the whole uptake strategy (win the shore regular by making
+SalishSea.io the tool Orca Network uses) rests on a partner we don't yet
+understand well enough. These need answering — largely via a discovery
+conversation with Howard Garrett & Susan Berta — *before* committing engineering.
+
+**Answer needed before:** scoping a community-uptake milestone / choosing the
+lead offer to Orca Network.
+
+### What is Orca Network's actual sighting-curation workflow, and where's the pain?
+
+How exactly do sightings move from a Facebook post / web form / phone / email
+into their daily sightings transcription? How manual is it, who does it, how many
+hours/day, and what's the most painful part? (This validates or kills the "#1
+delete-the-chore" offer.)
+
+### Would they value a map-first structured field tool — and would they advocate for it?
+
+Would a real-time, mapped, trajectory-aware sighting tool actually fit how their
+regulars work, or is the Facebook feed's social/low-friction nature the point?
+And critically: would Orca Network point their ~15k-subscriber email list and
+~140k+ Facebook followers at it?
+
+### What is the current Acartia data-flow granularity, and where does SalishSea.io add value vs. duplicate it?
+
+Orca Network already feeds Acartia (our own org) → WRAS → Conserve.io. What
+exactly flows, at what granularity/latency, and what does it *not* capture that a
+community-facing surface would? Avoid rebuilding what Acartia already does.
+
+### What would make them say no?
+
+Threat perception (competitor vs. amplifier), data ownership/control concerns,
+co-branding expectations, effort to change habits, dependence on a volunteer
+org's bandwidth. Surface the objections before pitching.
+
+**Pointers:**
+- [Orca Network — Report Sightings](https://www.orcanetwork.org/report-sightings)
+- [Orca Network — Whale Sighting Network](https://www.orcanetwork.org/sightings-network)
+- [Acartia (our org)](https://github.com/salish-sea/acartia)
+- [Ocean Wise WRAS](https://ocean.org/whales/wras/)

--- a/.planning/seeds/sighter-contribution-visible.md
+++ b/.planning/seeds/sighter-contribution-visible.md
@@ -29,14 +29,23 @@ contribution is *already real and attributable*. What's missing is only the
 **thin UI layer that makes it legible to the person who logged it** — there's no
 new pipeline to build.
 
-## Why it's a reinforcer, not the lead
+## Two audiences, one storytelling muscle
 
-Per the uptake strategy note, #4 (contribution visibility) and #2 (data credit)
-*reinforce* the lead offer (#1 delete-the-chore + #3 better tool); they don't
-carry adoption on their own. So this seed is a **layer on top of** the
-partnership play, best shipped once the map is populated (otherwise a lone
-contribution feels lonely). Sequence it after the Orca Network direction is
-confirmed.
+This is half of a single capability: **make the research impact of community
+observations legible.** Point it at two audiences:
+
+- **The individual sighter** (#4) — "your sighting is now part of the record /
+  feeds research."
+- **The org and community** (#2) — "the observations from *this organization and
+  these people* are feeding science." Critically, partners like Orca Network are
+  probably **completely unaware** their sightings ever reach GBIF/research today
+  (the Acartia → WRAS plumbing is invisible). Telling that story is unsolved and
+  differentiated — see the strategy note's "offer reframe."
+
+So this is **not merely a reinforcer** — for the partnership it may be a primary
+hook, because it gives an org real, felt recognition for decades of work nobody
+has surfaced. Sequence after the map is populated (a lone contribution feels
+lonely) and after the Orca Network direction is confirmed.
 
 ## Open design questions
 

--- a/.planning/seeds/sighter-contribution-visible.md
+++ b/.planning/seeds/sighter-contribution-visible.md
@@ -1,0 +1,48 @@
+---
+title: Make the sighter's contribution visible (thin UI over v1.3 provenance)
+trigger_condition: a community-uptake milestone is started (post Orca Network discovery), AND there is appetite for a sighter-facing surface that rewards logging on the site
+planted_date: 2026-06-29
+related:
+  - .planning/notes/community-uptake-orca-network-partnership.md
+  - .planning/PROJECT.md
+---
+
+# Seed: make the sighter's contribution visible
+
+## The idea
+
+Give a sighter visible, immediate proof that **their observation counts** —
+that it landed in the canonical record and feeds the scientific/open-data
+pipeline (Acartia → WRAS, the nightly DwC-A → GBIF). E.g. after logging:
+"Your sighting is now part of the Salish Sea record — it'll appear in tonight's
+DarwinCore Archive," plus a personal view of "your contributions" on the map.
+
+This is the **"it counts for something" (#4)** motive from the uptake
+exploration, rendered as a sighter-facing surface.
+
+## Why it's cheap
+
+The hard part is **already built.** The v1.2 DwC-A export and the v1.3
+provenance graph (provider · collection · organization · contributor +
+per-sighting FKs, real `recordedBy`, `recordedByID`/ORCID emit) mean the
+contribution is *already real and attributable*. What's missing is only the
+**thin UI layer that makes it legible to the person who logged it** — there's no
+new pipeline to build.
+
+## Why it's a reinforcer, not the lead
+
+Per the uptake strategy note, #4 (contribution visibility) and #2 (data credit)
+*reinforce* the lead offer (#1 delete-the-chore + #3 better tool); they don't
+carry adoption on their own. So this seed is a **layer on top of** the
+partnership play, best shipped once the map is populated (otherwise a lone
+contribution feels lonely). Sequence it after the Orca Network direction is
+confirmed.
+
+## Open design questions
+
+- What's the unit of visible reward — a per-sighting confirmation, a running
+  "your contributions" count, a personal map layer, or all three?
+- Does it tie to auth identity (Google sign-in) and the `contributor` record, so
+  a regular sees their *cumulative* contribution over time?
+- How loud should it be? Mission-driven shore regulars may prefer understated
+  legitimacy over gamified badges.


### PR DESCRIPTION
Captures the `/gsd-explore` session on improving uptake of SalishSea.io by the whale-sighting community. Docs-only — no code, no deploy impact.

## What's here

- **`.planning/notes/community-uptake-orca-network-partnership.md`** — the strategy: win the *shore regular* by making SalishSea.io the map-first coordination + curation tool that **Orca Network** uses, so their community follows. Includes the offer reframe: data *routing* is already solved (Orca Network → Acartia → WRAS), but the data *story* (their observations feed research) is not — and that storytelling is the differentiated, unsolved value.
- **`.planning/research/questions.md`** (appended) — discovery questions to answer *before* committing engineering: Orca Network's real curation workflow + pain, whether a map-first tool fits, Acartia data-flow granularity, the research-impact story, and what would make them say no.
- **`.planning/seeds/sighter-contribution-visible.md`** — forward-looking idea: a thin UI over the v1.3 provenance graph that makes a sighter's (and the org's) contribution to the scientific record visible.

The single gating insight: the next move is **discovery (talk to Howard & Susan)**, not engineering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added planning notes for a community partnership approach and a clearer way to present contributor impact.
  * Expanded the open research questions around partner workflows, data flow, recognition, and potential adoption concerns.
  * Added a concept note for making individual contributions more visible through a lightweight interface and clearer storytelling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->