### PR TITLE
iNaturalist ingest: functional core + persist layer (89d.2)

### DIFF
--- a/scripts/ingest/fixtures/inaturalist-observations.json
+++ b/scripts/ingest/fixtures/inaturalist-observations.json
@@ -1,0 +1,411 @@
+{
+  "total_results": 200,
+  "page": 1,
+  "per_page": 200,
+  "results": [
+    {
+      "id": 378638876,
+      "description": "Looks like a challenge with one of the smaller males getting caught in the middle",
+      "geojson": {
+        "coordinates": [
+          -123.0029971848,
+          37.7000040977
+        ],
+        "type": "Point"
+      },
+      "license_code": "cc-by-nc",
+      "time_observed_at": "2026-07-04T11:48:00-07:00",
+      "uri": "https://www.inaturalist.org/observations/378638876",
+      "public_positional_accuracy": 1000,
+      "updated_at": "2026-07-05T20:08:04-07:00",
+      "observation_photos": [
+        {
+          "id": 639716472,
+          "position": 0,
+          "photo": {
+            "id": 692500730,
+            "attribution": "(c) egines5, some rights reserved (CC BY-NC)",
+            "hidden": false,
+            "license_code": "cc-by-nc",
+            "original_dimensions": {
+              "height": 1365,
+              "width": 2048
+            },
+            "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/692500730/square.jpg"
+          }
+        },
+        {
+          "id": 639716475,
+          "position": 1,
+          "photo": {
+            "id": 692500735,
+            "attribution": "(c) egines5, some rights reserved (CC BY-NC)",
+            "hidden": false,
+            "license_code": "cc-by-nc",
+            "original_dimensions": {
+              "height": 1365,
+              "width": 2048
+            },
+            "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/692500735/square.jpg"
+          }
+        },
+        {
+          "id": 639716476,
+          "position": 2,
+          "photo": {
+            "id": 692500732,
+            "attribution": "(c) egines5, some rights reserved (CC BY-NC)",
+            "hidden": false,
+            "license_code": "cc-by-nc",
+            "original_dimensions": {
+              "height": 1365,
+              "width": 2048
+            },
+            "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/692500732/square.jpg"
+          }
+        },
+        {
+          "id": 639716477,
+          "position": 3,
+          "photo": {
+            "id": 692500792,
+            "attribution": "(c) egines5, some rights reserved (CC BY-NC)",
+            "hidden": false,
+            "license_code": "cc-by-nc",
+            "original_dimensions": {
+              "height": 1365,
+              "width": 2048
+            },
+            "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/692500792/square.jpg"
+          }
+        },
+        {
+          "id": 639716478,
+          "position": 4,
+          "photo": {
+            "id": 692500795,
+            "attribution": "(c) egines5, some rights reserved (CC BY-NC)",
+            "hidden": false,
+            "license_code": "cc-by-nc",
+            "original_dimensions": {
+              "height": 1365,
+              "width": 2048
+            },
+            "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/692500795/square.jpg"
+          }
+        }
+      ],
+      "taxon": {
+        "id": 41740,
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          40151,
+          848317,
+          848320,
+          848324,
+          41573,
+          372843,
+          41736,
+          41737,
+          41740
+        ]
+      },
+      "user": {
+        "id": 10482805,
+        "login": "egines5",
+        "name": "",
+        "orcid": null
+      }
+    },
+    {
+      "id": 378638325,
+      "description": "",
+      "geojson": {
+        "coordinates": [
+          -121.894845,
+          36.6080166667
+        ],
+        "type": "Point"
+      },
+      "license_code": "cc-by-nc",
+      "time_observed_at": "2026-07-05T17:14:16-07:00",
+      "uri": "https://www.inaturalist.org/observations/378638325",
+      "public_positional_accuracy": 2,
+      "updated_at": "2026-07-05T20:06:14-07:00",
+      "observation_photos": [
+        {
+          "id": 639715513,
+          "position": 0,
+          "photo": {
+            "id": 692524625,
+            "attribution": "(c) Amy Wolfrum, all rights reserved",
+            "hidden": false,
+            "license_code": null,
+            "original_dimensions": {
+              "height": 2048,
+              "width": 1536
+            },
+            "url": "https://static.inaturalist.org/photos/692524625/square.jpg"
+          }
+        }
+      ],
+      "taxon": {
+        "id": 117766,
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          40151,
+          848317,
+          848320,
+          848324,
+          41573,
+          372843,
+          41687,
+          41707,
+          41708,
+          117766
+        ]
+      },
+      "user": {
+        "id": 3204,
+        "login": "amybird",
+        "name": "Amy Wolfrum",
+        "orcid": null
+      }
+    },
+    {
+      "id": 378610508,
+      "description": null,
+      "geojson": {
+        "coordinates": [
+          -122.4829866667,
+          37.8223183333
+        ],
+        "type": "Point"
+      },
+      "license_code": "cc-by-nc",
+      "time_observed_at": "2026-07-04T09:06:00-07:00",
+      "uri": "https://www.inaturalist.org/observations/378610508",
+      "public_positional_accuracy": null,
+      "updated_at": "2026-07-05T18:52:59-07:00",
+      "observation_photos": [
+        {
+          "id": 639664899,
+          "position": 0,
+          "photo": {
+            "id": 692452607,
+            "attribution": "(c) egines5, some rights reserved (CC BY-NC)",
+            "hidden": false,
+            "license_code": "cc-by-nc",
+            "original_dimensions": {
+              "height": 1365,
+              "width": 2048
+            },
+            "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/692452607/square.jpg"
+          }
+        }
+      ],
+      "taxon": {
+        "id": 41708,
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          40151,
+          848317,
+          848320,
+          848324,
+          41573,
+          372843,
+          41687,
+          41707,
+          41708
+        ]
+      },
+      "user": {
+        "id": 10482805,
+        "login": "egines5",
+        "name": "",
+        "orcid": null
+      }
+    },
+    {
+      "id": 378550282,
+      "description": "",
+      "geojson": {
+        "coordinates": [
+          -122.4113166667,
+          37.8109083333
+        ],
+        "type": "Point"
+      },
+      "license_code": "cc-by",
+      "time_observed_at": "2026-07-05T13:51:41-07:00",
+      "uri": "https://www.inaturalist.org/observations/378550282",
+      "public_positional_accuracy": 2,
+      "updated_at": "2026-07-05T18:55:19-07:00",
+      "observation_photos": [
+        {
+          "id": 639554481,
+          "position": 0,
+          "photo": {
+            "id": 692349960,
+            "attribution": "(c) Devin Kellar, some rights reserved (CC BY)",
+            "hidden": false,
+            "license_code": "cc-by",
+            "original_dimensions": {
+              "height": 1536,
+              "width": 2048
+            },
+            "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/692349960/square.jpg"
+          }
+        }
+      ],
+      "taxon": {
+        "id": 41740,
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          40151,
+          848317,
+          848320,
+          848324,
+          41573,
+          372843,
+          41736,
+          41737,
+          41740
+        ]
+      },
+      "user": {
+        "id": 2323410,
+        "login": "devinkellar",
+        "name": "Devin Kellar",
+        "orcid": null
+      }
+    },
+    {
+      "id": 378638904,
+      "description": null,
+      "geojson": {
+        "coordinates": [
+          -122.9903584844,
+          37.6353427517
+        ],
+        "type": "Point"
+      },
+      "license_code": "cc-by-nc",
+      "time_observed_at": "2026-07-04T13:08:00-07:00",
+      "uri": "https://www.inaturalist.org/observations/378638904",
+      "public_positional_accuracy": 10000,
+      "updated_at": "2026-07-05T20:08:06-07:00",
+      "observation_photos": [],
+      "taxon": {
+        "id": 41553,
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          40151,
+          848317,
+          848320,
+          848324,
+          152870,
+          925158,
+          152871,
+          424321,
+          41546,
+          41547,
+          41553
+        ]
+      },
+      "user": {
+        "id": 10482805,
+        "login": "egines5",
+        "name": "",
+        "orcid": null
+      }
+    },
+    {
+      "id": 378638874,
+      "description": "This is for the small ones in front, Stellars has his own observation. California Sea Lions fighting for dominance.",
+      "geojson": {
+        "coordinates": [
+          -123.0029458039,
+          37.6999342583
+        ],
+        "type": "Point"
+      },
+      "license_code": "cc-by-nc",
+      "time_observed_at": null,
+      "uri": "https://www.inaturalist.org/observations/378638874",
+      "public_positional_accuracy": 1000,
+      "updated_at": "2026-07-05T20:08:04-07:00",
+      "observation_photos": [
+        {
+          "id": 639716469,
+          "position": 0,
+          "photo": {
+            "id": 692500074,
+            "attribution": "(c) egines5, some rights reserved (CC BY-NC)",
+            "hidden": false,
+            "license_code": "cc-by-nc",
+            "original_dimensions": {
+              "height": 1365,
+              "width": 2048
+            },
+            "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/692500074/square.jpg"
+          }
+        },
+        {
+          "id": 639716470,
+          "position": 1,
+          "photo": {
+            "id": 692500071,
+            "attribution": "(c) egines5, some rights reserved (CC BY-NC)",
+            "hidden": false,
+            "license_code": "cc-by-nc",
+            "original_dimensions": {
+              "height": 1365,
+              "width": 2048
+            },
+            "url": "https://inaturalist-open-data.s3.amazonaws.com/photos/692500071/square.jpg"
+          }
+        }
+      ],
+      "taxon": {
+        "id": 41740,
+        "ancestor_ids": [
+          48460,
+          1,
+          2,
+          355675,
+          40151,
+          848317,
+          848320,
+          848324,
+          41573,
+          372843,
+          41736,
+          41737,
+          41740
+        ]
+      },
+      "user": {
+        "id": 10482805,
+        "login": "egines5",
+        "name": "",
+        "orcid": null
+      }
+    }
+  ]
+}

