### PR TITLE
feat(edge): emit fb:app_id in preview meta tags

### DIFF
--- a/infra/lib/edge-handler/index.test.ts
+++ b/infra/lib/edge-handler/index.test.ts
@@ -96,6 +96,8 @@ describe('Lambda@Edge OG meta handler', () => {
     expect(result.body).toContain('<title>');
     // ...and a real <meta name="description"> for search snippets, not just og:*
     expect(result.body).toContain('<meta name="description"');
+    // fb:app_id enables Facebook Domain Insights and clears the debugger warning
+    expect(result.body).toContain('<meta property="fb:app_id" content="678644427974059">');
   });
 
   it('returns occurrence-specific OG tags with correct title, description, and image for cc0 photo', async () => {
@@ -113,6 +115,8 @@ describe('Lambda@Edge OG meta handler', () => {
     expect(result.body).toContain('<meta name="description" content="3 Orca');
     // Image is the photo src
     expect(result.body).toContain('https://example.com/orca.jpg');
+    // fb:app_id present on occurrence cards too
+    expect(result.body).toContain('<meta property="fb:app_id" content="678644427974059">');
   });
 
   it('uses branded fallback image when photo has cc-by-nc license', async () => {

--- a/infra/lib/edge-handler/index.ts
+++ b/infra/lib/edge-handler/index.ts
@@ -89,6 +89,7 @@ function genericPreviewTags(): OgTags {
     'og:description': SITE_DESCRIPTION,
     'og:image': FALLBACK_IMAGE,
     'twitter:card': 'summary_large_image',
+    'fb:app_id': FB_APP_ID,
   };
 }
 
@@ -108,6 +109,9 @@ interface Occurrence {
 // Only cc0 and cc-by are unambiguously open for re-use
 const OPEN_LICENSES = ['cc0', 'cc-by'];
 const FALLBACK_IMAGE = 'https://salishsea.io/preview.jpg';
+// Public Facebook App ID — links shared content to our FB app for Domain Insights.
+// Not a secret; it appears in page meta by design.
+const FB_APP_ID = '678644427974059';
 
 export const handler = async (event: any): Promise<any> => {
   const request = event.Records[0].cf.request;
@@ -205,6 +209,7 @@ export const handler = async (event: any): Promise<any> => {
       'og:description': description,
       'og:image': imageUrl,
       'twitter:card': 'summary_large_image',
+      'fb:app_id': FB_APP_ID,
     };
 
     return {


### PR DESCRIPTION
Adds the public Facebook App ID (`678644427974059`) to the OG meta tags emitted by the Lambda@Edge preview handler — on both the generic site card and occurrence cards.

Clears the Sharing Debugger's "required property missing: fb:app_id" warning and enables [Facebook Domain Insights](https://developers.facebook.com/docs/sharing/domain-insights) on shared links. The App ID is public by design (it's embedded in page meta for every visitor) — not a secret, so it's hard-coded rather than pulled from SSM.

Tests assert `<meta property="fb:app_id" content="678644427974059">` on both card types; edge-handler suite green (30 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Facebook app ID meta tag to generated preview pages, improving social preview metadata for shared links.
  * The same metadata is now included for both general previews and occurrence-specific previews.

* **Tests**
  * Updated HTML checks to verify the new meta tag is present in rendered preview output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->