### PR TITLE
Cutover: pg_cron → Edge Function via pg_net (89d.3)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,13 @@ jobs:
       - run: supabase link --project-ref "${PROJECT_REF}"
         env:
           PROJECT_REF: ${{ vars.SUPABASE_PROJECT_ID }}
+      # Deploy the ingest Edge Function BEFORE `db push`. The cutover migration
+      # (20260706000000) repoints pg_cron at this function via pg_net; deploying
+      # first means a bundling/deploy failure aborts the run before the cron
+      # switch lands, leaving the old SQL ingest in place (fail-safe ordering).
+      - run: supabase functions deploy ingest --project-ref "${PROJECT_REF}"
+        env:
+          PROJECT_REF: ${{ vars.SUPABASE_PROJECT_ID }}
       - run: supabase db push
       - name: Deploy to S3 and invalidate CloudFront
         env:

--- a/supabase/migrations/20260706000000_cutover_ingest_to_edge_function.sql
+++ b/supabase/migrations/20260706000000_cutover_ingest_to_edge_function.sql
@@ -1,0 +1,57 @@
+-- Cutover: drive ingest from the TypeScript Edge Function instead of in-DB SQL
+-- (epic salishsea-io-89d / decision 011, issue salishsea-io-89d.3).
+--
+-- Atomic switch: unschedule the two pg_cron SQL ingest jobs and, in their place,
+-- schedule pg_net calls to the `ingest` Edge Function every 5 minutes. Downtime
+-- is acceptable — each run re-fetches a rolling 10-day window via idempotent
+-- upsert, so any gap self-heals on the first new run.
+--
+-- SECRETS (set out-of-band in Vault, prod only):
+--   - ingest_function_url    → https://<project-ref>.supabase.co/functions/v1/ingest
+--   - ingest_trigger_secret  → the shared secret the function checks (also set as
+--                              an Edge Function secret so the function can compare)
+-- The scheduled command reads both from Vault. On a local `db reset` those
+-- secrets do not exist, so the `WHERE EXISTS (...)` guard makes net.http_post a
+-- no-op — local/dev NEVER calls the deployed function. (Local ingest, if needed,
+-- is a manual `supabase functions serve` + curl.)
+--
+-- The SQL ingest FUNCTIONS themselves are intentionally NOT dropped here
+-- (supabase/seed.sql still calls maplify.update_sightings directly). They are
+-- retired in a later migration after a prod bake-in confirms the Edge path is
+-- healthy via ingest.runs.
+
+-- 1. Retire the old SQL ingest cron jobs (no-op if already gone).
+SELECT cron.unschedule(jobid)
+FROM cron.job
+WHERE jobname IN ('load-recent-maplify-sightings', 'load-recent-inaturalist-observations');
+
+-- 2. Schedule the Edge Function via pg_net, one job per source, every 5 minutes.
+--    net.http_post is async (enqueues + returns immediately); the function does
+--    the work and records its own ingest.runs row, so we do not consume the
+--    response. The generous timeout only affects how pg_net logs the eventual
+--    response, not whether the ingest completes.
+SELECT cron.schedule('ingest-maplify', '*/5 * * * *', $job$
+  SELECT net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'ingest_function_url'),
+    headers := jsonb_build_object(
+      'content-type', 'application/json',
+      'x-ingest-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'ingest_trigger_secret')
+    ),
+    body := jsonb_build_object('source', 'maplify', 'trigger', 'cron'),
+    timeout_milliseconds := 60000
+  )
+  WHERE EXISTS (SELECT 1 FROM vault.decrypted_secrets WHERE name = 'ingest_function_url');
+$job$);
+
+SELECT cron.schedule('ingest-inaturalist', '*/5 * * * *', $job$
+  SELECT net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'ingest_function_url'),
+    headers := jsonb_build_object(
+      'content-type', 'application/json',
+      'x-ingest-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'ingest_trigger_secret')
+    ),
+    body := jsonb_build_object('source', 'inaturalist', 'trigger', 'cron'),
+    timeout_milliseconds := 60000
+  )
+  WHERE EXISTS (SELECT 1 FROM vault.decrypted_secrets WHERE name = 'ingest_function_url');
+$job$);