--- a/scripts/ingest/fixtures/inaturalist-taxa.json
+++ b/scripts/ingest/fixtures/inaturalist-taxa.json
@@ -1,0 +1,108 @@
+{
+  "total_results": 5,
+  "page": 1,
+  "per_page": 30,
+  "results": [
+    {
+      "id": 48460,
+      "ancestor_ids": [
+        48460
+      ],
+      "parent_id": null,
+      "rank": "stateofmatter",
+      "name": "Life",
+      "preferred_common_name": "life"
+    },
+    {
+      "id": 41708,
+      "ancestor_ids": [
+        48460,
+        1,
+        2,
+        355675,
+        40151,
+        848317,
+        848320,
+        848324,
+        41573,
+        372843,
+        41687,
+        41707,
+        41708
+      ],
+      "parent_id": 41707,
+      "rank": "species",
+      "name": "Phoca vitulina",
+      "preferred_common_name": "Harbor Seal"
+    },
+    {
+      "id": 41740,
+      "ancestor_ids": [
+        48460,
+        1,
+        2,
+        355675,
+        40151,
+        848317,
+        848320,
+        848324,
+        41573,
+        372843,
+        41736,
+        41737,
+        41740
+      ],
+      "parent_id": 41737,
+      "rank": "species",
+      "name": "Zalophus californianus",
+      "preferred_common_name": "California Sea Lion"
+    },
+    {
+      "id": 117766,
+      "ancestor_ids": [
+        48460,
+        1,
+        2,
+        355675,
+        40151,
+        848317,
+        848320,
+        848324,
+        41573,
+        372843,
+        41687,
+        41707,
+        41708,
+        117766
+      ],
+      "parent_id": 41708,
+      "rank": "subspecies",
+      "name": "Phoca vitulina richardii",
+      "preferred_common_name": "Pacific Harbor Seal"
+    },
+    {
+      "id": 41553,
+      "ancestor_ids": [
+        48460,
+        1,
+        2,
+        355675,
+        40151,
+        848317,
+        848320,
+        848324,
+        152870,
+        925158,
+        152871,
+        424321,
+        41546,
+        41547,
+        41553
+      ],
+      "parent_id": 41547,
+      "rank": "species",
+      "name": "Balaenoptera musculus",
+      "preferred_common_name": "Blue Whale"
+    }
+  ]
+}

