### PR TITLE
feat(ingest): wire iNaturalist into the Edge Function shell (89d.2)

### DIFF
--- a/scripts/ingest/persist.test.ts
+++ b/scripts/ingest/persist.test.ts
@@ -218,6 +218,21 @@ describe.skipIf(!DSN)('persistInaturalist (local Supabase)', () => {
         expect(bPhotos.count).toBe(1);
     });
 
+    test('collapses a photo id shared across two observations in one batch (last-wins, no ON CONFLICT crash)', async () => {
+        // iNaturalist attaches the same photo id to more than one observation; a
+        // single bulk upsert must dedupe or Postgres raises "ON CONFLICT DO UPDATE
+        // command cannot affect row a second time" (found in a live 2026 run).
+        const res = await persistInaturalist(sql, { taxa: testTaxa, plan: iplan({ upsert: [
+            observation({ id: 9000000070, photos: [photo({ id: 9100000070 })] }),
+            observation({ id: 9000000071, photos: [photo({ id: 9100000070 })] }), // same photo id
+        ] }), window: WINDOW });
+        expect(res.photosUpserted).toBe(1); // collapsed to a single row
+
+        const rows = await sql`select observation_id from inaturalist.observation_photos where id = 9100000070`;
+        expect(rows.count).toBe(1);
+        expect(Number(rows[0]?.['observation_id'])).toBe(9000000071); // last occurrence wins
+    });
+
     test('reconcile observation DELETE is window-bounded — an out-of-window id is NOT deleted', async () => {
         await persistInaturalist(sql, { taxa: testTaxa, plan: iplan({ upsert: [
             observation({ id: 9000000030, observedAt: '2026-07-03T10:00:00-07:00' }), // in window

--- a/scripts/ingest/persist.ts
+++ b/scripts/ingest/persist.ts
@@ -275,17 +275,30 @@ function toObservationPayload(observations: readonly NormalizedObservation[]): O
     }));
 }
 
+/**
+ * Flatten observations → photo rows, deduped by photo id (last occurrence wins).
+ *
+ * observation_photos.id is the PK, but iNaturalist attaches the SAME underlying
+ * photo id to more than one observation (verified against live data 2026-07-05:
+ * ~5 collisions in an 8 200-observation window). Feeding both to a single bulk
+ * `INSERT ... ON CONFLICT (id) DO UPDATE` fails with "command cannot affect row a
+ * second time". The legacy path never hit this because it upserted page-by-page;
+ * the consolidated bulk upsert must collapse the duplicate itself. A photo can be
+ * stored under exactly one observation, so last-wins is the only representable
+ * outcome — and it also keeps fetchedPhotoIds (derived from this payload) free of
+ * duplicates for the per-observation reconcile anti-join.
+ */
 function toPhotoPayload(observations: readonly NormalizedObservation[]): PhotoPayloadRow[] {
-    const rows: PhotoPayloadRow[] = [];
+    const byId = new Map<number, PhotoPayloadRow>();
     for (const o of observations) {
         for (const p of o.photos) {
-            rows.push({
+            byId.set(p.id, {
                 id: p.id, observation_id: o.id, seq: p.seq, attribution: p.attribution,
                 hidden: p.hidden, license: p.license, height: p.height, width: p.width, url: p.url,
             });
         }
     }
-    return rows;
+    return [...byId.values()];
 }
 
 /**

--- a/supabase/functions/ingest/fetch-inaturalist.ts
+++ b/supabase/functions/ingest/fetch-inaturalist.ts
@@ -1,0 +1,272 @@
+/**
+ * iNaturalist fetch — imperative shell (salishsea-io-89d.2 / decision 011).
+ *
+ * The two effectful orchestration loops iNat ingest needs; everything they call
+ * is the pure functional core (scripts/ingest/inaturalist.ts) or the persist
+ * layer (scripts/ingest/persist.ts). Both loops enforce decision 011's
+ * completeness invariant: they either produce a PROVABLY COMPLETE fetch or they
+ * throw — and a throw makes index.ts write nothing.
+ *
+ *   A. fetchAllObservationPages — page 1..N through `total_results`; every page
+ *      must parse; `isPaginationComplete` must hold; else throw. An empty first
+ *      page (total_results = 0) is complete and authoritative.
+ *
+ *   B. resolveTaxonClosure — resolve the FULL taxon-ancestor closure before the
+ *      caller opens the persist transaction (no HTTP inside the DB write). Fetch
+ *      the missing taxa, expand their references, recompute still-missing, loop
+ *      until empty. A taxa-API failure — or a requested taxon the API won't
+ *      return — counts against completeness → throw.
+ *
+ * Every fetch uses an AbortController timeout: Deno's fetch has no built-in
+ * timeout, and a hung connection would block the whole edge invocation.
+ */
+
+import type { Sql } from 'postgres';
+import {
+    MAX_ATTEMPTS,
+    retryDelayMs,
+    parseRetryAfter,
+    isRetryableStatus,
+} from '../../../scripts/ingest/retry.ts';
+import {
+    SALISH_SEA_BBOX,
+    INAT_ROOT_TAXON_IDS,
+    PER_PAGE,
+    parseInatResponse,
+    parseInatTaxa,
+    referencedTaxonIds,
+    referencedTaxonIdsFromTaxa,
+    missingTaxonIds,
+    expectedPageCount,
+    isPaginationComplete,
+    type FetchedPage,
+    type NormalizedObservation,
+    type NormalizedTaxon,
+} from '../../../scripts/ingest/inaturalist.ts';
+import { fetchExistingTaxonIds, type IngestWindow } from '../../../scripts/ingest/persist.ts';
+
+export type Logger = (msg: string, extra?: Record<string, unknown>) => void;
+
+const OBSERVATIONS_URL = 'https://api.inaturalist.org/v2/observations';
+const TAXA_URL = 'https://api.inaturalist.org/v2/taxa';
+
+// Deno fetch has no built-in timeout; bound each attempt so a hung connection
+// becomes a retryable AbortError instead of blocking the invocation.
+const FETCH_TIMEOUT_MS = 20_000;
+
+// iNat page-based pagination caps at page * per_page <= 10 000 records.
+const MAX_PAGE = Math.floor(10_000 / PER_PAGE);
+
+// iNat caps the `/taxa` `id` param at ~30 ids per request.
+const TAXA_ID_CHUNK = 30;
+
+// v2 `/observations` field selection. Extends the legacy SQL path's set with the
+// fields the functional core now requires: `updated_at` (drives the
+// newer-wins upsert), the observation_photo `id`, and `user.orcid` (minted into
+// the contributor). Kept as the tight projection iNat's v2 API expects.
+const OBSERVATION_FIELDS =
+    '(id:!t,description:!t,geojson:!t,license_code:!t,time_observed_at:!t,updated_at:!t,' +
+    'uri:!t,public_positional_accuracy:!t,' +
+    'observation_photos:(id:!t,position:!t,photo:(id:!t,attribution:!t,hidden:!t,' +
+    'license_code:!t,original_dimensions:(height:!t,width:!t),url:!t)),' +
+    'taxon:(id:!t,ancestor_ids:!t),' +
+    'user:(id:!t,login:!t,name:!t,orcid:!t))';
+
+// v2 `/taxa` field selection (copied from inaturalist.fetch_taxa in migration
+// 20250904165159_fetch_data.sql; matches parseInatTaxa's schema).
+const TAXA_FIELDS = '(id:!t,ancestor_ids:!t,parent_id:!t,rank:!t,name:!t,preferred_common_name:!t)';
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+function chunk<T>(items: readonly T[], size: number): T[][] {
+    const out: T[][] = [];
+    for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+    return out;
+}
+
+/**
+ * GET a URL with the shell's retry policy and a per-attempt timeout, returning
+ * the parsed JSON body on a 2xx. Throws after MAX_ATTEMPTS or on a
+ * non-retryable status. The caller turns any throw into a `failed` ingest.runs
+ * row and writes nothing (decision 011's "abort on a failed fetch").
+ */
+async function fetchJsonWithRetry(url: string, label: string, log: Logger): Promise<unknown> {
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        let res: Response;
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+        try {
+            res = await fetch(url, {
+                headers: { accept: 'application/json' },
+                signal: controller.signal,
+            });
+        } catch (e) {
+            lastError = e;
+            if (attempt === MAX_ATTEMPTS) break;
+            const delay = retryDelayMs(attempt);
+            log('inat fetch error, retrying', { label, attempt, delayMs: delay, error: String(e) });
+            await sleep(delay);
+            continue;
+        } finally {
+            clearTimeout(timeout);
+        }
+
+        if (res.ok) return await res.json();
+
+        lastError = new Error(`iNaturalist ${label} HTTP ${res.status}`);
+        if (!isRetryableStatus(res.status) || attempt === MAX_ATTEMPTS) {
+            await res.body?.cancel();
+            break;
+        }
+        await res.body?.cancel();
+        const delay = retryDelayMs(attempt, parseRetryAfter(res.headers.get('retry-after')));
+        log('inat non-2xx, retrying', { label, attempt, status: res.status, delayMs: delay });
+        await sleep(delay);
+    }
+
+    throw lastError ?? new Error(`iNaturalist ${label} fetch failed`);
+}
+
+function observationsUrl(window: IngestWindow, page: number): string {
+    const params = new URLSearchParams({
+        d1: window.start,
+        d2: window.end,
+        licensed: 'true',
+        nelat: String(SALISH_SEA_BBOX.neLat),
+        nelng: String(SALISH_SEA_BBOX.neLng),
+        swlat: String(SALISH_SEA_BBOX.swLat),
+        swlng: String(SALISH_SEA_BBOX.swLng),
+        taxon_id: INAT_ROOT_TAXON_IDS.join(','),
+        geoprivacy: 'open',
+        taxon_geoprivacy: 'open',
+        per_page: String(PER_PAGE),
+        page: String(page),
+        fields: OBSERVATION_FIELDS,
+    });
+    return `${OBSERVATIONS_URL}?${params.toString()}`;
+}
+
+function taxaUrl(ids: readonly number[]): string {
+    const params = new URLSearchParams({
+        id: ids.join(','),
+        fields: TAXA_FIELDS,
+        preferred_place_id: '1',
+        preferred_locale: 'en',
+    });
+    return `${TAXA_URL}?${params.toString()}`;
+}
+
+export type ObservationFetchResult = {
+    readonly pages: readonly FetchedPage[];
+    readonly observations: readonly NormalizedObservation[];
+    readonly totalResults: number;
+};
+
+/**
+ * Loop A. Fetch every page of the window through `total_results`, accumulating
+ * FetchedPage metadata and normalized observations. Throws on any parse/HTTP
+ * failure, on a window that exceeds iNat's 10 000-record pagination cap, or if
+ * the accumulated pages are not provably complete. Returns only on a complete
+ * fetch — the precondition reconcile() and persist require.
+ */
+export async function fetchAllObservationPages(
+    window: IngestWindow,
+    log: Logger,
+): Promise<ObservationFetchResult> {
+    const pages: FetchedPage[] = [];
+    const observations: NormalizedObservation[] = [];
+    let totalResults = 0;
+
+    for (let page = 1; ; page++) {
+        const raw = await fetchJsonWithRetry(observationsUrl(window, page), 'observations', log);
+        const result = parseInatResponse(raw);
+        if (!result.ok) {
+            throw new Error(`iNaturalist observations parse failed (page ${page}): ${result.error}`);
+        }
+        pages.push({ page, totalResults: result.totalResults, recordCount: result.recordCount });
+        observations.push(...result.observations);
+        totalResults = result.totalResults;
+
+        const expected = expectedPageCount(totalResults, PER_PAGE);
+        if (expected > MAX_PAGE) {
+            throw new Error(
+                `window exceeds iNaturalist pagination cap: total_results=${totalResults} ` +
+                    `needs ${expected} pages (max ${MAX_PAGE}); narrow the window`,
+            );
+        }
+        log('inat observations page', {
+            page, totalResults, recordCount: result.recordCount, expected,
+        });
+        if (page >= expected) break;
+    }
+
+    if (!isPaginationComplete(pages, PER_PAGE)) {
+        throw new Error(
+            `iNaturalist pagination incomplete: fetched ${pages.length} page(s) for ` +
+                `total_results=${totalResults}`,
+        );
+    }
+
+    return { pages, observations, totalResults };
+}
+
+/**
+ * Loop B. Resolve the full taxon-ancestor closure for the fetched observations
+ * BEFORE the caller opens the persist transaction. Diff referenced taxa against
+ * what's stored, fetch the missing ones (chunked), expand their references, and
+ * recompute still-missing until the set is empty. Returns the taxa newly fetched
+ * (to be upserted). Throws if a requested taxon cannot be resolved (a taxa-API
+ * failure or an id the API won't return) — that counts against completeness.
+ */
+export async function resolveTaxonClosure(
+    sql: Sql,
+    observations: readonly NormalizedObservation[],
+    log: Logger,
+): Promise<NormalizedTaxon[]> {
+    const referenced = new Set<number>(referencedTaxonIds(observations));
+    const present = new Set<number>(await fetchExistingTaxonIds(sql, [...referenced]));
+
+    const fetchedTaxa: NormalizedTaxon[] = [];
+    const fetchedIds = new Set<number>();
+    const requested = new Set<number>();
+
+    for (;;) {
+        const have = new Set<number>([...present, ...fetchedIds]);
+        const missing = missingTaxonIds(referenced, have);
+        if (missing.length === 0) break;
+
+        const toFetch = missing.filter((id) => !requested.has(id));
+        if (toFetch.length === 0) {
+            // Every still-missing id was already requested but never returned —
+            // the closure is unresolvable, so the fetch is not complete.
+            throw new Error(
+                `iNaturalist taxon closure unresolved: ${missing.length} taxa not returned ` +
+                    `(e.g. ${missing.slice(0, 10).join(', ')})`,
+            );
+        }
+
+        for (const ids of chunk(toFetch, TAXA_ID_CHUNK)) {
+            for (const id of ids) requested.add(id);
+            const raw = await fetchJsonWithRetry(taxaUrl(ids), 'taxa', log);
+            const parsed = parseInatTaxa(raw);
+            if (!parsed.ok) {
+                throw new Error(`iNaturalist taxa parse failed: ${parsed.error}`);
+            }
+            for (const t of parsed.taxa) {
+                if (fetchedIds.has(t.id)) continue;
+                fetchedTaxa.push(t);
+                fetchedIds.add(t.id);
+            }
+        }
+
+        // Newly fetched taxa may reference new ancestors → widen the referenced set.
+        for (const id of referencedTaxonIdsFromTaxa(fetchedTaxa)) referenced.add(id);
+        log('inat taxon closure round', {
+            referenced: referenced.size, present: present.size, fetched: fetchedTaxa.length,
+        });
+    }
+
+    return fetchedTaxa;
+}

--- a/supabase/functions/ingest/fetch-inaturalist.ts
+++ b/supabase/functions/ingest/fetch-inaturalist.ts
@@ -94,33 +94,38 @@ async function fetchJsonWithRetry(url: string, label: string, log: Logger): Prom
     let lastError: unknown;
 
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-        let res: Response;
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+        let res: Response;
         try {
             res = await fetch(url, {
                 headers: { accept: 'application/json' },
                 signal: controller.signal,
             });
+            if (res.ok) {
+                // Read the body under the SAME timeout: a server can send headers
+                // and then stall, and res.json() would otherwise hang past the
+                // deadline. Clear the timer only once the body is fully consumed.
+                const data = await res.json();
+                clearTimeout(timeout);
+                return data;
+            }
         } catch (e) {
+            // fetch-level failure, abort (timeout), or a stalled/aborted body read
+            clearTimeout(timeout);
             lastError = e;
             if (attempt === MAX_ATTEMPTS) break;
             const delay = retryDelayMs(attempt);
             log('inat fetch error, retrying', { label, attempt, delayMs: delay, error: String(e) });
             await sleep(delay);
             continue;
-        } finally {
-            clearTimeout(timeout);
         }
 
-        if (res.ok) return await res.json();
-
+        // Non-2xx: res is defined and not ok.
+        clearTimeout(timeout);
         lastError = new Error(`iNaturalist ${label} HTTP ${res.status}`);
-        if (!isRetryableStatus(res.status) || attempt === MAX_ATTEMPTS) {
-            await res.body?.cancel();
-            break;
-        }
         await res.body?.cancel();
+        if (!isRetryableStatus(res.status) || attempt === MAX_ATTEMPTS) break;
         const delay = retryDelayMs(attempt, parseRetryAfter(res.headers.get('retry-after')));
         log('inat non-2xx, retrying', { label, attempt, status: res.status, delayMs: delay });
         await sleep(delay);

--- a/supabase/functions/ingest/index.ts
+++ b/supabase/functions/ingest/index.ts
@@ -13,15 +13,23 @@
  *   - The ingest.runs `started` row is written OUTSIDE the data transaction, so a
  *     crash leaves a visible orphan (outcome NULL).
  *
- * Scope: Maplify only in this slice; source:'inaturalist' is rejected (405) until
- * salishsea-io-89d.2. Wiring pg_cron→pg_net is the cutover (salishsea-io-89d.3).
+ * Scope: Maplify and iNaturalist. Wiring pg_cron→pg_net is the cutover
+ * (salishsea-io-89d.3).
  */
 
-import postgres from 'postgres';
+import postgres, { type Sql } from 'postgres';
 import { z } from 'zod';
 import { parseMaplifyResponse, isIngestable, reconcile } from '../../../scripts/ingest/maplify.ts';
-import { persistMaplify, fetchWindowIds, type IngestWindow } from '../../../scripts/ingest/persist.ts';
+import { reconcile as reconcileInat } from '../../../scripts/ingest/inaturalist.ts';
+import {
+    persistMaplify,
+    persistInaturalist,
+    fetchWindowIds,
+    fetchObservationWindowIds,
+    type IngestWindow,
+} from '../../../scripts/ingest/persist.ts';
 import { fetchMaplify } from './fetch-maplify.ts';
+import { fetchAllObservationPages, resolveTaxonClosure } from './fetch-inaturalist.ts';
 
 const TRIGGER_SECRET = Deno.env.get('INGEST_TRIGGER_SECRET') ?? '';
 // Prefer a dedicated privileged ingest role (INGEST_DB_URL); fall back to the
@@ -59,6 +67,56 @@ function defaultWindow(): IngestWindow {
     return { start: startDate.toISOString().slice(0, 10), end };
 }
 
+/** Common per-run outcome recorded to ingest.runs and returned to the caller. */
+type IngestOutcome = {
+    readonly upserted: number;
+    readonly deleted: number;
+    readonly pagesFetched: number;
+    readonly totalResults: number;
+};
+
+/** Maplify: single-page fetch → parse → reconcile → persist (one atomic txn). */
+async function ingestMaplify(sql: Sql, window: IngestWindow, dryRun: boolean): Promise<IngestOutcome> {
+    const raw = await fetchMaplify(window, log);
+    const result = parseMaplifyResponse(raw);
+    if (!result.ok) throw new Error(`maplify parse failed: ${result.error}`);
+
+    const ingestable = result.sightings.filter(isIngestable);
+    const existing = await fetchWindowIds(sql, window);
+    const plan = reconcile(ingestable, existing);
+    const { upserted, deleted } = await persistMaplify(sql, plan, window, { dryRun });
+    return { upserted, deleted, pagesFetched: 1, totalResults: result.sightings.length };
+}
+
+/**
+ * iNaturalist: paginate to completeness → resolve the full taxon closure (all
+ * BEFORE the persist txn) → reconcile → persist observations + photos + taxa in
+ * one atomic txn. Any partial page or unresolved taxon threw before this returns.
+ */
+async function ingestInaturalist(
+    sql: Sql,
+    window: IngestWindow,
+    dryRun: boolean,
+    logger: typeof log,
+): Promise<IngestOutcome> {
+    const { pages, observations, totalResults } = await fetchAllObservationPages(window, logger);
+    const taxa = await resolveTaxonClosure(sql, observations, logger);
+
+    const existing = await fetchObservationWindowIds(sql, window);
+    const plan = reconcileInat(observations, existing);
+    const result = await persistInaturalist(sql, { taxa, plan, window }, { dryRun });
+
+    // rows_upserted / rows_deleted track the observations (the window's unit of
+    // reconcile); taxa and photo counts ride along in the structured log.
+    logger('inat persist detail', { ...result });
+    return {
+        upserted: result.observationsUpserted,
+        deleted: result.observationsDeleted,
+        pagesFetched: pages.length,
+        totalResults,
+    };
+}
+
 Deno.serve(async (req) => {
     const provided = req.headers.get('x-ingest-secret') ?? '';
     if (!secretsMatch(provided, TRIGGER_SECRET)) {
@@ -71,9 +129,6 @@ Deno.serve(async (req) => {
     if (!parsed.success) return jsonResponse({ error: z.prettifyError(parsed.error) }, 400);
 
     const { source, start, end, dry_run: dryRun = false, trigger = 'manual' } = parsed.data;
-    if (source !== 'maplify') {
-        return jsonResponse({ error: `source '${source}' not yet implemented (salishsea-io-89d.2)` }, 405);
-    }
     // A custom window needs BOTH bounds; a single bound is almost certainly a
     // mistake, and silently falling back to the default range would ignore the
     // curator's intent. Reject partial windows and inverted ranges.
@@ -95,24 +150,22 @@ Deno.serve(async (req) => {
             RETURNING id`;
         runId = started[0]!.id;
 
-        const raw = await fetchMaplify(window, log);
-        const result = parseMaplifyResponse(raw);
-        if (!result.ok) throw new Error(`maplify parse failed: ${result.error}`);
-
-        const ingestable = result.sightings.filter(isIngestable);
-        const existing = await fetchWindowIds(sql, window);
-        const plan = reconcile(ingestable, existing);
-        const { upserted, deleted } = await persistMaplify(sql, plan, window, { dryRun });
+        // Each branch performs a PROVABLY COMPLETE fetch (any partial/failed
+        // fetch throws before persist) and returns a common outcome shape.
+        const outcome = source === 'maplify'
+            ? await ingestMaplify(sql, window, dryRun)
+            : await ingestInaturalist(sql, window, dryRun, log);
 
         await sql`
             UPDATE ingest.runs SET
-                finished_at = now(), outcome = 'success', pages_fetched = 1,
-                total_results = ${result.sightings.length},
-                rows_upserted = ${upserted}, rows_deleted = ${deleted}
+                finished_at = now(), outcome = 'success',
+                pages_fetched = ${outcome.pagesFetched},
+                total_results = ${outcome.totalResults},
+                rows_upserted = ${outcome.upserted}, rows_deleted = ${outcome.deleted}
             WHERE id = ${runId}`;
 
-        log('ingest ok', { source, window, dryRun, upserted, deleted });
-        return jsonResponse({ ok: true, runId, source, window, dryRun, upserted, deleted }, 200);
+        log('ingest ok', { source, window, dryRun, ...outcome });
+        return jsonResponse({ ok: true, runId, source, window, dryRun, ...outcome }, 200);
     } catch (e) {
         const message = e instanceof Error ? e.message : String(e);
         log('ingest failed', { source, window, error: message });


### PR DESCRIPTION
Implements the Deno Edge Function **shell** for iNaturalist ingest — the second and final slice of `salishsea-io-89d.2`, completing the imperative shell over the already-merged functional core + persist layer ([decision 011](docs/decisions/011-ingest-imperative-shell.md)).

## What this adds

**`supabase/functions/ingest/fetch-inaturalist.ts`** (new) — the two effectful orchestration loops:

- **Pagination loop** (`fetchAllObservationPages`) — fetches page 1..N of `/v2/observations` through `total_results`, accumulating `FetchedPage` metadata + normalized observations, then asserts `isPaginationComplete` before returning. An empty first page (`total_results=0`) is complete and authoritative; a window exceeding iNat's 10 000-record pagination cap aborts honestly. Every `fetch` uses an `AbortController` timeout.
- **Taxon-closure loop** (`resolveTaxonClosure`) — diffs referenced taxon ids against `inaturalist.taxa`, fetches the missing ids (chunked ≤30), expands their references, and recomputes still-missing until the full ancestor closure resolves — all **before** the persist transaction (no HTTP inside a DB write). A taxa-API failure, or a requested id the API won't return, aborts (writes nothing).

**`index.ts`** — branches on `source` after auth + window validation; Maplify and iNaturalist both produce a shared `{upserted, deleted, pagesFetched, totalResults}` outcome and share the `ingest.runs` success/failure update. `pages_fetched` is generalized (was hardcoded to 1). All existing invariants preserved: constant-time secret auth, partial/inverted-window 400s, `started` row outside the data txn, failed-fetch-throws-before-persist.

**`persist.ts`** — `toPhotoPayload` now dedupes photos by id (last-wins). See below.

## Real-API surprise caught by the live run

iNaturalist attaches the **same photo id to more than one observation** (~5 collisions in an 8 200-observation live window). `observation_photos.id` is the PK, so the consolidated bulk `INSERT ... ON CONFLICT (id) DO UPDATE` raised `ON CONFLICT DO UPDATE command cannot affect row a second time`. The legacy SQL path never hit this because it upserted page-by-page. Fixed by deduping in the payload builder; added an integration test.

## Live validation (real iNaturalist API + local Supabase)

- Bad secret → 401; inverted/partial window → 400.
- Dry-run over all of 2026: **42 pages, total_results 8269**, would-be 7812 upserts, 0 writes.
- Real run (2026-06-25..07-05): 3 pages, 432 results, 35 upserted, recorded in `ingest.runs`.
- **Taxon-closure loop exercised live**: deleted taxon 41537 (*Lissodelphis borealis*) + its observation, re-ran; the loop logged `referenced:62, present:61, fetched:1` and re-fetched the taxon from the real `/taxa` API. DB self-healed (observation + 4 photos + taxon restored).
- Failed-fetch abort recorded as a `failed` `ingest.runs` row with the error and no writes.

## Gates

`deno check` clean · `npx tsc --noEmit` clean · 283 vitest tests green (+1 new).

Refs `salishsea-io-89d.2`, decision 011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ingesting iNaturalist data alongside the existing source.
  * Improved ingest handling for larger iNaturalist result sets, including full pagination and taxon lookup coverage.
  * Added support for custom date windows with validation for required start/end values.

* **Bug Fixes**
  * Prevented failures when multiple records share the same photo ID by deduplicating photo updates.
  * Improved ingest reliability so duplicate photo references are handled safely and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->