### PR DESCRIPTION
The capstone of epic `salishsea-io-89d` ([decision 011](docs/decisions/011-ingest-imperative-shell.md)): retire the in-DB SQL ingest cron and drive ingest from the deployed TypeScript Edge Function. **Do not merge until the secrets below are set** (a push to `main` deploys and applies this immediately).

## What this PR does
- **`20260706000000_cutover_ingest_to_edge_function.sql`** — `cron.unschedule`s `load-recent-maplify-sightings` and `load-recent-inaturalist-observations`; `cron.schedule`s `ingest-maplify` and `ingest-inaturalist` (every 5 min) that `net.http_post` to the `ingest` function. The URL + trigger secret are read from **Vault**, guarded by `WHERE EXISTS`, so a local `db reset` (no Vault secrets) is a **no-op** — dev never calls prod.
- **`deploy.yml`** — adds `supabase functions deploy ingest` **before** `db push`. Fail-safe ordering: if the function fails to bundle/deploy, the run aborts before the cron switch lands and the old SQL ingest stays active.

## Fail-safe / rollback posture
- Downtime is acceptable — every run re-fetches a 10-day window via idempotent upsert, so any gap self-heals on the first new run.
- The SQL ingest **functions are NOT dropped** here (`seed.sql` still calls `update_sightings`); they're retired in a later migration after a prod bake-in confirms the Edge path is healthy via `ingest.runs`.
- Rollback = revert this migration (re-schedules the SQL jobs, unschedules the pg_net jobs).

## ⚠️ REQUIRED before merging — set the secrets
Generate one secret and register it in three places (project ref `grztmjpzamcxlzecmqca`):

```bash
SECRET=$(openssl rand -hex 32)

# 1. Edge Function secret (so the function can check the header)
supabase secrets set INGEST_TRIGGER_SECRET="$SECRET" --project-ref grztmjpzamcxlzecmqca
```
```sql
-- 2 & 3. Vault secrets (so pg_cron can read URL + secret) — run in prod SQL:
select vault.create_secret('<paste same SECRET>', 'ingest_trigger_secret');
select vault.create_secret('https://grztmjpzamcxlzecmqca.supabase.co/functions/v1/ingest', 'ingest_function_url');
```

## Recommended go-live sequence
1. Set the three secrets above.
2. **Before merging**, manually smoke-test in prod to de-risk Edge-Function bundling of the cross-tree `../../../scripts/ingest` imports:
   `supabase functions deploy ingest --project-ref grztmjpzamcxlzecmqca`, then
   `curl -sS -X POST https://grztmjpzamcxlzecmqca.supabase.co/functions/v1/ingest -H "x-ingest-secret: $SECRET" -H 'content-type: application/json' -d '{"source":"maplify","dry_run":true}'` → expect `{"ok":true,...}`.
3. Merge. The deploy re-deploys the function then applies the cron switch. Watch `ingest.runs` for cron-driven `success` rows within ~5 min.

## Known risk
This is the first prod deploy of the Edge Function, so it's the first real test of whether `supabase functions deploy` bundles the imports from `scripts/ingest/` (outside the function folder). Local `serve` uses the same runtime and works; the manual smoke-deploy in step 2 confirms it before the cron switch commits. If bundling fails, the fix is relocating the shared core under `supabase/functions/_shared/`.

## Deferred (follow-ups)
- Retire the SQL ingest functions (later migration, post-bake).
- Dedicated least-privilege ingest DB role (`89d.1` follow-up; go-live uses the default connection).
- Sentry Deno wiring; `salishsea-io-1wz` (fetch-maplify timeout tidy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)