--- a/scripts/ingest/inaturalist.test.ts
+++ b/scripts/ingest/inaturalist.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Vitest suite for the iNaturalist functional core (salishsea-io-89d.2 / decision 011).
+ *
+ * Pure unit tests — no DB, no network. `fixtures/inaturalist-observations.json`
+ * is real records captured from the live v2 /observations endpoint on 2026-07-05
+ * (covering: multiple photos, a photo with null license_code, null
+ * public_positional_accuracy, a non-default record license, a record with NO
+ * photos, and one crafted record with time_observed_at=null to exercise
+ * skipping). `fixtures/inaturalist-taxa.json` is real /taxa records (incl.
+ * "Life", parent_id=null).
+ */
+
+import { describe, test, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import {
+    parseInatResponse,
+    parseInatTaxa,
+    normalizeTaxon,
+    referencedTaxonIds,
+    referencedTaxonIdsFromTaxa,
+    missingTaxonIds,
+    expectedPageCount,
+    isPaginationComplete,
+    reconcile,
+    InatObservationSchema,
+    InatTaxonSchema,
+    type NormalizedObservation,
+    type FetchedPage,
+} from './inaturalist.ts';
+
+const obsFixture = JSON.parse(
+    readFileSync(path.resolve(__dirname, 'fixtures/inaturalist-observations.json'), 'utf8'),
+);
+const taxaFixture = JSON.parse(
+    readFileSync(path.resolve(__dirname, 'fixtures/inaturalist-taxa.json'), 'utf8'),
+);
+
+/** A minimal valid upstream observation, for targeted mutation. */
+const rawObs = {
+    id: 100,
+    description: 'a whale',
+    geojson: { type: 'Point', coordinates: [-123.5, 48.2] },
+    license_code: 'cc-by-nc',
+    time_observed_at: '2026-07-04T13:08:00-07:00',
+    uri: 'https://www.inaturalist.org/observations/100',
+    public_positional_accuracy: 25,
+    updated_at: '2026-07-05T20:08:06-07:00',
+    observation_photos: [
+        {
+            id: 900,
+            position: 0,
+            photo: {
+                id: 9000,
+                attribution: '(c) someone',
+                hidden: false,
+                license_code: 'cc-by-nc',
+                original_dimensions: { height: 1365, width: 2048 },
+                url: 'https://example.com/photo.jpg',
+            },
+        },
+    ],
+    taxon: { id: 41553, ancestor_ids: [48460, 1, 2, 41553] },
+    user: { id: 5, login: 'obs_user', name: '', orcid: null },
+};
+
+const obs = (over: Partial<NormalizedObservation> = {}): NormalizedObservation => ({
+    id: 1, description: null, lon: -123, lat: 48, observedAt: '2026-07-04T13:08:00-07:00',
+    licenseCode: 'cc-by-nc', uri: 'https://inat/1', login: 'u', orcid: null, taxonId: 41553,
+    ancestorIds: [48460, 1, 41553], publicPositionalAccuracy: null,
+    updatedAt: '2026-07-05T20:08:06-07:00', photos: [], ...over,
+});
+
+describe('parseInatResponse', () => {
+    test('accepts the real fixture and skips the null-time record', () => {
+        const r = parseInatResponse(obsFixture);
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        // fixture has 6 results; exactly one has time_observed_at=null and is skipped
+        const skipped = obsFixture.results.filter((x: { time_observed_at: unknown }) => x.time_observed_at == null).length;
+        expect(skipped).toBe(1);
+        expect(r.observations).toHaveLength(obsFixture.results.length - 1);
+        expect(r.recordCount).toBe(obsFixture.results.length); // raw count includes the skipped record
+        expect(r.totalResults).toBe(obsFixture.total_results);
+        expect(typeof r.totalResults).toBe('number'); // real int, not a string (unlike Maplify's count)
+    });
+
+    test('normalizes coordinates as lon/lat, carries the ancestor chain', () => {
+        const r = parseInatResponse({ total_results: 1, results: [rawObs] });
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        const o = r.observations[0]!;
+        expect(o.lon).toBe(-123.5);
+        expect(o.lat).toBe(48.2);
+        expect(o.taxonId).toBe(41553);
+        expect(o.ancestorIds).toEqual([48460, 1, 2, 41553]);
+        expect(o.login).toBe('obs_user');
+    });
+
+    test('normalizes a record WITHOUT photos to an empty photo list', () => {
+        const r = parseInatResponse({ total_results: 1, results: [{ ...rawObs, observation_photos: [] }] });
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        expect(r.observations[0]!.photos).toEqual([]);
+    });
+
+    test('accepts an authoritative empty result set (total_results=0)', () => {
+        const r = parseInatResponse({ total_results: 0, page: 1, per_page: 200, results: [] });
+        expect(r).toMatchObject({ ok: true, observations: [], totalResults: 0, recordCount: 0 });
+    });
+
+    test('blank description → null; blank orcid → null; blank photo license → null', () => {
+        const raw = {
+            ...rawObs,
+            description: '   ',
+            user: { id: 5, login: 'u', name: '', orcid: '' },
+            observation_photos: [{
+                ...rawObs.observation_photos[0]!,
+                photo: { ...rawObs.observation_photos[0]!.photo, license_code: '' },
+            }],
+        };
+        const r = parseInatResponse({ total_results: 1, results: [raw] });
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        const o = r.observations[0]!;
+        expect(o.description).toBeNull();
+        expect(o.orcid).toBeNull();
+        expect(o.photos[0]!.license).toBeNull();
+    });
+
+    test('null public_positional_accuracy normalizes to null', () => {
+        const r = parseInatResponse({ total_results: 1, results: [{ ...rawObs, public_positional_accuracy: null }] });
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        expect(r.observations[0]!.publicPositionalAccuracy).toBeNull();
+    });
+
+    test('rejects a malformed envelope (results not an array)', () => {
+        expect(parseInatResponse({ total_results: 0, results: 'nope' }).ok).toBe(false);
+    });
+
+    test('rejects the whole response when ANY record is malformed (no silent drop)', () => {
+        const bad = { total_results: 2, results: [rawObs, { ...rawObs, id: 2, uri: undefined }] };
+        expect(parseInatResponse(bad).ok).toBe(false);
+    });
+
+    test('rejects a record whose geojson lacks two coordinates', () => {
+        const bad = { total_results: 1, results: [{ ...rawObs, geojson: { coordinates: [-123.5] } }] };
+        expect(parseInatResponse(bad).ok).toBe(false);
+    });
+
+    test('rejects a record with an unknown license_code (fail-fast, not at persist cast)', () => {
+        const bad = { total_results: 1, results: [{ ...rawObs, license_code: 'cc-wtf' }] };
+        expect(parseInatResponse(bad).ok).toBe(false);
+    });
+
+    test('a null license_code IS allowed (→ null)', () => {
+        const r = parseInatResponse({ total_results: 1, results: [{ ...rawObs, license_code: null }] });
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        expect(r.observations[0]!.licenseCode).toBeNull();
+    });
+
+    test('non-object input does not throw', () => {
+        expect(parseInatResponse(null).ok).toBe(false);
+        expect(parseInatResponse('nonsense').ok).toBe(false);
+    });
+});
+
+describe('InatObservationSchema', () => {
+    test('accepts every real fixture record (shape validation)', () => {
+        for (const r of obsFixture.results) {
+            expect(InatObservationSchema.safeParse(r).success).toBe(true);
+        }
+    });
+});
+
+describe('parseInatTaxa / normalizeTaxon', () => {
+    test('accepts the real taxa fixture', () => {
+        const r = parseInatTaxa(taxaFixture);
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        expect(r.taxa).toHaveLength(taxaFixture.results.length);
+    });
+
+    test('maps name→scientificName, preferred_common_name→vernacularName, keeps rank', () => {
+        const life = taxaFixture.results.find((t: { id: number }) => t.id === 48460);
+        const parsed = InatTaxonSchema.parse(life);
+        const n = normalizeTaxon(parsed);
+        expect(n.scientificName).toBe('Life');
+        expect(n.rank).toBe('stateofmatter');
+        expect(n.parentId).toBeNull(); // "Life" has no parent
+    });
+
+    test('rejects a taxon with an unknown rank', () => {
+        const bad = { total_results: 1, results: [{ id: 1, ancestor_ids: [1], parent_id: null, rank: 'genusoid', name: 'X' }] };
+        expect(parseInatTaxa(bad).ok).toBe(false);
+    });
+});
+
+describe('taxon closure diffs', () => {
+    test('referencedTaxonIds unions taxon + ancestors, sorted & deduped', () => {
+        const ids = referencedTaxonIds([
+            obs({ taxonId: 5, ancestorIds: [1, 2, 5] }),
+            obs({ taxonId: 9, ancestorIds: [1, 3, 9] }),
+        ]);
+        expect(ids).toEqual([1, 2, 3, 5, 9]);
+    });
+
+    test('referencedTaxonIdsFromTaxa unions id, parent, ancestors', () => {
+        const r = parseInatTaxa(taxaFixture);
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        const ids = referencedTaxonIdsFromTaxa(r.taxa);
+        // includes a parent_id that is not itself in the fixture results
+        expect(ids).toContain(41707); // parent of Phoca vitulina (41708)
+        expect(ids).toContain(48460);
+    });
+
+    test('missingTaxonIds returns referenced-not-present, sorted', () => {
+        expect(missingTaxonIds([3, 1, 2, 3], [2])).toEqual([1, 3]);
+    });
+
+    test('missingTaxonIds empty when everything present (closure resolved)', () => {
+        expect(missingTaxonIds([1, 2, 3], [1, 2, 3, 4])).toEqual([]);
+    });
+});
+
+describe('pagination completeness', () => {
+    test('expectedPageCount: empty total needs the one reporting page', () => {
+        expect(expectedPageCount(0, 200)).toBe(1);
+    });
+    test('expectedPageCount: ceil(total/perPage)', () => {
+        expect(expectedPageCount(200, 200)).toBe(1);
+        expect(expectedPageCount(201, 200)).toBe(2);
+        expect(expectedPageCount(1826, 200)).toBe(10);
+    });
+
+    const page = (over: Partial<FetchedPage> & { page: number }): FetchedPage => ({
+        totalResults: 0, recordCount: 0, ...over,
+    });
+
+    test('a single empty page (total=0) is complete and authoritative', () => {
+        expect(isPaginationComplete([page({ page: 1, totalResults: 0, recordCount: 0 })], 200)).toBe(true);
+    });
+
+    test('all pages present with counts summing to total → complete', () => {
+        const pages = [
+            page({ page: 1, totalResults: 450, recordCount: 200 }),
+            page({ page: 2, totalResults: 450, recordCount: 200 }),
+            page({ page: 3, totalResults: 450, recordCount: 50 }),
+        ];
+        expect(isPaginationComplete(pages, 200)).toBe(true);
+    });
+
+    test('a missing final page → incomplete', () => {
+        const pages = [
+            page({ page: 1, totalResults: 450, recordCount: 200 }),
+            page({ page: 2, totalResults: 450, recordCount: 200 }),
+        ];
+        expect(isPaginationComplete(pages, 200)).toBe(false);
+    });
+
+    test('a gap in page numbers → incomplete', () => {
+        const pages = [
+            page({ page: 1, totalResults: 450, recordCount: 200 }),
+            page({ page: 3, totalResults: 450, recordCount: 250 }),
+        ];
+        expect(isPaginationComplete(pages, 200)).toBe(false);
+    });
+
+    test('a duplicated page number → incomplete', () => {
+        const pages = [
+            page({ page: 1, totalResults: 400, recordCount: 200 }),
+            page({ page: 1, totalResults: 400, recordCount: 200 }),
+        ];
+        expect(isPaginationComplete(pages, 200)).toBe(false);
+    });
+
+    test('inconsistent total_results across pages → incomplete', () => {
+        const pages = [
+            page({ page: 1, totalResults: 400, recordCount: 200 }),
+            page({ page: 2, totalResults: 401, recordCount: 200 }),
+        ];
+        expect(isPaginationComplete(pages, 200)).toBe(false);
+    });
+
+    test('record counts that do not sum to total → incomplete', () => {
+        const pages = [
+            page({ page: 1, totalResults: 450, recordCount: 200 }),
+            page({ page: 2, totalResults: 450, recordCount: 200 }),
+            page({ page: 3, totalResults: 450, recordCount: 40 }), // 440 != 450
+        ];
+        expect(isPaginationComplete(pages, 200)).toBe(false);
+    });
+
+    test('no pages fetched at all → incomplete', () => {
+        expect(isPaginationComplete([], 200)).toBe(false);
+    });
+});
+
+describe('reconcile', () => {
+    test('upserts everything fetched', () => {
+        const fetched = [obs({ id: 1 }), obs({ id: 2 })];
+        expect(reconcile(fetched, [1, 2]).upsert).toEqual(fetched);
+    });
+    test('deletes stored ids absent from the fetch', () => {
+        expect(reconcile([obs({ id: 1 }), obs({ id: 3 })], [1, 2, 3]).delete).toEqual([2]);
+    });
+    test('empty fetch over a populated window deletes all of it (caller must guard failure)', () => {
+        expect(reconcile([], [10, 11, 12]).delete).toEqual([10, 11, 12]);
+    });
+    test('empty window yields no deletes', () => {
+        expect(reconcile([obs({ id: 1 })], []).delete).toEqual([]);
+    });
+    test('new ids in the fetch are upserted, not treated as deletes', () => {
+        const plan = reconcile([obs({ id: 1 }), obs({ id: 99 })], [1]);
+        expect(plan.upsert.map((o) => o.id)).toEqual([1, 99]);
+        expect(plan.delete).toEqual([]);
+    });
+});

--- a/scripts/ingest/inaturalist.ts
+++ b/scripts/ingest/inaturalist.ts
@@ -1,0 +1,441 @@
+/**
+ * iNaturalist ingest — functional core (epic salishsea-io-89d.2 / decision 011).
+ *
+ * Pure, runtime-agnostic transforms over iNaturalist's v2 `/observations` and
+ * `/taxa` JSON. No I/O, no DB, no Deno/Node APIs — importable unchanged by the
+ * Deno Edge Function shell and by vitest. All effects (fetch, paginate, retry,
+ * persist, log) live in the imperative shell; everything here is data-in,
+ * data-out and exhaustively unit-tested.
+ *
+ * Boundary discipline (decision 008): this validates and translates *upstream*
+ * iNaturalist records into our normalized shape. Upstream field semantics stop
+ * here.
+ *
+ * The two hard parts of iNat ingest (decision 011) both reduce to pure helpers
+ * this module owns; the loops/effects around them are the shell's job:
+ *
+ *   1. Pagination completeness — `isPaginationComplete` decides whether the shell
+ *      has accumulated every page through `total_results`. A fetch is COMPLETE
+ *      only if page 1..N (N = ceil(total/per_page)) each returned 200 with a
+ *      well-formed body and the record counts sum to `total_results`. An empty
+ *      first page (`total_results = 0`) is complete and authoritative. Any missing
+ *      or failed page → not complete → the shell writes nothing.
+ *
+ *   2. Taxon-ancestor closure — `referencedTaxonIds` extracts the taxon ids an
+ *      observation batch needs (self + ancestors); `missingTaxonIds` diffs that
+ *      against what's already stored; `parseInatTaxa` + `referencedTaxonIdsFromTaxa`
+ *      let the shell expand newly-fetched taxa and recompute the still-missing set.
+ *      The shell loops fetch → recompute until the set is empty (closure), all
+ *      BEFORE opening the persist transaction. A taxon-API failure counts against
+ *      fetch-completeness (shell aborts, writes nothing).
+ *
+ * Persist-time resolutions kept in SQL (see persist.ts / decision 011), unchanged
+ * from the prior path:
+ *   - provider_id     — column DEFAULT (3 = iNaturalist).
+ *   - collection_id   — column DEFAULT (8 = iNaturalist).
+ *   - contributor_id  — inaturalist.mint_contributor(login, orcid), a DB upsert
+ *                       against public.contributors (a relational lookup, not a
+ *                       transform, exactly like maplify.resolve_collection).
+ */
+
+import { z } from 'zod';
+
+/** Salish Sea bounding box (decision 009); the shell passes it to the query. */
+export const SALISH_SEA_BBOX = { swLng: -136, swLat: 36, neLng: -120, neLat: 54 } as const;
+
+/** In-scope root taxa: Cetacea, Phocoidea (pinnipeds), Lutrinae (otters). */
+export const INAT_ROOT_TAXON_IDS: readonly number[] = [152871, 372843, 526556];
+
+/** iNat page-based pagination page size; also its per-page cap. */
+export const PER_PAGE = 200;
+
+/** public.license enum values (introspected 2026-07-05). */
+export const LICENSE_CODES = [
+    'cc0', 'cc-by', 'cc-by-nc', 'cc-by-sa', 'cc-by-nd', 'cc-by-nc-sa', 'cc-by-nc-nd', 'none',
+] as const;
+
+/** inaturalist.rank enum values (introspected 2026-07-05). */
+export const TAXON_RANKS = [
+    'infrahybrid', 'form', 'variety', 'subspecies', 'hybrid', 'species', 'complex',
+    'subsection', 'section', 'subgenus', 'genushybrid', 'genus', 'subtribe', 'tribe',
+    'supertribe', 'subfamily', 'family', 'epifamily', 'superfamily', 'zoosubsection',
+    'zoosection', 'parvorder', 'infraorder', 'suborder', 'order', 'superorder',
+    'subterclass', 'infraclass', 'subclass', 'class', 'superclass', 'subphylum',
+    'phylum', 'kingdom', 'stateofmatter',
+] as const;
+
+/** '' or absent → null; otherwise the value validated against the license enum. */
+const licenseSchema = z.preprocess(
+    (v) => (v === '' || v == null ? null : v),
+    z.enum(LICENSE_CODES).nullable(),
+);
+
+const blankToNull = (s: string | null | undefined): string | null => {
+    const t = s?.trim();
+    return t ? t : null;
+};
+
+// --------------------------------------------------------------------------
+// Upstream schemas. Strict enough that a malformed record fails the WHOLE
+// response (see parseInatResponse) rather than being silently dropped — a
+// dropped record would otherwise become a reconcile delete-candidate, risking
+// data loss on a transient upstream glitch (same rationale as Maplify).
+// --------------------------------------------------------------------------
+
+const InatPhotoSchema = z.object({
+    id: z.number().int(),
+    attribution: z.string(),
+    hidden: z.boolean(),
+    license_code: licenseSchema,
+    original_dimensions: z.object({ height: z.number().int(), width: z.number().int() }),
+    url: z.string(),
+});
+
+const InatObservationPhotoSchema = z.object({
+    id: z.number().int(),
+    position: z.number().int(),
+    photo: InatPhotoSchema,
+});
+
+const InatGeojsonSchema = z.object({
+    // GeoJSON Point: [lon, lat]. Tuple (not array) so the two coords narrow to
+    // `number` under noUncheckedIndexedAccess.
+    coordinates: z.tuple([z.number(), z.number()]),
+});
+
+const InatUserSchema = z.object({
+    id: z.number().int(),
+    login: z.string(),
+    name: z.string().nullish(),
+    orcid: z.string().nullish(),
+});
+
+const InatTaxonRefSchema = z.object({
+    id: z.number().int(),
+    // ancestor_ids is the full root→self chain and INCLUDES self as the last
+    // element (verified against live data 2026-07-05).
+    ancestor_ids: z.array(z.number().int()),
+});
+
+export const InatObservationSchema = z.object({
+    id: z.number().int(),
+    description: z.string().nullish(),
+    geojson: InatGeojsonSchema,
+    license_code: licenseSchema,
+    // NULLABLE, not required: a record with time_observed_at === null is VALID
+    // upstream but out of scope for us — parseInatResponse SKIPS it (mirrors the
+    // live `WHERE time_observed_at IS NOT NULL`). It is not a malformed record.
+    time_observed_at: z.string().nullish(),
+    uri: z.string(),
+    public_positional_accuracy: z.number().int().nullish(),
+    updated_at: z.string(),
+    observation_photos: z.array(InatObservationPhotoSchema),
+    taxon: InatTaxonRefSchema,
+    user: InatUserSchema,
+});
+
+export const InatResponseSchema = z.object({
+    // Live API returns these as genuine ints (NOT strings, unlike Maplify's
+    // `count`). total_results drives pagination completeness.
+    total_results: z.number().int(),
+    page: z.number().int().nullish(),
+    per_page: z.number().int().nullish(),
+    results: z.array(InatObservationSchema),
+});
+
+export const InatTaxonSchema = z.object({
+    id: z.number().int(),
+    ancestor_ids: z.array(z.number().int()),
+    parent_id: z.number().int().nullish(),
+    rank: z.enum(TAXON_RANKS),
+    name: z.string(),
+    preferred_common_name: z.string().nullish(),
+});
+
+export const InatTaxaResponseSchema = z.object({
+    results: z.array(InatTaxonSchema),
+});
+
+// --------------------------------------------------------------------------
+// Normalized shapes — map 1:1 to the columns the shell persists.
+// --------------------------------------------------------------------------
+
+/** One normalized photo, child of an observation. */
+export type NormalizedPhoto = {
+    readonly id: number;
+    readonly seq: number;
+    readonly attribution: string;
+    readonly hidden: boolean;
+    readonly license: (typeof LICENSE_CODES)[number] | null;
+    readonly height: number;
+    readonly width: number;
+    readonly url: string;
+};
+
+/** One normalized observation; photos travel with their parent. */
+export type NormalizedObservation = {
+    readonly id: number;
+    readonly description: string | null;
+    readonly lon: number;
+    readonly lat: number;
+    /** ISO8601 with offset, verbatim from time_observed_at (cast to timestamptz at persist). */
+    readonly observedAt: string;
+    readonly licenseCode: (typeof LICENSE_CODES)[number] | null;
+    readonly uri: string;
+    readonly login: string;
+    readonly orcid: string | null;
+    readonly taxonId: number;
+    /** Full root→self ancestor chain, for taxon-closure resolution. */
+    readonly ancestorIds: readonly number[];
+    readonly publicPositionalAccuracy: number | null;
+    /** ISO8601 with offset, verbatim from updated_at (cast to timestamp at persist). */
+    readonly updatedAt: string;
+    readonly photos: readonly NormalizedPhoto[];
+};
+
+/** One normalized taxon row (the taxa closure the shell resolves before persist). */
+export type NormalizedTaxon = {
+    readonly id: number;
+    readonly parentId: number | null;
+    readonly scientificName: string;
+    readonly vernacularName: string | null;
+    readonly rank: (typeof TAXON_RANKS)[number];
+    /** Full root→self ancestor chain; lets the shell expand the closure. */
+    readonly ancestorIds: readonly number[];
+};
+
+function normalizePhoto(p: z.infer<typeof InatObservationPhotoSchema>): NormalizedPhoto {
+    return {
+        id: p.photo.id,
+        seq: p.position,
+        attribution: p.photo.attribution,
+        hidden: p.photo.hidden,
+        license: p.photo.license_code,
+        height: p.photo.original_dimensions.height,
+        width: p.photo.original_dimensions.width,
+        url: p.photo.url,
+    };
+}
+
+/** Normalize one validated observation. Precondition: time_observed_at is present. */
+export function normalizeObservation(
+    r: z.infer<typeof InatObservationSchema>,
+    observedAt: string,
+): NormalizedObservation {
+    return {
+        id: r.id,
+        description: blankToNull(r.description),
+        lon: r.geojson.coordinates[0],
+        lat: r.geojson.coordinates[1],
+        observedAt,
+        licenseCode: r.license_code,
+        uri: r.uri,
+        login: r.user.login,
+        orcid: blankToNull(r.user.orcid),
+        taxonId: r.taxon.id,
+        ancestorIds: r.taxon.ancestor_ids,
+        publicPositionalAccuracy: r.public_positional_accuracy ?? null,
+        updatedAt: r.updated_at,
+        photos: r.observation_photos.map(normalizePhoto),
+    };
+}
+
+/** Normalize one validated taxon. Pure. */
+export function normalizeTaxon(t: z.infer<typeof InatTaxonSchema>): NormalizedTaxon {
+    return {
+        id: t.id,
+        parentId: t.parent_id ?? null,
+        scientificName: t.name,
+        vernacularName: blankToNull(t.preferred_common_name),
+        rank: t.rank,
+        ancestorIds: t.ancestor_ids,
+    };
+}
+
+export type InatParseResult =
+    | {
+          readonly ok: true;
+          readonly observations: readonly NormalizedObservation[];
+          readonly totalResults: number;
+          /** Raw page result count BEFORE null-time skipping — feeds the completeness sum. */
+          readonly recordCount: number;
+          readonly page: number | null;
+      }
+    | { readonly ok: false; readonly error: string };
+
+/**
+ * Validate and normalize ONE page of an iNat `/observations` response.
+ *
+ * Returns ok:false if the envelope or ANY record is malformed — the shell then
+ * treats the fetch as not-complete and aborts (writes nothing), never reconciling
+ * against a partially-trusted response (decision 011).
+ *
+ * Records with `time_observed_at === null` are SKIPPED (not persisted, out of
+ * scope) but still count toward `recordCount`, because `total_results` counts
+ * them too — the completeness sum must reconcile against the raw page size.
+ */
+export function parseInatResponse(raw: unknown): InatParseResult {
+    const parsed = InatResponseSchema.safeParse(raw);
+    if (!parsed.success) {
+        return { ok: false, error: z.prettifyError(parsed.error) };
+    }
+    const observations: NormalizedObservation[] = [];
+    for (const r of parsed.data.results) {
+        const observedAt = r.time_observed_at;
+        if (observedAt == null) continue; // out of scope; skip (mirrors live SQL)
+        observations.push(normalizeObservation(r, observedAt));
+    }
+    return {
+        ok: true,
+        observations,
+        totalResults: parsed.data.total_results,
+        recordCount: parsed.data.results.length,
+        page: parsed.data.page ?? null,
+    };
+}
+
+export type InatTaxaParseResult =
+    | { readonly ok: true; readonly taxa: readonly NormalizedTaxon[] }
+    | { readonly ok: false; readonly error: string };
+
+/** Validate and normalize an iNat `/taxa` response. Malformed → ok:false. */
+export function parseInatTaxa(raw: unknown): InatTaxaParseResult {
+    const parsed = InatTaxaResponseSchema.safeParse(raw);
+    if (!parsed.success) {
+        return { ok: false, error: z.prettifyError(parsed.error) };
+    }
+    return { ok: true, taxa: parsed.data.results.map(normalizeTaxon) };
+}
+
+// --------------------------------------------------------------------------
+// Taxon-ancestor closure (pure diffs). The shell drives the fetch loop.
+// --------------------------------------------------------------------------
+
+/**
+ * Every taxon id an observation batch depends on: each observation's taxon plus
+ * its full ancestor chain. Sorted & deduped. The observations' `ancestor_ids`
+ * already include self, but taxonId is unioned in defensively.
+ */
+export function referencedTaxonIds(observations: readonly NormalizedObservation[]): number[] {
+    const s = new Set<number>();
+    for (const o of observations) {
+        s.add(o.taxonId);
+        for (const a of o.ancestorIds) s.add(a);
+    }
+    return [...s].sort((a, b) => a - b);
+}
+
+/**
+ * Every taxon id a batch of *fetched taxa* references — self, ancestors, and
+ * parent. Used by the shell to expand the closure after each `/taxa` fetch and
+ * recompute what's still missing.
+ */
+export function referencedTaxonIdsFromTaxa(taxa: readonly NormalizedTaxon[]): number[] {
+    const s = new Set<number>();
+    for (const t of taxa) {
+        s.add(t.id);
+        if (t.parentId != null) s.add(t.parentId);
+        for (const a of t.ancestorIds) s.add(a);
+    }
+    return [...s].sort((a, b) => a - b);
+}
+
+/**
+ * The referenced ids not yet present in the store. Pure diff — the shell loops
+ * (fetch missing → parse → union new references → recompute missing) until this
+ * returns empty (closure resolved) before opening the persist transaction.
+ */
+export function missingTaxonIds(
+    referenced: Iterable<number>,
+    present: Iterable<number>,
+): number[] {
+    const have = new Set(present);
+    const out = new Set<number>();
+    for (const id of referenced) if (!have.has(id)) out.add(id);
+    return [...out].sort((a, b) => a - b);
+}
+
+// --------------------------------------------------------------------------
+// Pagination completeness (the core safety predicate).
+// --------------------------------------------------------------------------
+
+/** Metadata the shell records for each page it successfully fetched & parsed. */
+export type FetchedPage = {
+    readonly page: number;
+    readonly totalResults: number;
+    /** Raw result count for this page (before null-time skipping). */
+    readonly recordCount: number;
+};
+
+/**
+ * Number of pages that must be fetched to cover `totalResults` at `perPage`.
+ * `totalResults === 0` still requires the ONE page (page 1) that authoritatively
+ * reported the empty result. NB: iNat caps page-based pagination at 10 000
+ * records, so a window with total > 10 000 cannot be completed by this route —
+ * `isPaginationComplete` will (honestly) never return true for it, and the shell
+ * aborts rather than persist a truncated view.
+ */
+export function expectedPageCount(totalResults: number, perPage: number): number {
+    if (perPage <= 0) return 0;
+    if (totalResults <= 0) return 1;
+    return Math.ceil(totalResults / perPage);
+}
+
+/**
+ * Whether the accumulated pages constitute a PROVABLY COMPLETE fetch (decision
+ * 011's central invariant). Complete iff:
+ *   - at least page 1 was fetched;
+ *   - every page reports the same total_results (no shifting ground);
+ *   - the fetched page numbers are exactly 1..N with no gap or duplicate,
+ *     where N = expectedPageCount(total, perPage);
+ *   - the per-page record counts sum to total_results.
+ * Any hole, an extra/short page, or a mid-pagination failure (which leaves a page
+ * un-accumulated) → false → the shell writes nothing.
+ */
+export function isPaginationComplete(pages: readonly FetchedPage[], perPage: number): boolean {
+    if (pages.length === 0) return false;
+    const total = pages[0]!.totalResults;
+    if (pages.some((p) => p.totalResults !== total)) return false;
+
+    const expected = expectedPageCount(total, perPage);
+    if (pages.length !== expected) return false;
+
+    const nums = new Set(pages.map((p) => p.page));
+    if (nums.size !== expected) return false;
+    for (let i = 1; i <= expected; i++) if (!nums.has(i)) return false;
+
+    const sum = pages.reduce((n, p) => n + p.recordCount, 0);
+    return sum === total;
+}
+
+// --------------------------------------------------------------------------
+// Reconcile (the safety-critical diff — same shape as Maplify).
+// --------------------------------------------------------------------------
+
+export type ObservationReconcilePlan = {
+    readonly upsert: readonly NormalizedObservation[];
+    readonly delete: readonly number[];
+};
+
+/**
+ * Compute the authoritative reconcile plan for a window, given the complete set
+ * of fetched observations and the observation ids currently stored in that
+ * window. Upsert everything fetched; delete stored ids the fetch no longer
+ * contains. Photos travel inside each upserted observation and are reconciled
+ * per-observation at persist time (a bounded SQL anti-join, like the live path).
+ *
+ * Precondition (enforced by the shell, not here): only call this with a fetch
+ * that parsed ok AND is complete (isPaginationComplete) AND whose taxon closure
+ * resolved. Given an empty `fetched`, every existing id is a delete — which is
+ * why the shell must never reach this on a failed/incomplete fetch.
+ */
+export function reconcile(
+    fetched: readonly NormalizedObservation[],
+    existingWindowIds: readonly number[],
+): ObservationReconcilePlan {
+    const fetchedIds = new Set(fetched.map((o) => o.id));
+    return {
+        upsert: fetched,
+        delete: existingWindowIds.filter((id) => !fetchedIds.has(id)),
+    };
+}

--- a/scripts/ingest/persist.test.ts
+++ b/scripts/ingest/persist.test.ts
@@ -14,8 +14,20 @@
 import { describe, test, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import postgres from 'postgres';
 import type { Sql } from 'postgres';
-import { persistMaplify, type IngestWindow } from './persist.ts';
+import {
+    persistMaplify,
+    persistInaturalist,
+    fetchExistingTaxonIds,
+    fetchObservationWindowIds,
+    type IngestWindow,
+} from './persist.ts';
 import type { NormalizedSighting, ReconcilePlan } from './maplify.ts';
+import type {
+    NormalizedObservation,
+    NormalizedPhoto,
+    NormalizedTaxon,
+    ObservationReconcilePlan,
+} from './inaturalist.ts';
 
 const DSN = process.env['SUPABASE_DB_URL'];
 const WINDOW: IngestWindow = { start: '2026-07-01', end: '2026-07-05' };
@@ -105,5 +117,161 @@ describe.skipIf(!DSN)('persistMaplify (local Supabase)', () => {
         expect(res.upserted).toBe(1);
         const rows = await sql`select id from maplify.sightings where id = 900301`;
         expect(rows.count).toBe(0);
+    });
+});
+
+/**
+ * Integration suite for the iNaturalist persist layer (salishsea-io-89d.2 / 011).
+ *
+ * Reserved bands (all cleaned in afterEach): observations/photos 9_000_000_000+
+ * (well above real iNat ids ~3.8e8), taxa 2_000_000_000+ (within int4), and
+ * contributors with an inat_login prefixed 'test_inat'. Proves: taxa+observation+
+ * photo upsert with contributor minting and provider/collection defaults; the
+ * updated_at freshness guard; per-observation photo reconciliation bounded to the
+ * fetched observations; and the window-bounded observation DELETE (the data-loss
+ * regression lock, mirroring the Maplify assertion).
+ */
+describe.skipIf(!DSN)('persistInaturalist (local Supabase)', () => {
+    let sql: Sql;
+    beforeAll(() => { sql = postgres(DSN!, { max: 1 }); });
+    afterAll(async () => { await sql?.end(); });
+    afterEach(async () => {
+        await sql`delete from inaturalist.observation_photos where observation_id >= 9000000000 and observation_id < 9000010000`;
+        await sql`delete from inaturalist.observations where id >= 9000000000 and id < 9000010000`;
+        await sql`delete from inaturalist.taxa where id >= 2000000000 and id < 2000001000`;
+        await sql`delete from public.contributors where inat_login like 'test_inat%'`;
+    });
+
+    const testTaxa: NormalizedTaxon[] = [
+        { id: 2000000001, parentId: null, scientificName: 'Testessa radix', vernacularName: null, rank: 'stateofmatter', ancestorIds: [2000000001] },
+        { id: 2000000002, parentId: 2000000001, scientificName: 'Testus specificus', vernacularName: 'Test Whale', rank: 'species', ancestorIds: [2000000001, 2000000002] },
+    ];
+
+    const photo = (over: Partial<NormalizedPhoto> & { id: number }): NormalizedPhoto => ({
+        seq: 0, attribution: '(c) tester', hidden: false, license: 'cc-by-nc',
+        height: 100, width: 200, url: 'https://example.com/p.jpg', ...over,
+    });
+    const observation = (over: Partial<NormalizedObservation> & { id: number }): NormalizedObservation => ({
+        description: null, lon: -123, lat: 48, observedAt: '2026-07-03T10:00:00-07:00',
+        licenseCode: 'cc-by-nc', uri: 'https://www.inaturalist.org/observations/x',
+        login: 'test_inat_a', orcid: null, taxonId: 2000000002,
+        ancestorIds: [2000000001, 2000000002], publicPositionalAccuracy: 10,
+        updatedAt: '2026-07-05T10:00:00-07:00', photos: [], ...over,
+    });
+    const iplan = (over: Partial<ObservationReconcilePlan> = {}): ObservationReconcilePlan =>
+        ({ upsert: [], delete: [], ...over });
+
+    test('upserts taxa + observation + photos, mints contributor, applies provider/collection defaults', async () => {
+        const res = await persistInaturalist(sql, {
+            taxa: testTaxa,
+            plan: iplan({ upsert: [observation({ id: 9000000001, photos: [photo({ id: 9100000001, seq: 0 }), photo({ id: 9100000002, seq: 1 })] })] }),
+            window: WINDOW,
+        });
+        expect(res.taxaUpserted).toBe(2);
+        expect(res.observationsUpserted).toBe(1);
+        expect(res.photosUpserted).toBe(2);
+
+        const [o] = await sql`select provider_id, collection_id, contributor_id, taxon_id from inaturalist.observations where id = 9000000001`;
+        expect(o?.['provider_id']).toBe(3);       // iNaturalist provider DEFAULT
+        expect(o?.['collection_id']).toBe(8);     // iNaturalist collection DEFAULT
+        expect(Number(o?.['taxon_id'])).toBe(2000000002);
+        expect(o?.['contributor_id']).not.toBeNull();
+
+        const [c] = await sql`select inat_login from public.contributors where id = ${o?.['contributor_id'] as number}`;
+        expect(c?.['inat_login']).toBe('test_inat_a');
+
+        const photos = await sql`select id from inaturalist.observation_photos where observation_id = 9000000001`;
+        expect(photos.count).toBe(2);
+    });
+
+    test('is idempotent and honors the updated_at freshness guard', async () => {
+        await persistInaturalist(sql, { taxa: testTaxa, plan: iplan({ upsert: [observation({ id: 9000000002, description: 'first', updatedAt: '2026-07-05T10:00:00-07:00' })] }), window: WINDOW });
+        // newer updated_at → overwrites
+        await persistInaturalist(sql, { taxa: testTaxa, plan: iplan({ upsert: [observation({ id: 9000000002, description: 'second', updatedAt: '2026-07-06T10:00:00-07:00' })] }), window: WINDOW });
+        const rows = await sql`select description from inaturalist.observations where id = 9000000002`;
+        expect(rows.count).toBe(1);
+        expect(rows[0]?.['description']).toBe('second');
+        // older updated_at → stale, must NOT overwrite
+        await persistInaturalist(sql, { taxa: testTaxa, plan: iplan({ upsert: [observation({ id: 9000000002, description: 'stale', updatedAt: '2026-07-04T10:00:00-07:00' })] }), window: WINDOW });
+        const rows2 = await sql`select description from inaturalist.observations where id = 9000000002`;
+        expect(rows2[0]?.['description']).toBe('second');
+    });
+
+    test('reconciles photos per-observation, bounded to the fetched observations', async () => {
+        // obs A has photos p1,p2; obs B (separate) has photo p9 that must never be touched
+        await persistInaturalist(sql, { taxa: testTaxa, plan: iplan({ upsert: [
+            observation({ id: 9000000010, photos: [photo({ id: 9100000010 }), photo({ id: 9100000011 })] }),
+            observation({ id: 9000000020, photos: [photo({ id: 9100000090 })] }),
+        ] }), window: WINDOW });
+
+        // re-fetch obs A with p1 kept, p3 new (p2 gone). obs B is NOT in this batch.
+        const res = await persistInaturalist(sql, { taxa: testTaxa, plan: iplan({ upsert: [
+            observation({ id: 9000000010, updatedAt: '2026-07-06T10:00:00-07:00', photos: [photo({ id: 9100000010 }), photo({ id: 9100000012 })] }),
+        ] }), window: WINDOW });
+        expect(res.photosDeleted).toBe(1); // only p2 (9100000011)
+
+        const aPhotos = await sql`select id from inaturalist.observation_photos where observation_id = 9000000010 order by id`;
+        expect(aPhotos.map((r) => Number(r['id']))).toEqual([9100000010, 9100000012]);
+
+        // obs B's photo untouched — reconcile did not reach an observation absent from the batch
+        const bPhotos = await sql`select id from inaturalist.observation_photos where observation_id = 9000000020`;
+        expect(bPhotos.count).toBe(1);
+    });
+
+    test('reconcile observation DELETE is window-bounded — an out-of-window id is NOT deleted', async () => {
+        await persistInaturalist(sql, { taxa: testTaxa, plan: iplan({ upsert: [
+            observation({ id: 9000000030, observedAt: '2026-07-03T10:00:00-07:00' }), // in window
+            observation({ id: 9000000031, observedAt: '2026-06-01T10:00:00-07:00' }), // a month before
+        ] }), window: WINDOW });
+
+        // caller passes BOTH ids to delete; the window guard must spare 9000000031
+        const res = await persistInaturalist(sql, { taxa: [], plan: iplan({ delete: [9000000030, 9000000031] }), window: WINDOW });
+        expect(res.observationsDeleted).toBe(1);
+
+        const survivors = await sql`select id from inaturalist.observations where id in (9000000030, 9000000031)`;
+        expect(survivors.map((r) => Number(r['id']))).toEqual([9000000031]);
+    });
+
+    test('deletes an observation together with its photos (FK-safe order)', async () => {
+        await persistInaturalist(sql, { taxa: testTaxa, plan: iplan({ upsert: [
+            observation({ id: 9000000060, photos: [photo({ id: 9100000060 }), photo({ id: 9100000061 })] }),
+        ] }), window: WINDOW });
+        const res = await persistInaturalist(sql, { taxa: [], plan: iplan({ delete: [9000000060] }), window: WINDOW });
+        expect(res.observationsDeleted).toBe(1);
+        expect(res.photosDeleted).toBe(2);
+        const left = await sql`select id from inaturalist.observation_photos where observation_id = 9000000060`;
+        expect(left.count).toBe(0);
+    });
+
+    test('fetchExistingTaxonIds returns only the ids already present', async () => {
+        await persistInaturalist(sql, { taxa: testTaxa, plan: iplan(), window: WINDOW });
+        const present = await fetchExistingTaxonIds(sql, [2000000001, 2000000002, 2000000999]);
+        expect([...present].sort((a, b) => a - b)).toEqual([2000000001, 2000000002]);
+    });
+
+    test('fetchObservationWindowIds returns in-window ids and excludes out-of-window ones', async () => {
+        await persistInaturalist(sql, { taxa: testTaxa, plan: iplan({ upsert: [
+            observation({ id: 9000000050, observedAt: '2026-07-03T10:00:00-07:00' }),
+            observation({ id: 9000000051, observedAt: '2026-06-01T10:00:00-07:00' }),
+        ] }), window: WINDOW });
+        const ids = await fetchObservationWindowIds(sql, WINDOW);
+        expect(ids).toContain(9000000050);
+        expect(ids).not.toContain(9000000051);
+    });
+
+    test('dry run exercises constraints, reports would-be counts, writes nothing', async () => {
+        const res = await persistInaturalist(sql, {
+            taxa: testTaxa,
+            plan: iplan({ upsert: [observation({ id: 9000000040, photos: [photo({ id: 9100000040 })] })] }),
+            window: WINDOW,
+        }, { dryRun: true });
+        expect(res.taxaUpserted).toBe(2);
+        expect(res.observationsUpserted).toBe(1);
+        expect(res.photosUpserted).toBe(1);
+
+        const obsRows = await sql`select id from inaturalist.observations where id = 9000000040`;
+        expect(obsRows.count).toBe(0);
+        const taxaRows = await sql`select id from inaturalist.taxa where id = 2000000001`;
+        expect(taxaRows.count).toBe(0);
     });
 });

