### PR TITLE
feat: encourage sighting submissions with a sidebar value-proposition callout

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-06-19)
 Phase: Milestone v1.3 complete
 Plan: —
 Status: Awaiting next milestone
-Last activity: 2026-06-24 — Milestone v1.3 completed and archived
+Last activity: 2026-07-02 — Completed quick task 260702-i4d: sidebar contribution pitch
 
 ## Accumulated Context
 
@@ -94,6 +94,7 @@ Items acknowledged and deferred at v1.3 roadmap creation (2026-06-19):
 |---|-------------|------|--------|-----------|
 | 260526-scf | Add taxon id 526556 Lutrinae to iNaturalist observations query migration | 2026-05-27 | 370c786 | [260526-scf-add-taxon-id-526556-lutrinae-to-inatural](./quick/260526-scf-add-taxon-id-526556-lutrinae-to-inatural/) |
 | 260629-ggu | Break the About popover out into its own /about.html page (Vite multi-page; dialog removed; static-HTML content for SEO; zero infra change) | 2026-06-29 | cf2f3d1 | [260629-ggu-break-the-about-popover-out-into-its-own](./quick/260629-ggu-break-the-about-popover-out-into-its-own/) |
+| 260702-i4d | Add sidebar value-proposition line ("the public is our best source of data on how whales use these waters") above Add-a-Sighting, shown to logged-out visitors only | 2026-07-02 | f014316 | [260702-i4d-add-sidebar-value-proposition-line-encou](./quick/260702-i4d-add-sidebar-value-proposition-line-encou/) |
 
 ## Session Continuity
 

