### PR TITLE
Enable pg_net (cutover cron prerequisite)

### DIFF
--- a/supabase/migrations/20260706120000_enable_pg_net.sql
+++ b/supabase/migrations/20260706120000_enable_pg_net.sql
@@ -1,0 +1,14 @@
+-- Enable pg_net (async HTTP from Postgres), required by the ingest cutover
+-- (20260706000000): the pg_cron jobs call net.http_post to invoke the ingest
+-- Edge Function.
+--
+-- The local Supabase CLI stack ships pg_net pre-enabled, so the cutover migration
+-- validated locally — but the production project did NOT have it, and the cron
+-- jobs failed at runtime with `schema "net" does not exist`. This migration makes
+-- pg_net an explicit, tracked prerequisite rather than an assumed-present
+-- extension. It is idempotent (no-op where pg_net already exists) and was applied
+-- out-of-band to prod to restore ingest; this codifies that state.
+--
+-- pg_net installs its functions into the `net` schema, which the cutover cron
+-- commands reference (net.http_post).
+CREATE EXTENSION IF NOT EXISTS pg_net;


### PR DESCRIPTION
Follow-up to the ingest cutover (#308). The cutover cron calls `net.http_post`, but **`pg_net` was never installed in the production project** — the local Supabase CLI stack ships it pre-enabled, so the cutover migration validated locally while prod's cron failed every 5 min with `schema "net" does not exist`.

I enabled `pg_net` out-of-band to restore ingest immediately (confirmed: both sources now producing cron-driven `success` rows in `ingest.runs`, all `pg_net` HTTP calls returning 200). This migration **codifies** it as a tracked prerequisite so a fresh prod rebuild / CI `db reset` gets it too. `CREATE EXTENSION IF NOT EXISTS` — no-op where already present.

Root cause is a local/prod parity gap the manual dry-run couldn't catch (the dry-run tested the function, not the pg_cron→pg_net path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a database migration to enable support for network-based Postgres operations needed for upcoming ingestion processing.
  * Ensures the required extension is created safely and only when missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->