--- a/scripts/ingest/persist.ts
+++ b/scripts/ingest/persist.ts
@@ -22,6 +22,11 @@
 
 import type { Sql, TransactionSql } from 'postgres';
 import { resolveScientificName, type NormalizedSighting, type ReconcilePlan } from './maplify.ts';
+import type {
+    NormalizedObservation,
+    NormalizedTaxon,
+    ObservationReconcilePlan,
+} from './inaturalist.ts';
 
 export type IngestWindow = {
     /** inclusive start date, 'YYYY-MM-DD' */
@@ -171,4 +176,282 @@ export async function persistMaplify(
     }
 
     return sql.begin(run) as Promise<PersistResult>;
+}
+
+// =========================================================================
+// iNaturalist persist (epic salishsea-io-89d.2 / decision 011).
+//
+// The iNat write step. Same discipline as Maplify: injected postgres.js
+// connection, SQL authored here, ONE atomic transaction. Two structural
+// differences from Maplify:
+//   - Parent/child rows: taxa (referenced by observations.taxon_id, NOT NULL)
+//     and observation_photos (referencing observations.id). The transaction
+//     orders writes to respect the FKs: taxa → observations → photos → deletes.
+//   - Photos reconcile PER-OBSERVATION (a bounded SQL anti-join), exactly like
+//     the live upsert_observation_page: for the observations present in this
+//     fetch, any stored photo the fetch no longer returns is deleted; photos of
+//     other observations are never touched.
+//
+// The taxa passed in are the closure the shell resolved BEFORE opening this
+// transaction (no HTTP inside a DB write, decision 011). Persist-time DB
+// resolutions kept in SQL, unchanged from the prior path:
+//   - provider_id / collection_id — column DEFAULTs (3 / 8 = iNaturalist).
+//   - contributor_id              — inaturalist.mint_contributor(login, orcid),
+//                                   a relational upsert into public.contributors.
+//
+// Like Maplify, both destructive DELETEs are window-bounded (observed_at in
+// [start, end+1)) in SQL as defence-in-depth — a caller that passes an
+// out-of-window id cannot delete outside the window.
+// =========================================================================
+
+export type InatPersistResult = {
+    readonly taxaUpserted: number;
+    readonly observationsUpserted: number;
+    readonly observationsDeleted: number;
+    readonly photosUpserted: number;
+    readonly photosDeleted: number;
+};
+
+/**
+ * Of the given candidate ids, those already present in inaturalist.taxa. The
+ * shell diffs referenced against this (missingTaxonIds) to drive the taxon
+ * closure loop before opening the persist transaction.
+ */
+export async function fetchExistingTaxonIds(
+    sql: Sql,
+    candidateIds: readonly number[],
+): Promise<number[]> {
+    if (candidateIds.length === 0) return [];
+    const rows = await sql<{ id: number }[]>`
+        SELECT id FROM inaturalist.taxa WHERE id = ANY(${candidateIds as unknown as number[]}::int[])`;
+    return rows.map((r) => r.id);
+}
+
+/**
+ * The observation ids currently stored in a window (by observed_at) — fed to
+ * reconcile() to compute the delete set. Uses the SAME bound as the reconcile
+ * DELETE ([start, end+1)) so the read and the write agree on window membership.
+ * observations.id is bigint (returned as string by postgres.js) → coerced to
+ * number (iNat ids are well within 2^53).
+ */
+export async function fetchObservationWindowIds(sql: Sql, window: IngestWindow): Promise<number[]> {
+    const rows = await sql<{ id: string }[]>`
+        SELECT id FROM inaturalist.observations
+        WHERE observed_at >= ${window.start}::date
+          AND observed_at < (${window.end}::date + 1)`;
+    return rows.map((r) => Number(r.id));
+}
+
+type TaxonPayloadRow = {
+    id: number; parent_id: number | null; scientific_name: string;
+    vernacular_name: string | null; rank: string;
+};
+
+type ObservationPayloadRow = {
+    id: number; description: string | null; lon: number; lat: number;
+    observed_at: string; license_code: string | null; uri: string;
+    login: string; orcid: string | null; taxon_id: number;
+    public_positional_accuracy: number | null; updated_at: string;
+};
+
+type PhotoPayloadRow = {
+    id: number; observation_id: number; seq: number; attribution: string;
+    hidden: boolean; license: string | null; height: number; width: number; url: string;
+};
+
+function toTaxonPayload(taxa: readonly NormalizedTaxon[]): TaxonPayloadRow[] {
+    return taxa.map((t) => ({
+        id: t.id, parent_id: t.parentId, scientific_name: t.scientificName,
+        vernacular_name: t.vernacularName, rank: t.rank,
+    }));
+}
+
+function toObservationPayload(observations: readonly NormalizedObservation[]): ObservationPayloadRow[] {
+    return observations.map((o) => ({
+        id: o.id, description: o.description, lon: o.lon, lat: o.lat,
+        observed_at: o.observedAt, license_code: o.licenseCode, uri: o.uri,
+        login: o.login, orcid: o.orcid, taxon_id: o.taxonId,
+        public_positional_accuracy: o.publicPositionalAccuracy, updated_at: o.updatedAt,
+    }));
+}
+
+function toPhotoPayload(observations: readonly NormalizedObservation[]): PhotoPayloadRow[] {
+    const rows: PhotoPayloadRow[] = [];
+    for (const o of observations) {
+        for (const p of o.photos) {
+            rows.push({
+                id: p.id, observation_id: o.id, seq: p.seq, attribution: p.attribution,
+                hidden: p.hidden, license: p.license, height: p.height, width: p.width, url: p.url,
+            });
+        }
+    }
+    return rows;
+}
+
+/**
+ * Apply an iNaturalist reconcile plan for one window atomically, with the taxon
+ * closure the shell already resolved.
+ *
+ * On dryRun the whole transaction is rolled back after executing (so constraints
+ * and FKs are still exercised) and nothing is persisted.
+ *
+ * Precondition (decision 011): the caller has verified the fetch was complete
+ * (isPaginationComplete) AND the taxon closure resolved (missingTaxonIds empty).
+ * This function must NEVER be reached on a failed/incomplete fetch.
+ */
+export async function persistInaturalist(
+    sql: Sql,
+    input: {
+        readonly taxa: readonly NormalizedTaxon[];
+        readonly plan: ObservationReconcilePlan;
+        readonly window: IngestWindow;
+    },
+    opts: { readonly dryRun?: boolean } = {},
+): Promise<InatPersistResult> {
+    const { taxa, plan, window } = input;
+    const taxonPayload = toTaxonPayload(taxa);
+    const obsPayload = toObservationPayload(plan.upsert);
+    const photoPayload = toPhotoPayload(plan.upsert);
+    const upsertObsIds = plan.upsert.map((o) => o.id);
+    const fetchedPhotoIds = photoPayload.map((p) => p.id);
+    const deleteIds = plan.delete;
+
+    const run = async (tx: TransactionSql): Promise<InatPersistResult> => {
+        // 1. Taxa first — observations.taxon_id (NOT NULL) references them. The
+        //    self-referential parent_id FK is DEFERRABLE, so a single batch with
+        //    intra-batch parents resolves at commit. DO NOTHING: taxa are stable
+        //    reference data (matches the live upsert_taxon).
+        let taxaUpserted = 0;
+        if (taxonPayload.length > 0) {
+            const rows = await tx`
+                INSERT INTO inaturalist.taxa (id, parent_id, scientific_name, vernacular_name, rank)
+                SELECT v.id, v.parent_id, v.scientific_name, v.vernacular_name, v.rank::inaturalist.rank
+                FROM jsonb_to_recordset(${tx.json(taxonPayload as never)}) AS v(
+                    id int, parent_id int, scientific_name text, vernacular_name text, rank text
+                )
+                ON CONFLICT (id) DO NOTHING
+                RETURNING id`;
+            taxaUpserted = rows.count;
+        }
+
+        // 2. Observations. contributor_id is minted only on INSERT (mint_contributor
+        //    upserts public.contributors); on conflict we refresh mirror fields but
+        //    only when the incoming updated_at is newer (mirrors the live MERGE's
+        //    `WHEN MATCHED AND v.updated_at > o.updated_at`).
+        let observationsUpserted = 0;
+        if (obsPayload.length > 0) {
+            const rows = await tx`
+                INSERT INTO inaturalist.observations (
+                    id, description, location, observed_at, license_code, uri, username,
+                    taxon_id, fetched_at, public_positional_accuracy, updated_at, contributor_id
+                )
+                SELECT
+                    v.id, v.description,
+                    gis.ST_Point(v.lon, v.lat)::gis.geography,
+                    v.observed_at::timestamptz, v.license_code::license, v.uri, v.login,
+                    v.taxon_id, current_timestamp, v.public_positional_accuracy,
+                    v.updated_at::timestamp,
+                    inaturalist.mint_contributor(v.login, v.orcid)
+                FROM jsonb_to_recordset(${tx.json(obsPayload as never)}) AS v(
+                    id bigint, description text, lon float8, lat float8, observed_at text,
+                    license_code text, uri text, login text, orcid text, taxon_id int,
+                    public_positional_accuracy int, updated_at text
+                )
+                ON CONFLICT (id) DO UPDATE SET
+                    description = EXCLUDED.description,
+                    location = EXCLUDED.location,
+                    observed_at = EXCLUDED.observed_at,
+                    license_code = EXCLUDED.license_code,
+                    username = EXCLUDED.username,
+                    taxon_id = EXCLUDED.taxon_id,
+                    fetched_at = EXCLUDED.fetched_at,
+                    public_positional_accuracy = EXCLUDED.public_positional_accuracy,
+                    updated_at = EXCLUDED.updated_at
+                WHERE EXCLUDED.updated_at > inaturalist.observations.updated_at
+                RETURNING id`;
+            observationsUpserted = rows.count;
+        }
+
+        // 3. Photos for the fetched observations, then reconcile: delete any stored
+        //    photo of THOSE observations that the fetch no longer returns. Bounded
+        //    to upsertObsIds — photos of observations outside this fetch are never
+        //    touched (same guarantee as the live per-observation reconcile).
+        let photosUpserted = 0;
+        let photosDeleted = 0;
+        if (upsertObsIds.length > 0) {
+            if (photoPayload.length > 0) {
+                const rows = await tx`
+                    INSERT INTO inaturalist.observation_photos (
+                        id, observation_id, seq, attribution, hidden, license, original_dimensions, url
+                    )
+                    SELECT
+                        v.id, v.observation_id, v.seq, v.attribution, v.hidden,
+                        v.license::license, ROW(v.height, v.width)::public.dimensions, v.url
+                    FROM jsonb_to_recordset(${tx.json(photoPayload as never)}) AS v(
+                        id bigint, observation_id bigint, seq int2, attribution text, hidden bool,
+                        license text, height int, width int, url text
+                    )
+                    ON CONFLICT (id) DO UPDATE SET
+                        observation_id = EXCLUDED.observation_id,
+                        seq = EXCLUDED.seq,
+                        attribution = EXCLUDED.attribution,
+                        hidden = EXCLUDED.hidden,
+                        license = EXCLUDED.license,
+                        original_dimensions = EXCLUDED.original_dimensions,
+                        url = EXCLUDED.url
+                    RETURNING id`;
+                photosUpserted = rows.count;
+            }
+            const stale = await tx`
+                DELETE FROM inaturalist.observation_photos
+                WHERE observation_id = ANY(${upsertObsIds as unknown as number[]}::bigint[])
+                  AND id <> ALL(${fetchedPhotoIds as unknown as number[]}::bigint[])
+                RETURNING id`;
+            photosDeleted += stale.count;
+        }
+
+        // 4. Reconcile deletes, window-bounded. Photos first (FK: no cascade), then
+        //    the observations themselves.
+        let observationsDeleted = 0;
+        if (deleteIds.length > 0) {
+            const delPhotos = await tx`
+                DELETE FROM inaturalist.observation_photos p
+                USING inaturalist.observations o
+                WHERE p.observation_id = o.id
+                  AND o.id = ANY(${deleteIds as unknown as number[]}::bigint[])
+                  AND o.observed_at >= ${window.start}::date
+                  AND o.observed_at < (${window.end}::date + 1)
+                RETURNING p.id`;
+            photosDeleted += delPhotos.count;
+
+            const delObs = await tx`
+                DELETE FROM inaturalist.observations
+                WHERE id = ANY(${deleteIds as unknown as number[]}::bigint[])
+                  AND observed_at >= ${window.start}::date
+                  AND observed_at < (${window.end}::date + 1)
+                RETURNING id`;
+            observationsDeleted = delObs.count;
+        }
+
+        return { taxaUpserted, observationsUpserted, observationsDeleted, photosUpserted, photosDeleted };
+    };
+
+    if (opts.dryRun) {
+        const sentinel = Symbol('dry-run-rollback');
+        let result: InatPersistResult = {
+            taxaUpserted: 0, observationsUpserted: 0, observationsDeleted: 0,
+            photosUpserted: 0, photosDeleted: 0,
+        };
+        try {
+            await sql.begin(async (tx) => {
+                result = await run(tx);
+                throw sentinel;
+            });
+        } catch (e) {
+            if (e !== sentinel) throw e;
+        }
+        return result;
+    }
+
+    return sql.begin(run) as Promise<InatPersistResult>;
 }


