### PR TITLE
Ingest rewrite: Deno Edge Function shell for Maplify (89d.1)

### DIFF
--- a/scripts/ingest/fixtures/maplify-sample.json
+++ b/scripts/ingest/fixtures/maplify-sample.json
@@ -1,5 +1,5 @@
 {
-  "count": 6,
+  "count": "6",
   "results": [
     {
       "type": "sighting",

--- a/scripts/ingest/maplify.test.ts
+++ b/scripts/ingest/maplify.test.ts
@@ -61,12 +61,12 @@ describe('parseMaplifyResponse', () => {
         expect(r.sightings).toHaveLength(fixture.results.length);
     });
 
-    test('normalizes blank scientific_name and photo_url to null; 0/1 to boolean', () => {
+    test('keeps blank scientific_name verbatim (mirror column); nulls blank photo_url; 0/1 to boolean', () => {
         const r = parseMaplifyResponse(fixture);
         expect(r.ok).toBe(true);
         if (!r.ok) return;
         const blankSci = r.sightings.find((s) => s.id === 252129);
-        expect(blankSci?.scientificName).toBeNull();
+        expect(blankSci?.scientificName).toBe(''); // verbatim, not null — column is NOT NULL
         for (const s of r.sightings) {
             expect(typeof s.inOcean).toBe('boolean');
             expect(s.photoUrl === null || s.photoUrl.length > 0).toBe(true);
@@ -144,13 +144,18 @@ describe('resolveScientificName', () => {
     });
 
     test('falls back to the common-name map when scientific name is blank', () => {
-        expect(resolveScientificName(norm({ scientificName: null, name: 'California Sea Lion' })))
+        expect(resolveScientificName(norm({ scientificName: '', name: 'California Sea Lion' })))
+            .toBe('Zalophus californianus');
+    });
+
+    test('trims a whitespace-only scientific name before falling back', () => {
+        expect(resolveScientificName(norm({ scientificName: '   ', name: 'California Sea Lion' })))
             .toBe('Zalophus californianus');
     });
 
     test('returns null when neither resolves', () => {
-        expect(resolveScientificName(norm({ scientificName: null, name: 'Blue Whale' }))).toBeNull();
-        expect(resolveScientificName(norm({ scientificName: null, name: null }))).toBeNull();
+        expect(resolveScientificName(norm({ scientificName: '', name: 'Blue Whale' }))).toBeNull();
+        expect(resolveScientificName(norm({ scientificName: '', name: null }))).toBeNull();
     });
 });
 

--- a/scripts/ingest/maplify.test.ts
+++ b/scripts/ingest/maplify.test.ts
@@ -74,8 +74,14 @@ describe('parseMaplifyResponse', () => {
     });
 
     test('accepts a successful-but-empty result set (authoritative empty)', () => {
-        const r = parseMaplifyResponse({ count: 0, results: [] });
+        const r = parseMaplifyResponse({ count: '0', results: [] });
         expect(r).toEqual({ ok: true, sightings: [] });
+    });
+
+    test('tolerates the live API string-typed `count` field (regression)', () => {
+        // Maplify returns count as a string, e.g. "99"; we ignore it and must not fail.
+        const r = parseMaplifyResponse({ count: '99', results: [rawRecord] });
+        expect(r.ok).toBe(true);
     });
 
     test('rejects a malformed envelope (results not an array)', () => {

--- a/scripts/ingest/maplify.ts
+++ b/scripts/ingest/maplify.ts
@@ -108,8 +108,13 @@ export type NormalizedSighting = {
     readonly projectId: number;
     readonly tripId: number;
     readonly name: string | null;
-    /** Blank upstream scientific_name is normalized to null. */
-    readonly scientificName: string | null;
+    /**
+     * Stored verbatim (may be '') — maplify.sightings is an upstream mirror
+     * (decision 008) and its scientific_name column is NOT NULL. Taxon resolution
+     * uses resolveScientificName, which trims and falls back; it does not depend
+     * on this being nulled.
+     */
+    readonly scientificName: string;
     readonly lon: number;
     readonly lat: number;
     readonly numberSighted: number;
@@ -136,7 +141,7 @@ export function normalizeRecord(r: z.infer<typeof MaplifyRecordSchema>): Normali
         projectId: r.project_id,
         tripId: r.trip_id,
         name: blankToNull(r.name),
-        scientificName: blankToNull(r.scientific_name),
+        scientificName: r.scientific_name, // verbatim (mirror column, NOT NULL)
         lon: r.longitude,
         lat: r.latitude,
         numberSighted: r.number_sighted,
@@ -162,7 +167,8 @@ export function isIngestable(s: NormalizedSighting): boolean {
  * common-name fallback, or null. The taxon_id lookup itself is persist-time.
  */
 export function resolveScientificName(s: NormalizedSighting): string | null {
-    if (s.scientificName) return s.scientificName;
+    const trimmed = s.scientificName.trim();
+    if (trimmed) return trimmed;
     if (s.name) return NAME_TO_SCIENTIFIC.get(s.name) ?? null;
     return null;
 }

--- a/scripts/ingest/maplify.ts
+++ b/scripts/ingest/maplify.ts
@@ -97,7 +97,8 @@ export const MaplifyRecordSchema = z.object({
 });
 
 export const MaplifyResponseSchema = z.object({
-    count: z.number().int().optional(),
+    // NB: the live API returns `count` as a STRING ('99'); we don't use it, so it
+    // is intentionally omitted here (unknown keys are ignored) rather than typed.
     results: z.array(MaplifyRecordSchema),
 });
 

--- a/scripts/ingest/persist.test.ts
+++ b/scripts/ingest/persist.test.ts
@@ -89,6 +89,17 @@ describe.skipIf(!DSN)('persistMaplify (local Supabase)', () => {
         expect(survivors.map((r) => r['id'])).toEqual([900202]);
     });
 
+    test('persists a record with a blank scientific_name (NOT NULL mirror column, taxon null)', async () => {
+        // Real Maplify data includes records with scientific_name '' (e.g. "Blue Whale").
+        const res = await persistMaplify(sql, plan({
+            upsert: [sighting({ id: 900105, scientificName: '', name: 'Blue Whale' })],
+        }), WINDOW);
+        expect(res.upserted).toBe(1);
+        const [row] = await sql`select scientific_name, taxon_id from maplify.sightings where id = 900105`;
+        expect(row?.['scientific_name']).toBe(''); // stored verbatim, no NOT NULL violation
+        expect(row?.['taxon_id']).toBeNull();       // 'Blue Whale' not in the fallback map
+    });
+
     test('dry run reports would-be counts but writes nothing', async () => {
         const res = await persistMaplify(sql, plan({ upsert: [sighting({ id: 900301 })] }), WINDOW, { dryRun: true });
         expect(res.upserted).toBe(1);

--- a/scripts/ingest/persist.ts
+++ b/scripts/ingest/persist.ts
@@ -36,6 +36,19 @@ export type PersistResult = {
 };
 
 /**
+ * The ids currently stored in a window — fed to reconcile() to compute the delete
+ * set. Uses the SAME bound as the reconcile DELETE ([start, end+1)) so the read
+ * and the write agree on window membership.
+ */
+export async function fetchWindowIds(sql: Sql, window: IngestWindow): Promise<number[]> {
+    const rows = await sql<{ id: number }[]>`
+        SELECT id FROM maplify.sightings
+        WHERE created_at >= ${window.start}::timestamp
+          AND created_at < (${window.end}::date + 1)::timestamp`;
+    return rows.map((r) => r.id);
+}
+
+/**
  * Row shape handed to jsonb_to_recordset — snake_case keys that match the
  * recordset column names exactly (jsonb_to_recordset maps by key name).
  * resolved_name feeds only the taxon join, not a stored column.

--- a/scripts/ingest/retry.test.ts
+++ b/scripts/ingest/retry.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from 'vitest';
+import { MAX_ATTEMPTS, parseRetryAfter, retryDelayMs, isRetryableStatus } from './retry.ts';
+
+describe('parseRetryAfter', () => {
+    test('parses delay-seconds', () => {
+        expect(parseRetryAfter('120')).toBe(120);
+        expect(parseRetryAfter('0')).toBe(0);
+    });
+    test('returns null for HTTP-date, empty, or garbage', () => {
+        expect(parseRetryAfter('Wed, 21 Oct 2026 07:28:00 GMT')).toBeNull();
+        expect(parseRetryAfter(null)).toBeNull();
+        expect(parseRetryAfter(undefined)).toBeNull();
+        expect(parseRetryAfter('  ')).toBeNull();
+        expect(parseRetryAfter('-5')).toBeNull();
+    });
+});
+
+describe('retryDelayMs', () => {
+    test('exponential backoff by failed attempt, capped', () => {
+        expect(retryDelayMs(1)).toBe(500);
+        expect(retryDelayMs(2)).toBe(1000);
+        expect(retryDelayMs(3)).toBe(2000);
+        expect(retryDelayMs(100)).toBe(30_000); // capped
+    });
+    test('Retry-After overrides backoff and is capped', () => {
+        expect(retryDelayMs(1, 5)).toBe(5000);
+        expect(retryDelayMs(3, 0)).toBe(0);
+        expect(retryDelayMs(1, 9999)).toBe(30_000);
+    });
+});
+
+describe('isRetryableStatus', () => {
+    test('429 and 5xx are retryable; 2xx/4xx (except 429) are not', () => {
+        expect(isRetryableStatus(429)).toBe(true);
+        expect(isRetryableStatus(500)).toBe(true);
+        expect(isRetryableStatus(503)).toBe(true);
+        expect(isRetryableStatus(200)).toBe(false);
+        expect(isRetryableStatus(403)).toBe(false);
+        expect(isRetryableStatus(404)).toBe(false);
+    });
+    test('MAX_ATTEMPTS is a small positive number', () => {
+        expect(MAX_ATTEMPTS).toBeGreaterThanOrEqual(2);
+        expect(MAX_ATTEMPTS).toBeLessThanOrEqual(5);
+    });
+});

--- a/scripts/ingest/retry.ts
+++ b/scripts/ingest/retry.ts
@@ -1,0 +1,46 @@
+/**
+ * Ingest retry policy — functional core (salishsea-io-89d.1 / decision 011).
+ *
+ * Pure, runtime-agnostic. The imperative shell owns the actual sleeping and
+ * re-fetching; this module only decides HOW LONG to wait. Minimal by design: a
+ * few attempts with short exponential backoff, honouring an upstream Retry-After.
+ * Beyond MAX_ATTEMPTS the shell aborts and lets the next 5-minute cron be the real
+ * retry — the cadence plus self-healing 10-day windows already provide free retry.
+ */
+
+/** Total fetch attempts per invocation (1 initial + up to 2 retries). */
+export const MAX_ATTEMPTS = 3;
+
+const BASE_DELAY_MS = 500;
+const MAX_DELAY_MS = 30_000;
+
+/**
+ * Parse a Retry-After header value. Supports the delay-seconds form only; the
+ * HTTP-date form returns null (the caller falls back to exponential backoff)
+ * because resolving a date requires the current time, which is an effect.
+ */
+export function parseRetryAfter(header: string | null | undefined): number | null {
+    if (header == null) return null;
+    const trimmed = header.trim();
+    if (!/^\d+$/.test(trimmed)) return null;
+    const seconds = Number(trimmed);
+    return Number.isSafeInteger(seconds) ? seconds : null;
+}
+
+/**
+ * Milliseconds to wait before the next attempt, given the 1-based number of the
+ * attempt that just failed and an optional Retry-After (seconds). Retry-After
+ * wins when present; otherwise exponential backoff, both capped at MAX_DELAY_MS.
+ */
+export function retryDelayMs(failedAttempt: number, retryAfterSeconds?: number | null): number {
+    if (retryAfterSeconds != null && retryAfterSeconds >= 0) {
+        return Math.min(retryAfterSeconds * 1000, MAX_DELAY_MS);
+    }
+    const exp = BASE_DELAY_MS * 2 ** Math.max(0, failedAttempt - 1);
+    return Math.min(exp, MAX_DELAY_MS);
+}
+
+/** Whether an HTTP status is worth retrying (transient): 429 and 5xx. */
+export function isRetryableStatus(status: number): boolean {
+    return status === 429 || (status >= 500 && status <= 599);
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -344,3 +344,6 @@ s3_region = "env(S3_REGION)"
 s3_access_key = "env(S3_ACCESS_KEY)"
 # Configures AWS_SECRET_ACCESS_KEY for S3 bucket
 s3_secret_key = "env(S3_SECRET_KEY)"
+
+[functions.ingest]
+verify_jwt = false

--- a/supabase/functions/ingest/deno.json
+++ b/supabase/functions/ingest/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "zod": "npm:zod@^4.4.3",
+    "postgres": "npm:postgres@^3.4.9"
+  }
+}

--- a/supabase/functions/ingest/fetch-maplify.ts
+++ b/supabase/functions/ingest/fetch-maplify.ts
@@ -22,6 +22,11 @@ const MAPLIFY_URL = 'https://maplify.com/waseak/php/search-all-sightings.php';
 
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
+// Deno's fetch has no built-in timeout; without one a hung Maplify connection
+// would block an attempt (and the whole edge invocation) indefinitely. Bound
+// each attempt so a hang becomes a retryable AbortError instead.
+const FETCH_TIMEOUT_MS = 15_000;
+
 export type Logger = (msg: string, extra?: Record<string, unknown>) => void;
 
 export async function fetchMaplify(window: IngestWindow, log: Logger): Promise<unknown> {
@@ -30,16 +35,20 @@ export async function fetchMaplify(window: IngestWindow, log: Logger): Promise<u
 
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
         let res: Response;
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
         try {
-            res = await fetch(url, { headers: { accept: 'application/json' } });
+            res = await fetch(url, { headers: { accept: 'application/json' }, signal: controller.signal });
         } catch (e) {
-            // network-level failure — retry with backoff
+            // network-level failure or timeout abort — retry with backoff
             lastError = e;
             if (attempt === MAX_ATTEMPTS) break;
             const delay = retryDelayMs(attempt);
             log('maplify fetch error, retrying', { attempt, delayMs: delay, error: String(e) });
             await sleep(delay);
             continue;
+        } finally {
+            clearTimeout(timeout);
         }
 
         if (res.ok) return await res.json();

--- a/supabase/functions/ingest/fetch-maplify.ts
+++ b/supabase/functions/ingest/fetch-maplify.ts
@@ -1,0 +1,60 @@
+/**
+ * Maplify fetch with retry — imperative shell (salishsea-io-89d.1 / decision 011).
+ *
+ * Effectful: builds the request, fetches, and retries transient failures using
+ * the pure policy in scripts/ingest/retry.ts. Returns the parsed JSON body on a
+ * 2xx, or throws after MAX_ATTEMPTS. A non-retryable status (e.g. 403) throws
+ * immediately. The caller (index.ts) turns any throw into a `failed` ingest.runs
+ * row and writes nothing — upholding decision 011's "abort on a failed fetch".
+ */
+
+import {
+    MAX_ATTEMPTS,
+    retryDelayMs,
+    parseRetryAfter,
+    isRetryableStatus,
+} from '../../../scripts/ingest/retry.ts';
+import type { IngestWindow } from '../../../scripts/ingest/persist.ts';
+
+// Salish Sea bounding box (CONTEXT.md: Acartia / SRKW range), lon/lat WGS84.
+const BBOX = '-136,36,-120,54';
+const MAPLIFY_URL = 'https://maplify.com/waseak/php/search-all-sightings.php';
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export type Logger = (msg: string, extra?: Record<string, unknown>) => void;
+
+export async function fetchMaplify(window: IngestWindow, log: Logger): Promise<unknown> {
+    const url = `${MAPLIFY_URL}?start=${window.start}&end=${window.end}&BBOX=${BBOX}`;
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        let res: Response;
+        try {
+            res = await fetch(url, { headers: { accept: 'application/json' } });
+        } catch (e) {
+            // network-level failure — retry with backoff
+            lastError = e;
+            if (attempt === MAX_ATTEMPTS) break;
+            const delay = retryDelayMs(attempt);
+            log('maplify fetch error, retrying', { attempt, delayMs: delay, error: String(e) });
+            await sleep(delay);
+            continue;
+        }
+
+        if (res.ok) return await res.json();
+
+        lastError = new Error(`Maplify HTTP ${res.status}`);
+        if (!isRetryableStatus(res.status) || attempt === MAX_ATTEMPTS) {
+            // drain the body so the connection can be reused/closed cleanly
+            await res.body?.cancel();
+            break;
+        }
+        await res.body?.cancel();
+        const delay = retryDelayMs(attempt, parseRetryAfter(res.headers.get('retry-after')));
+        log('maplify non-2xx, retrying', { attempt, status: res.status, delayMs: delay });
+        await sleep(delay);
+    }
+
+    throw lastError ?? new Error('maplify fetch failed');
+}

--- a/supabase/functions/ingest/index.ts
+++ b/supabase/functions/ingest/index.ts
@@ -70,14 +70,20 @@ Deno.serve(async (req) => {
     const parsed = RequestSchema.safeParse(rawBody ?? {});
     if (!parsed.success) return jsonResponse({ error: z.prettifyError(parsed.error) }, 400);
 
-    const { source, dry_run: dryRun = false, trigger = 'manual' } = parsed.data;
+    const { source, start, end, dry_run: dryRun = false, trigger = 'manual' } = parsed.data;
     if (source !== 'maplify') {
         return jsonResponse({ error: `source '${source}' not yet implemented (salishsea-io-89d.2)` }, 405);
     }
-    const window: IngestWindow =
-        parsed.data.start && parsed.data.end
-            ? { start: parsed.data.start, end: parsed.data.end }
-            : defaultWindow();
+    // A custom window needs BOTH bounds; a single bound is almost certainly a
+    // mistake, and silently falling back to the default range would ignore the
+    // curator's intent. Reject partial windows and inverted ranges.
+    if ((start == null) !== (end == null)) {
+        return jsonResponse({ error: 'provide both start and end, or neither' }, 400);
+    }
+    if (start != null && end != null && start > end) {
+        return jsonResponse({ error: 'start must be on or before end' }, 400);
+    }
+    const window: IngestWindow = start != null && end != null ? { start, end } : defaultWindow();
 
     const sql = postgres(DB_URL, { prepare: false, max: 2 });
     let runId: number | undefined;

--- a/supabase/functions/ingest/index.ts
+++ b/supabase/functions/ingest/index.ts
@@ -1,0 +1,121 @@
+/**
+ * Ingest Edge Function — the imperative shell (salishsea-io-89d.1 / decision 011).
+ *
+ * HTTP entrypoint invoked by pg_cron/pg_net (rolling window, writes on) and by a
+ * Curator (explicit window; writes on, or dry_run to preview). Orchestrates:
+ *   fetch (retry) → parse+normalize (core) → read window ids → reconcile (core)
+ *   → persist in one atomic txn (persist layer) → record ingest.runs.
+ *
+ * Invariants it enforces (decision 011):
+ *   - Gated by a dedicated INGEST_TRIGGER_SECRET (constant-time compare).
+ *   - A failed/unparseable fetch throws BEFORE persist → writes nothing, records
+ *     a `failed` run. Reconcile only ever runs against a parsed, complete fetch.
+ *   - The ingest.runs `started` row is written OUTSIDE the data transaction, so a
+ *     crash leaves a visible orphan (outcome NULL).
+ *
+ * Scope: Maplify only in this slice; source:'inaturalist' is rejected (405) until
+ * salishsea-io-89d.2. Wiring pg_cron→pg_net is the cutover (salishsea-io-89d.3).
+ */
+
+import postgres from 'postgres';
+import { z } from 'zod';
+import { parseMaplifyResponse, isIngestable, reconcile } from '../../../scripts/ingest/maplify.ts';
+import { persistMaplify, fetchWindowIds, type IngestWindow } from '../../../scripts/ingest/persist.ts';
+import { fetchMaplify } from './fetch-maplify.ts';
+
+const TRIGGER_SECRET = Deno.env.get('INGEST_TRIGGER_SECRET') ?? '';
+// Prefer a dedicated privileged ingest role (INGEST_DB_URL); fall back to the
+// platform-provided connection. The dedicated role + grants land in a follow-up.
+const DB_URL = Deno.env.get('INGEST_DB_URL') ?? Deno.env.get('SUPABASE_DB_URL') ?? '';
+
+const RequestSchema = z.object({
+    source: z.enum(['maplify', 'inaturalist']),
+    start: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+    end: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+    dry_run: z.boolean().optional(),
+    trigger: z.enum(['cron', 'manual']).optional(),
+});
+
+const jsonResponse = (data: unknown, status: number) =>
+    new Response(JSON.stringify(data), { status, headers: { 'content-type': 'application/json' } });
+
+const log = (msg: string, extra?: Record<string, unknown>) =>
+    console.log(JSON.stringify({ level: 'info', fn: 'ingest', msg, ...extra }));
+
+/** Length-independent constant-time string compare. */
+function secretsMatch(a: string, b: string): boolean {
+    if (a.length === 0 || a.length !== b.length) return false;
+    let diff = 0;
+    for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+    return diff === 0;
+}
+
+/** Rolling 10-day window ending today (UTC), matching the legacy cron cadence. */
+function defaultWindow(): IngestWindow {
+    const now = new Date();
+    const end = now.toISOString().slice(0, 10);
+    const startDate = new Date(now);
+    startDate.setUTCDate(startDate.getUTCDate() - 10);
+    return { start: startDate.toISOString().slice(0, 10), end };
+}
+
+Deno.serve(async (req) => {
+    const provided = req.headers.get('x-ingest-secret') ?? '';
+    if (!secretsMatch(provided, TRIGGER_SECRET)) {
+        return jsonResponse({ error: 'unauthorized' }, 401);
+    }
+
+    let rawBody: unknown = {};
+    try { rawBody = await req.json(); } catch { /* empty/invalid body → defaults */ }
+    const parsed = RequestSchema.safeParse(rawBody ?? {});
+    if (!parsed.success) return jsonResponse({ error: z.prettifyError(parsed.error) }, 400);
+
+    const { source, dry_run: dryRun = false, trigger = 'manual' } = parsed.data;
+    if (source !== 'maplify') {
+        return jsonResponse({ error: `source '${source}' not yet implemented (salishsea-io-89d.2)` }, 405);
+    }
+    const window: IngestWindow =
+        parsed.data.start && parsed.data.end
+            ? { start: parsed.data.start, end: parsed.data.end }
+            : defaultWindow();
+
+    const sql = postgres(DB_URL, { prepare: false, max: 2 });
+    let runId: number | undefined;
+    try {
+        // `started` row OUTSIDE the data txn (orphan on crash).
+        const started = await sql<{ id: number }[]>`
+            INSERT INTO ingest.runs (source, trigger, dry_run, window_start, window_end)
+            VALUES (${source}, ${trigger}, ${dryRun}, ${window.start}, ${window.end})
+            RETURNING id`;
+        runId = started[0]!.id;
+
+        const raw = await fetchMaplify(window, log);
+        const result = parseMaplifyResponse(raw);
+        if (!result.ok) throw new Error(`maplify parse failed: ${result.error}`);
+
+        const ingestable = result.sightings.filter(isIngestable);
+        const existing = await fetchWindowIds(sql, window);
+        const plan = reconcile(ingestable, existing);
+        const { upserted, deleted } = await persistMaplify(sql, plan, window, { dryRun });
+
+        await sql`
+            UPDATE ingest.runs SET
+                finished_at = now(), outcome = 'success', pages_fetched = 1,
+                total_results = ${result.sightings.length},
+                rows_upserted = ${upserted}, rows_deleted = ${deleted}
+            WHERE id = ${runId}`;
+
+        log('ingest ok', { source, window, dryRun, upserted, deleted });
+        return jsonResponse({ ok: true, runId, source, window, dryRun, upserted, deleted }, 200);
+    } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        log('ingest failed', { source, window, error: message });
+        if (runId != null) {
+            await sql`UPDATE ingest.runs SET finished_at = now(), outcome = 'failed', error = ${message} WHERE id = ${runId}`
+                .catch(() => { /* best-effort; do not mask the original error */ });
+        }
+        return jsonResponse({ ok: false, error: message }, 500);
+    } finally {
+        await sql.end({ timeout: 5 });
+    }
+});


### PR DESCRIPTION
Completes `salishsea-io-89d.1`: the imperative shell that ties the merged functional core + persist layer into a running Edge Function ([decision 011](docs/decisions/011-ingest-imperative-shell.md)). Builds on #304.

## What's here

**Deno Edge Function** (`supabase/functions/ingest/`) — HTTP entrypoint that orchestrates: fetch (retry, honor `Retry-After`) → parse/normalize (core) → read window ids → reconcile (core) → persist in one atomic txn → record `ingest.runs`. Gated by `INGEST_TRIGGER_SECRET` (constant-time compare); accepts `source`/`window`/`dry_run`/`trigger`.

**Pure retry policy** (`scripts/ingest/retry.ts`, unit-tested) — `parseRetryAfter`, `retryDelayMs` (exponential backoff, cap, Retry-After override), `isRetryableStatus`.

**`fetchWindowIds`** on the persist layer — reads the window's existing ids using the *same* bound as the reconcile DELETE, so read and write agree on membership.

## A real bug the live run caught

Maplify returns `count` as a **string** (`"99"`), not a number. My hand-built fixture had it as an int, so unit tests were green but real data failed to parse. We don't use `count` — dropped it from the schema (unknown keys ignored), made the fixture faithful, added a regression test. This is exactly why decision 011 mandates a live smoke invocation, not just unit tests.

## Validated end-to-end (served locally against live Maplify + local Supabase)

- 401 on bad secret; 405 for `source:'inaturalist'` (not yet — 89d.2).
- Dry-run: fetched 99, 97 ingestable, `{upserted:97, deleted:0}`, **nothing written**.
- Real run: idempotent (window count stable).
- `ingest.runs` recorded dry-run success, real success, AND the earlier parse **failure** with its error message (proving the started-row-outside-txn + failure path and the "failed must have error" constraint).

`deno check` clean, `tsc` clean, full vitest **237 tests** green.

## Safety / deploy posture

- A failed or unparseable fetch throws **before** persist → writes nothing, records `failed`.
- The function is **dormant** until deployed: `deploy.yml` does not run `supabase functions deploy`, so merging does not activate it. Deploying it + wiring `pg_cron → pg_net` is the cutover (`salishsea-io-89d.3`).

## Follow-ups (not this PR)

- Dedicated privileged ingest DB role + grants (shell already prefers `INGEST_DB_URL`, falls back to `SUPABASE_DB_URL`).
- Sentry Deno wiring (durable `ingest.runs` + structured logs cover failures for now).
- iNaturalist (`89d.2`), cutover (`89d.3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new ingest endpoint for Maplify data with support for date ranges, dry runs, and a default rolling 10-day window.
  * Added improved retry handling for fetches, including backoff and respect for retry hints when available.

* **Bug Fixes**
  * The ingestion parser now accepts API responses where the `count` value is returned as a string.
  * Ingestion now handles empty result sets and retryable HTTP/network failures more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->