--- a/.planning/quick/260702-i4d-add-sidebar-value-proposition-line-encou/260702-i4d-PLAN.md
+++ b/.planning/quick/260702-i4d-add-sidebar-value-proposition-line-encou/260702-i4d-PLAN.md
@@ -1,0 +1,60 @@
+---
+quick_id: 260702-i4d
+title: Add sidebar value-proposition line encouraging sighting submissions
+date: 2026-07-02
+mode: quick
+---
+
+# Quick Task 260702-i4d: Sidebar contribution pitch
+
+## Goal
+
+Add a single-line value-proposition message to the sidebar (`src/obs-panel.ts`)
+that motivates logged-out visitors to submit their whale sightings. UI + copy
+task — deliberate about layout, spacing, and the responsive portrait layout.
+
+## Context
+
+This came out of a product conversation. The original "reward the sighter after
+they submit" idea (planted seed `sighter-contribution-visible.md`) was reframed:
+a post-submission thank-you is only seen *after* submitting, and realistically
+~2 people do all the submissions, so we don't want to slow them down or get in
+their faces. Instead: persistent, ambient sidebar messaging visible to
+**logged-out** visitors, encouraging first-party submission.
+
+The hook is the unique value proposition (user's words): **the public is our
+best source of granular data about how whales use these waters** — the sighter's
+distributed shore vantage sees what surveys can't. This is sharper and more
+distinctive than a generic "contribute to science" appeal.
+
+## Decisions (locked)
+
+- Single line of copy, landing the "public is our best source of data" point.
+- Shown to logged-out visitors only; hidden once signed in (gate on `this.user`
+  via the existing `userContext` consume). Do not nag the known contributors.
+- Also hidden while the sighting form is open (`this.showForm`) — no pitch when
+  the user is already mid-submission.
+- Placed directly above the existing "Add a Sighting" button so it reads
+  motivation → action.
+- Static copy only. No backend, no live numbers, no schema change.
+- Subtle link to `/about.html` for the fuller story ("Learn more.").
+
+## Tasks
+
+1. **Add the pitch to `obs-panel.ts`.**
+   - `files`: `src/obs-panel.ts`
+   - `action`: Add a `.contribute-pitch` styled `<p>` (muted `#444`, 0.875rem,
+     line-height 1.4) with the value-prop sentence + a `/about.html` link.
+     Render it conditionally (`!this.user && !this.showForm`) immediately before
+     the `button[name=show]`. Reuse the panel's existing `gap: 1rem` flex spacing
+     rather than adding bespoke margins.
+   - `verify`: `npx tsc --noEmit` clean; `npx vitest run` green; visual check in
+     dev server (logged-out) on a busy day and an empty day.
+   - `done`: Muted pitch line renders above the button for logged-out visitors,
+     disappears when the form opens; layout clean at 25rem and full-width.
+
+## Out of scope
+
+- Post-submission confirmation / personal "your contributions" view (deferred).
+- Org/community-facing research-impact story (blocked on Orca Network discovery).
+- Live impact numbers (future enhancement).

--- a/.planning/quick/260702-i4d-add-sidebar-value-proposition-line-encou/260702-i4d-SUMMARY.md
+++ b/.planning/quick/260702-i4d-add-sidebar-value-proposition-line-encou/260702-i4d-SUMMARY.md
@@ -1,0 +1,52 @@
+---
+quick_id: 260702-i4d
+title: Add sidebar value-proposition line encouraging sighting submissions
+date: 2026-07-02
+status: complete
+commit: f014316
+---
+
+# Quick Task 260702-i4d: Summary
+
+## What changed
+
+`src/obs-panel.ts` — added a `.contribute-pitch` paragraph rendered
+conditionally (`!this.user && !this.showForm`) immediately above the
+`button[name=show]` ("Add a Sighting"):
+
+> The public is our best source of data on how whales use these waters — add
+> what you see. [Learn more.](/about.html)
+
+Styled muted (`#444`, 0.875rem, line-height 1.4, no bespoke margin — it inherits
+the panel's `gap: 1rem` flex spacing). The "Learn more." link uses the panel's
+accent blue (`#1976d2`) with `white-space: nowrap`.
+
+## Behavior
+
+- **Logged-out visitors** see the pitch above the CTA button (motivation →
+  action).
+- **Signed-in users** never see it — the `userContext` gate hides it, so the
+  ~2 known contributors aren't nagged.
+- **Hidden while the form is open** (`showForm`) — no pitch mid-submission.
+
+## Verification
+
+- `npx tsc --noEmit` — clean.
+- `npx vitest run` — 195 passed, 11 skipped (unchanged from baseline; no new
+  tests — pure presentational copy).
+- Visual check in dev server (logged-out):
+  - Busy day: pitch sits between date-nav and the button, above the occurrence
+    cards. Reads cleanly.
+  - Empty day: fills the otherwise-blank space between header and button —
+    improves the empty state.
+  - Portrait/full-width panel not captured (browser tooling rendered landscape
+    regardless of window resize); low risk — a wider container only reduces
+    wrapping for a plain block paragraph.
+
+## Notes / follow-ups (unchanged, still deferred)
+
+- Post-submission confirmation + personal "your contributions" view — deferred.
+- Org/community research-impact story (the Orca Network hook) — blocked on
+  partner discovery (talk to Garrett & Berta first).
+- Live impact numbers ("N sightings in last night's archive") — future
+  enhancement.

--- a/src/obs-panel.ts
+++ b/src/obs-panel.ts
@@ -99,13 +99,21 @@ export class ObsPanel extends LitElement {
       background-color: rgba(128, 128, 128, 0.1);
     }
     .contribute-pitch {
-      color: #444;
-      font-size: 0.875rem;
-      line-height: 1.4;
+      background: rgba(25, 118, 210, 0.08);
+      border-left: 3px solid #1976d2;
+      border-radius: 4px;
+      color: #1f2d3d;
+      font-size: 0.9375rem;
+      line-height: 1.45;
       margin: 0;
+      padding: 0.625rem 0.75rem;
+    }
+    .contribute-pitch strong {
+      font-weight: 600;
     }
     .contribute-pitch a {
       color: #1976d2;
+      font-weight: 600;
       white-space: nowrap;
     }
     .hide {
@@ -163,7 +171,7 @@ export class ObsPanel extends LitElement {
       `)}
       ${!this.user && !this.showForm ? html`
         <p class="contribute-pitch">
-          The public is our best source of data on how whales use these waters — add what you see.
+          The public is our <strong>best source of data on how whales use these waters</strong> — add what you see.
           <a href="/about.html">Learn more.</a>
         </p>
       ` : ''}

--- a/src/obs-panel.ts
+++ b/src/obs-panel.ts
@@ -98,6 +98,16 @@ export class ObsPanel extends LitElement {
     sighting-form {
       background-color: rgba(128, 128, 128, 0.1);
     }
+    .contribute-pitch {
+      color: #444;
+      font-size: 0.875rem;
+      line-height: 1.4;
+      margin: 0;
+    }
+    .contribute-pitch a {
+      color: #1976d2;
+      white-space: nowrap;
+    }
     .hide {
       display: none;
     }
@@ -151,6 +161,12 @@ export class ObsPanel extends LitElement {
           date=${this.date}
         ></sighting-form>
       `)}
+      ${!this.user && !this.showForm ? html`
+        <p class="contribute-pitch">
+          The public is our best source of data on how whales use these waters — add what you see.
+          <a href="/about.html">Learn more.</a>
+        </p>
+      ` : ''}
       <button class=${classMap({hide: this.showForm})} @click=${this.doShowForm} type="button" name="show">
         <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px">${cameraAddIcon}</svg>
         <span>Add a Sighting</span>


### PR DESCRIPTION
## What

Adds a single-line value-proposition callout to the observations sidebar (`obs-panel`) that encourages visitors to log their own whale sightings:

> The public is our **best source of data on how whales use these waters** — add what you see. [Learn more.](/about.html)

## Why

The first four milestones were all backend/data plumbing. This is a small, cheap step toward community uptake: it surfaces the site's unique value proposition — the sighter's distributed shore vantage sees things surveys can't — right where someone might act on it, next to the "Add a Sighting" button. It leans on the already-shipped open-data pipeline (nightly DwC-A → researchers), so there's no new backend.

The original idea was a post-submission thank-you, but that's only seen *after* submitting, and realistically ~2 people do all the submissions today — we don't want to slow them down or nag them. An ambient, logged-out-facing pitch reaches the incidental visitor instead.

## Behavior

- Shown to **logged-out visitors only** — hidden once signed in (gated on `userContext`), so known contributors aren't nagged.
- Hidden while the sighting form is open — no pitch mid-submission.
- Styled as a light callout (brand-blue left accent, tinted background, bolded value phrase) so it reads as one motivation→action unit with the button below.
- Static copy, no backend, no schema change.

## Screenshots

**Desktop (side panel):**

![Desktop sidebar with contribution callout](https://raw.githubusercontent.com/salish-sea/salishsea-io/pr-assets-260702-i4d/desktop.png)

**Mobile (portrait / column layout):**

![Mobile portrait with contribution callout](https://raw.githubusercontent.com/salish-sea/salishsea-io/pr-assets-260702-i4d/mobile.png)

## Test plan

- `npx tsc --noEmit` — clean
- `npx vitest run` — 195 passed, 11 skipped (no new tests; presentational copy)
- Visual check via Playwright at desktop (1280×800) and mobile (390×844) viewports, logged-out, on a populated day.

## Notes

- Also includes the GSD quick-task tracking docs under `.planning/quick/260702-i4d-…`.
- Deferred (out of scope here): post-submission confirmation, a personal "your contributions" view, and the org/community-facing research-impact story (the Orca Network hook, still pending partner discovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