### PR DESCRIPTION
First slice of iNaturalist ingest (`salishsea-io-89d.2`), following [decision 011](docs/decisions/011-ingest-imperative-shell.md) and mirroring the merged Maplify slice (`89d.1`). This PR builds the **functional core** and **persist layer** with tests. The Deno Edge Function shell (the paging + taxon-closure orchestration loops) is deliberately the **next slice** — not built here.

## Functional core — `scripts/ingest/inaturalist.ts`
Pure, runtime-agnostic transforms (importable by both the Deno shell and vitest):
- **Validation/normalize** for observations, photos, and taxa via zod. A malformed record rejects the *whole* response — no silent drops, since a dropped record would become a reconcile delete-candidate. Records with `time_observed_at = null` are **skipped** (out of scope), not rejected.
- **Taxon-ancestor closure** (the pure pieces the shell loops over before opening the txn): `referencedTaxonIds`, `referencedTaxonIdsFromTaxa`, `missingTaxonIds`.
- **Pagination completeness**: `expectedPageCount` + `isPaginationComplete` — complete iff every page `1..N` is present with consistent `total_results` and record counts summing to it; an empty first page (`total_results = 0`) is authoritative.
- **`reconcile`**: window upsert/delete plan (photos travel inside each observation).

## Persist layer — `scripts/ingest/persist.ts`
- **`persistInaturalist`**: one atomic transaction — taxa → observations → photos → window-bounded deletes (FK-safe order). `jsonb_to_recordset` upserts with snake_case keys; **per-observation photo reconciliation** via a bounded anti-join (matching the live `upsert_observation_page`); the `updated_at` freshness guard; `contributor_id` minted via `inaturalist.mint_contributor`; provider/collection column defaults; dry-run rollback.
- **`fetchExistingTaxonIds`** and **`fetchObservationWindowIds`** readers.

## Tests & fixtures
- `inaturalist.test.ts`: 35 unit tests. `persist.test.ts`: 8 iNat integration tests (gated on `SUPABASE_DB_URL`, reserved id bands, `afterEach` cleanup) — proving taxa+observation+photo upsert, idempotency + freshness guard, per-observation photo reconciliation, and the **window-bounded observation DELETE** (the data-loss regression lock).
- Fixtures captured from the **live v2 API** on 2026-07-05, trimmed to representative records (with/without photos, null photo license, null `public_positional_accuracy`, a crafted null-`time_observed_at` skip case; taxa incl. "Life" with `parent_id = null`).

## Gates
`npx tsc --noEmit` clean; full `npx vitest run` green (282 tests / 25 files). No migration touched (iNat reuses the existing schema).

## Real-API surprises
- iNat returns `total_results`/`page`/`per_page` as **real ints** (unlike Maplify's string `count`).
- `ancestor_ids` **includes self** as the last element.

Refs `salishsea-io-89d.2`, decision 011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)