### PR TITLE
feat(ingest): heartbeat/freshness alert via scheduled GitHub Action (89d.4)

### DIFF
--- a/.github/workflows/ingest-heartbeat.yml
+++ b/.github/workflows/ingest-heartbeat.yml
@@ -1,0 +1,101 @@
+name: Ingest Heartbeat
+
+# External observer for the 5-minute pg_cron → Edge Function ingest
+# (salishsea-io-89d.4 / decision 012). pg_cron can't watch itself die — the
+# 2026-07-06 pg_net gap failed prod ingest silently — so this runs OUTSIDE the
+# database: a scheduled check of ingest.runs that files a GitHub issue when no
+# successful run is fresh enough, or a run is stuck mid-flight. GitHub's cron
+# is best-effort (often 10-30 min late); that lateness only delays detection,
+# never falsifies it, because staleness is measured against the DB clock.
+
+on:
+    schedule:
+        - cron: '*/30 * * * *'
+    workflow_dispatch:
+
+concurrency:
+    group: ingest-heartbeat
+    cancel-in-progress: false
+
+jobs:
+    check:
+        runs-on: ubuntu-latest
+        environment: production
+        permissions:
+            contents: read
+            issues: write  # failure issue, dwca-nightly pattern
+        env:
+            FRESHNESS_MINUTES: '30'  # ingest cron fires every 5 min → 6 misses
+            STUCK_MINUTES: '15'      # Edge Function wall clock is minutes at most
+
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  persist-credentials: false
+
+            - name: Setup Node
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+              with:
+                  node-version-file: package.json
+                  cache: npm
+
+            - name: Install dependencies
+              run: npm ci
+
+            # Pre-seed the failure-issue body so content-filepath always exists even
+            # when the job dies before heartbeat.ts runs (DSN/secret issue, npm error,
+            # DB unreachable). heartbeat.ts overwrites it with real findings on trip.
+            # Same pattern and rationale as dwca-nightly.yml.
+            - name: Seed default failure-issue body
+              run: |
+                  mkdir -p dist/ingest
+                  cat > dist/ingest/heartbeat-report.txt <<EOF
+                  Heartbeat workflow failed before scripts/ingest/heartbeat.ts could evaluate.
+
+                  Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                  Triggered: ${{ github.event_name }} on ${{ github.sha }} at $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+                  Check the failing step's logs. Common causes: DSN/secret issue, npm
+                  dependency error, or the database being unreachable — the last of which
+                  is itself an ingest outage, so treat this issue as a real alert.
+                  EOF
+
+            # Same DSN assembly as dwca-nightly.yml (see the rationale there): URL-encode
+            # the password, mask it, connect via the IPv4 session pooler on port 5432.
+            - name: Prepare Postgres DSN
+              env:
+                  DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+                  SUPABASE_PROJECT_ID: ${{ vars.SUPABASE_PROJECT_ID }}
+              run: |
+                  ENCODED_PW=$(node -e 'process.stdout.write(encodeURIComponent(process.env.DB_PASSWORD))')
+                  echo "::add-mask::${ENCODED_PW}"
+                  printf 'SUPABASE_DB_URL=postgres://postgres.%s:%s@aws-1-us-west-1.pooler.supabase.com:5432/postgres\n' \
+                    "${SUPABASE_PROJECT_ID}" "${ENCODED_PW}" >> "${GITHUB_ENV}"
+
+            - name: Check ingest heartbeat
+              run: npx tsx scripts/ingest/heartbeat.ts
+
+            - name: Find existing failure issue
+              id: find-issue
+              if: failure()
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+              with:
+                  script: |
+                      const issues = await github.rest.issues.listForRepo({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        state: 'open',
+                        labels: 'ingest-heartbeat-failed',
+                        per_page: 1,
+                      });
+                      core.setOutput('issue-number', issues.data[0]?.number ?? '');
+
+            - name: Open or update failure issue
+              if: failure()
+              uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
+              with:
+                  title: "Ingest heartbeat failed (run ${{ github.run_id }})"
+                  content-filepath: ./dist/ingest/heartbeat-report.txt
+                  labels: ingest-heartbeat-failed
+                  issue-number: ${{ steps.find-issue.outputs.issue-number }}

--- a/docs/decisions/012-ingest-heartbeat.md
+++ b/docs/decisions/012-ingest-heartbeat.md
@@ -1,0 +1,66 @@
+# 012 — Ingest heartbeat: an external observer via scheduled GitHub Action
+
+**Status:** accepted · **Decided:** 2026-07-06
+
+## Context
+
+Decision [011](011-ingest-imperative-shell.md) anticipated a heartbeat/freshness alert as a
+cheap follow-on once `ingest.runs` existed, closing the silent-stop gap Sentry alone can't
+catch: a cron that stops firing throws no exception. The 2026-07-06 cutover proved the gap
+immediately — prod `pg_cron` failed for ~10 minutes on a missing `pg_net` extension, silently,
+and was caught only by active polling.
+
+Two failure modes need coverage, both readable from `ingest.runs` (decision 011's write
+protocol):
+
+- **Stale**: the newest successful non-dry-run run per source is older than a threshold —
+  the cron stopped firing, or every run is failing.
+- **Stuck**: a run has `started_at` but no `finished_at` past a threshold — the started-orphan
+  pattern; the shell crashed or hung between opening and resolving the audit row.
+
+## Decision
+
+A **scheduled GitHub Action** (`.github/workflows/ingest-heartbeat.yml`, every 30 minutes)
+runs [`scripts/ingest/heartbeat.ts`](../../scripts/ingest/heartbeat.ts) against prod over the
+session pooler and **fails loudly by filing/updating a labeled GitHub issue**
+(`ingest-heartbeat-failed`), the same alert channel as the DwC-A nightly guard.
+
+- The check must live **outside the database**: `pg_cron` cannot observe its own death, and
+  the pg_net incident was precisely a scheduler-side failure. GitHub Actions is the external
+  scheduler this repo already operates.
+- GitHub cron's best-effort lateness (10–30 min) — the reason it was rejected as the *ingest*
+  host in 011 — is acceptable for the *observer*: staleness is measured against the DB
+  server's clock, so a late check delays detection but never falsifies it.
+- Structure follows 011: a pure, unit-tested predicate (`evaluateHeartbeat`) over fetched
+  rows; a thin shell that connects, fetches, and reports. Integration tests run the real
+  reads against local Supabase inside a rolled-back transaction.
+- Thresholds: freshness 30 min (six consecutive missed 5-minute runs), stuck 15 min (an Edge
+  Function's wall clock is minutes at most). Dry-run successes don't count toward freshness —
+  they write nothing. Both env-overridable in the workflow.
+- A DB-unreachable check run also files the issue (fail-loud default body) — unreachability
+  is itself an ingest outage.
+
+## Rejected alternatives
+
+- **pg_cron self-check** (a SQL job raising on staleness). Cannot catch the scheduler dying,
+  which is the primary threat; also has no notification channel of its own.
+- **Sentry cron monitors / check-ins.** A capable fit, but a new external dependency and
+  configuration surface; the repo already alerts via labeled GitHub issues for the DwC-A
+  nightly, and one channel beats two. Revisit if/when Sentry gains the server-side ingest
+  surface planned in 011.
+- **Alerting from inside the ingest Edge Function.** The function can report its own failures
+  (Sentry will cover that), but by definition never runs when the cron is dead.
+
+## Consequences
+
+- Detection latency is bounded by check cadence + GitHub cron lateness: roughly 30–60 minutes
+  after the freshness window is exceeded, which fits the self-healing 10-day window design.
+- The heartbeat reuses the production environment's existing `DB_PASSWORD` /
+  `SUPABASE_PROJECT_ID`; no new secrets.
+- An open `ingest-heartbeat-failed` issue is updated, not duplicated, on repeated failures.
+
+## Reference
+
+Issue: `salishsea-io-89d.4`. Substrate: `ingest.runs`
+([20260705130000_ingest_runs.sql](../../supabase/migrations/20260705130000_ingest_runs.sql)).
+Alert-channel precedent: [003](003-dwc-export-pipeline.md) (DwC-A nightly failure issue).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -15,3 +15,4 @@ Product and technical decisions with rationale and rejected alternatives. Add a 
 | [009](009-taxonomic-scope-marine-mammals.md) | Taxonomic scope: PSEMP Marine Mammal Working Group (supersedes 001 scope) | accepted |
 | [010](010-fresh-codebase-vs-acartia.md) | SalishSea.io is a fresh codebase, not an extension of acartia.io | accepted |
 | [011](011-ingest-imperative-shell.md) | Network ingest as a TypeScript imperative shell over a functional core | accepted |
+| [012](012-ingest-heartbeat.md) | Ingest heartbeat: external observer via scheduled GitHub Action | accepted |

--- a/scripts/ingest/heartbeat.test.ts
+++ b/scripts/ingest/heartbeat.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Heartbeat check (salishsea-io-89d.4): unit tier for the pure predicate,
+ * integration tier for the ingest.runs reads (decision 011's two tiers).
+ *
+ * The integration suite runs against local Supabase, gated on SUPABASE_DB_URL
+ * (set by build.yml in CI; skips on a fresh checkout). It empties and reseeds
+ * ingest.runs INSIDE a transaction that is always rolled back, so results are
+ * deterministic regardless of prior local runs and the DB is left untouched.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import postgres from 'postgres';
+import type { Sql, TransactionSql } from 'postgres';
+import {
+    evaluateHeartbeat,
+    fetchHeartbeatInput,
+    type HeartbeatInput,
+    type Thresholds,
+} from './heartbeat.ts';
+
+const THRESHOLDS: Thresholds = { freshnessMinutes: 30, stuckMinutes: 15 };
+const NOW = new Date('2026-07-06T12:00:00Z');
+const minutesAgo = (m: number) => new Date(NOW.getTime() - m * 60_000);
+
+const healthy: HeartbeatInput = {
+    now: NOW,
+    lastSuccesses: [
+        { source: 'maplify', finishedAt: minutesAgo(4) },
+        { source: 'inaturalist', finishedAt: minutesAgo(6) },
+    ],
+    orphans: [],
+};
+
+describe('evaluateHeartbeat', () => {
+    test('fresh successes for every source, no orphans → healthy', () => {
+        expect(evaluateHeartbeat(healthy, THRESHOLDS)).toEqual([]);
+    });
+
+    test('one stale source trips only that source', () => {
+        const findings = evaluateHeartbeat(
+            {
+                ...healthy,
+                lastSuccesses: [
+                    { source: 'maplify', finishedAt: minutesAgo(47) },
+                    { source: 'inaturalist', finishedAt: minutesAgo(6) },
+                ],
+            },
+            THRESHOLDS,
+        );
+        expect(findings).toHaveLength(1);
+        expect(findings[0]).toMatchObject({ kind: 'stale', source: 'maplify' });
+        expect(findings[0]!.message).toContain('47m ago');
+    });
+
+    test('a source with no success at all → never_succeeded', () => {
+        const findings = evaluateHeartbeat(
+            {
+                ...healthy,
+                lastSuccesses: [{ source: 'maplify', finishedAt: minutesAgo(4) }],
+            },
+            THRESHOLDS,
+        );
+        expect(findings).toEqual([
+            expect.objectContaining({ kind: 'never_succeeded', source: 'inaturalist' }),
+        ]);
+    });
+
+    test('age exactly at the freshness threshold does not trip', () => {
+        const findings = evaluateHeartbeat(
+            {
+                ...healthy,
+                lastSuccesses: [
+                    { source: 'maplify', finishedAt: minutesAgo(30) },
+                    { source: 'inaturalist', finishedAt: minutesAgo(6) },
+                ],
+            },
+            THRESHOLDS,
+        );
+        expect(findings).toEqual([]);
+    });
+
+    test('an orphan older than stuckMinutes → stuck', () => {
+        const findings = evaluateHeartbeat(
+            {
+                ...healthy,
+                orphans: [
+                    {
+                        id: 42,
+                        source: 'maplify',
+                        trigger: 'cron',
+                        dryRun: false,
+                        startedAt: minutesAgo(22),
+                    },
+                ],
+            },
+            THRESHOLDS,
+        );
+        expect(findings).toHaveLength(1);
+        expect(findings[0]).toMatchObject({ kind: 'stuck', source: 'maplify' });
+        expect(findings[0]!.message).toContain('run #42');
+    });
+
+    test('a young orphan is a run in flight, not a finding', () => {
+        const findings = evaluateHeartbeat(
+            {
+                ...healthy,
+                orphans: [
+                    {
+                        id: 43,
+                        source: 'inaturalist',
+                        trigger: 'cron',
+                        dryRun: false,
+                        startedAt: minutesAgo(3),
+                    },
+                ],
+            },
+            THRESHOLDS,
+        );
+        expect(findings).toEqual([]);
+    });
+
+    test('stale and stuck findings accumulate', () => {
+        const findings = evaluateHeartbeat(
+            {
+                now: NOW,
+                lastSuccesses: [{ source: 'inaturalist', finishedAt: minutesAgo(90) }],
+                orphans: [
+                    {
+                        id: 7,
+                        source: 'maplify',
+                        trigger: 'manual',
+                        dryRun: true,
+                        startedAt: minutesAgo(60),
+                    },
+                ],
+            },
+            THRESHOLDS,
+        );
+        expect(findings.map((f) => f.kind).sort()).toEqual([
+            'never_succeeded',
+            'stale',
+            'stuck',
+        ]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: the reads against local Supabase
+// ---------------------------------------------------------------------------
+
+const DSN = process.env['SUPABASE_DB_URL'];
+
+/** Run fn in a transaction that is ALWAYS rolled back. */
+class Rollback extends Error {}
+async function withRollback(sql: Sql, fn: (tx: TransactionSql) => Promise<void>): Promise<void> {
+    await sql
+        .begin(async (tx) => {
+            await fn(tx);
+            throw new Rollback();
+        })
+        .catch((err: unknown) => {
+            if (!(err instanceof Rollback)) throw err;
+        });
+}
+
+describe.skipIf(!DSN)('fetchHeartbeatInput (local Supabase)', () => {
+    let sql: Sql;
+
+    beforeAll(() => {
+        sql = postgres(DSN as string, { prepare: false, max: 1 });
+    });
+
+    afterAll(async () => {
+        await sql.end();
+    });
+
+    test('excludes dry-run and failed runs from last success; surfaces orphans', async () => {
+        await withRollback(sql, async (tx) => {
+            await tx`DELETE FROM ingest.runs`;
+            await tx`
+                INSERT INTO ingest.runs
+                    (source, trigger, dry_run, window_start, window_end,
+                     started_at, finished_at, outcome, error)
+                VALUES
+                    -- the real last success for maplify
+                    ('maplify', 'cron', false, '2026-06-26', '2026-07-06',
+                     now() - interval '20 minutes', now() - interval '19 minutes', 'success', NULL),
+                    -- newer, but dry-run: must NOT count as freshness
+                    ('maplify', 'manual', true, '2026-06-26', '2026-07-06',
+                     now() - interval '5 minutes', now() - interval '4 minutes', 'success', NULL),
+                    -- newer, but failed: must NOT count either
+                    ('maplify', 'cron', false, '2026-06-26', '2026-07-06',
+                     now() - interval '3 minutes', now() - interval '2 minutes', 'failed', 'boom'),
+                    -- inaturalist success
+                    ('inaturalist', 'cron', false, '2026-06-26', '2026-07-06',
+                     now() - interval '6 minutes', now() - interval '5 minutes', 'success', NULL),
+                    -- an orphan: started, never finished
+                    ('inaturalist', 'cron', false, '2026-06-26', '2026-07-06',
+                     now() - interval '45 minutes', NULL, NULL, NULL)`;
+
+            const input = await fetchHeartbeatInput(tx);
+
+            expect(input.now).toBeInstanceOf(Date);
+
+            const bySource = new Map(input.lastSuccesses.map((s) => [s.source, s.finishedAt]));
+            const maplifyAge = input.now.getTime() - bySource.get('maplify')!.getTime();
+            // ~19 minutes, i.e. the non-dry-run success — not the 4m dry run or 2m failure
+            expect(maplifyAge).toBeGreaterThan(18 * 60_000);
+            expect(bySource.get('inaturalist')).toBeInstanceOf(Date);
+
+            expect(input.orphans).toHaveLength(1);
+            expect(input.orphans[0]).toMatchObject({
+                source: 'inaturalist',
+                trigger: 'cron',
+                dryRun: false,
+            });
+            expect(typeof input.orphans[0]!.id).toBe('number');
+        });
+    });
+
+    test('a source with no rows simply has no lastSuccess entry', async () => {
+        await withRollback(sql, async (tx) => {
+            await tx`DELETE FROM ingest.runs`;
+            await tx`
+                INSERT INTO ingest.runs
+                    (source, trigger, dry_run, window_start, window_end,
+                     started_at, finished_at, outcome)
+                VALUES ('maplify', 'cron', false, '2026-06-26', '2026-07-06',
+                        now() - interval '2 minutes', now() - interval '1 minutes', 'success')`;
+
+            const input = await fetchHeartbeatInput(tx);
+            expect(input.lastSuccesses.map((s) => s.source)).toEqual(['maplify']);
+            expect(
+                evaluateHeartbeat(input, THRESHOLDS).map((f) => [f.kind, f.source]),
+            ).toEqual([['never_succeeded', 'inaturalist']]);
+        });
+    });
+});

--- a/scripts/ingest/heartbeat.ts
+++ b/scripts/ingest/heartbeat.ts
@@ -1,0 +1,247 @@
+/**
+ * Ingest heartbeat/freshness check (salishsea-io-89d.4 / decisions 011, 012).
+ *
+ * Queries ingest.runs and exits non-zero when either silent-failure mode is live:
+ *   - STALE:  the newest successful non-dry-run run for a source is older than
+ *             FRESHNESS_MINUTES (or the source has no successful run at all).
+ *             Catches a cron that stopped firing — the gap Sentry can't see,
+ *             because a job that never runs throws no exception.
+ *   - STUCK:  a run has started_at but no finished_at for longer than
+ *             STUCK_MINUTES (decision 011's started-orphan pattern: the audit
+ *             row is written outside the data txn, so a crashed/hung run leaves
+ *             a visible orphan).
+ *
+ * Invoked by .github/workflows/ingest-heartbeat.yml on a schedule, against prod
+ * via SUPABASE_DB_URL (session pooler). Staleness is measured against the DB
+ * server's clock (SELECT now()), not the runner's, so clock skew can't lie.
+ *
+ * On trip: writes a human-readable report to dist/ingest/heartbeat-report.txt
+ * (the workflow files it as a GitHub issue) and exits 1.
+ *
+ * Security: NEVER log the DSN — errors are scrubbed via maskDsn() (T-7-01,
+ * same rule as scripts/dwca/guard.ts).
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import postgres from 'postgres';
+import type { Sql, TransactionSql } from 'postgres';
+
+// ---------------------------------------------------------------------------
+// Constants (env-overridable; the workflow sets both explicitly)
+// ---------------------------------------------------------------------------
+
+const REPORT_PATH = 'dist/ingest/heartbeat-report.txt';
+
+/** Sources the ingest pipeline must keep fresh — mirrors the ingest.runs CHECK. */
+export const SOURCES = ['maplify', 'inaturalist'] as const;
+
+/** Cron fires every 5 min; 30 min of no success = 6 consecutive missed/failed runs. */
+const FRESHNESS_MINUTES = Number(process.env['FRESHNESS_MINUTES'] ?? 30);
+
+/** Edge Function wall clock tops out well under 15 min; older unfinished = dead. */
+const STUCK_MINUTES = Number(process.env['STUCK_MINUTES'] ?? 15);
+
+// ---------------------------------------------------------------------------
+// Functional core — pure evaluation over already-fetched rows
+// ---------------------------------------------------------------------------
+
+export type Thresholds = {
+    readonly freshnessMinutes: number;
+    readonly stuckMinutes: number;
+};
+
+export type LastSuccess = {
+    readonly source: string;
+    readonly finishedAt: Date;
+};
+
+export type OrphanRun = {
+    readonly id: number;
+    readonly source: string;
+    readonly trigger: string;
+    readonly dryRun: boolean;
+    readonly startedAt: Date;
+};
+
+export type HeartbeatInput = {
+    /** DB server clock at query time — the reference for all age math. */
+    readonly now: Date;
+    /** Newest successful non-dry-run finished_at per source (absent = never succeeded). */
+    readonly lastSuccesses: readonly LastSuccess[];
+    /** All runs with no finished_at, oldest first. */
+    readonly orphans: readonly OrphanRun[];
+};
+
+export type Finding = {
+    readonly kind: 'never_succeeded' | 'stale' | 'stuck';
+    readonly source: string;
+    readonly message: string;
+};
+
+const minutesBetween = (from: Date, to: Date): number =>
+    Math.round((to.getTime() - from.getTime()) / 60_000);
+
+/**
+ * The heartbeat predicate. Healthy = empty array. An orphan younger than
+ * stuckMinutes is a run legitimately in flight and produces no finding; ages
+ * exactly at a threshold do not trip (strictly-older-than semantics).
+ */
+export function evaluateHeartbeat(input: HeartbeatInput, thresholds: Thresholds): Finding[] {
+    const findings: Finding[] = [];
+    const bySource = new Map(input.lastSuccesses.map((s) => [s.source, s.finishedAt]));
+
+    for (const source of SOURCES) {
+        const finishedAt = bySource.get(source);
+        if (finishedAt === undefined) {
+            findings.push({
+                kind: 'never_succeeded',
+                source,
+                message: `no successful (non-dry-run) ${source} run recorded at all`,
+            });
+            continue;
+        }
+        const ageMinutes = minutesBetween(finishedAt, input.now);
+        if (ageMinutes > thresholds.freshnessMinutes) {
+            findings.push({
+                kind: 'stale',
+                source,
+                message: `newest successful ${source} run finished ${ageMinutes}m ago (threshold ${thresholds.freshnessMinutes}m)`,
+            });
+        }
+    }
+
+    for (const orphan of input.orphans) {
+        const ageMinutes = minutesBetween(orphan.startedAt, input.now);
+        if (ageMinutes > thresholds.stuckMinutes) {
+            findings.push({
+                kind: 'stuck',
+                source: orphan.source,
+                message:
+                    `run #${orphan.id} (${orphan.source}, trigger=${orphan.trigger}` +
+                    `${orphan.dryRun ? ', dry-run' : ''}) started ${ageMinutes}m ago ` +
+                    `and never finished (threshold ${thresholds.stuckMinutes}m)`,
+            });
+        }
+    }
+
+    return findings;
+}
+
+// ---------------------------------------------------------------------------
+// Shell — fetch, evaluate, report
+// ---------------------------------------------------------------------------
+
+/**
+ * The three reads behind the predicate. dry_run successes are excluded here
+ * (they prove the pipeline runs but write nothing, so they don't make data
+ * fresh); failed runs never count. The last-success query walks
+ * runs_source_finished_idx (partial on outcome = 'success').
+ *
+ * Accepts a plain connection or a transaction (postgres.js types them as
+ * unrelated siblings) so the integration test can call it inside a rollback.
+ */
+export async function fetchHeartbeatInput(sql: Sql | TransactionSql): Promise<HeartbeatInput> {
+    const [nowRow] = await sql<{ db_now: Date }[]>`SELECT now() AS db_now`;
+    const successRows = await sql<{ source: string; finished_at: Date }[]>`
+        SELECT source, max(finished_at) AS finished_at
+        FROM ingest.runs
+        WHERE outcome = 'success' AND NOT dry_run
+        GROUP BY source`;
+    const orphanRows = await sql<
+        { id: number; source: string; trigger: string; dry_run: boolean; started_at: Date }[]
+    >`
+        SELECT id, source, trigger, dry_run, started_at
+        FROM ingest.runs
+        WHERE finished_at IS NULL
+        ORDER BY started_at`;
+
+    return {
+        now: nowRow!.db_now,
+        lastSuccesses: successRows.map((r) => ({ source: r.source, finishedAt: r.finished_at })),
+        orphans: orphanRows.map((r) => ({
+            id: Number(r.id),
+            source: r.source,
+            trigger: r.trigger,
+            dryRun: r.dry_run,
+            startedAt: r.started_at,
+        })),
+    };
+}
+
+/** Mask the password in any DSN-shaped substring (mirrors scripts/dwca/guard.ts). */
+function maskDsn(s: string): string {
+    const masked = s.replace(/\b(postgres(?:ql)?:\/\/[^:\s/@]+:)[^@\s]+(@)/gi, '$1***$2');
+    if (masked !== s) return masked;
+    return s.includes('://') ? '<redacted>' : s;
+}
+
+function reportBody(findings: readonly Finding[], input: HeartbeatInput): string {
+    const lines = findings.map((f) => `- [${f.kind}] ${f.message}`).join('\n');
+    return (
+        `Ingest heartbeat tripped at ${input.now.toISOString()} (DB clock)\n\n` +
+        `${lines}\n\n` +
+        `stale / never_succeeded: the pg_cron → pg_net → Edge Function ingest has stopped\n` +
+        `producing successful runs for that source. stuck: a run crashed or hung mid-flight\n` +
+        `(started row never got its outcome — decision 011's orphan pattern).\n\n` +
+        `Diagnose (npx supabase db query --linked, or psql via the session pooler):\n` +
+        `  SELECT * FROM ingest.runs ORDER BY started_at DESC LIMIT 20;\n` +
+        `  SELECT jobname, status, return_message, start_time FROM cron.job_run_details\n` +
+        `    ORDER BY start_time DESC LIMIT 20;\n` +
+        `  SELECT id, status_code, error_msg, created FROM net._http_response\n` +
+        `    ORDER BY created DESC LIMIT 20;\n\n` +
+        `Also check the ingest Edge Function logs in the Supabase dashboard.\n` +
+        `The window self-heals: once the cause is fixed, the next successful run\n` +
+        `re-fetches the whole 10-day window (decision 011).\n`
+    );
+}
+
+export async function main(): Promise<void> {
+    const dsn = process.env['SUPABASE_DB_URL'];
+    if (!dsn) {
+        console.error('SUPABASE_DB_URL is not set');
+        process.exit(1);
+    }
+
+    const sql = postgres(dsn, { prepare: false, max: 1 });
+    let input: HeartbeatInput;
+    try {
+        input = await fetchHeartbeatInput(sql);
+    } finally {
+        await sql.end();
+    }
+
+    const thresholds: Thresholds = {
+        freshnessMinutes: FRESHNESS_MINUTES,
+        stuckMinutes: STUCK_MINUTES,
+    };
+    const findings = evaluateHeartbeat(input, thresholds);
+
+    if (findings.length === 0) {
+        const ages = SOURCES.map((source) => {
+            const hit = input.lastSuccesses.find((s) => s.source === source);
+            return `${source} last success ${minutesBetween(hit!.finishedAt, input.now)}m ago`;
+        }).join('; ');
+        console.log(
+            `heartbeat ok: ${ages}; ${input.orphans.length} run(s) in flight ` +
+                `(freshness<=${thresholds.freshnessMinutes}m, stuck<=${thresholds.stuckMinutes}m)`,
+        );
+        return;
+    }
+
+    mkdirSync('dist/ingest', { recursive: true });
+    writeFileSync(REPORT_PATH, reportBody(findings, input));
+    for (const f of findings) console.error(`heartbeat tripped: [${f.kind}] ${f.message}`);
+    process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point — only runs when invoked as a script, not when imported.
+// ---------------------------------------------------------------------------
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+    main().catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error('[heartbeat] FAILED:', maskDsn(msg));
+        process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary

External observer for the 5-minute pg_cron → Edge Function ingest, per new [decision 012](docs/decisions/012-ingest-heartbeat.md) (follow-on anticipated by decision 011). Closes the silent-stop gap the 2026-07-06 pg_net incident demonstrated: a cron that stops firing throws no exception, so Sentry alone can't see it.

- **`.github/workflows/ingest-heartbeat.yml`** — every 30 min (+ `workflow_dispatch`), `environment: production`, reuses the existing `DB_PASSWORD`/`SUPABASE_PROJECT_ID` via the dwca-nightly session-pooler DSN pattern. On any failure it files/updates a single `ingest-heartbeat-failed` GitHub issue (same channel as the DwC-A nightly guard).
- **`scripts/ingest/heartbeat.ts`** — pure `evaluateHeartbeat` predicate (decision 011's functional core) over three reads of `ingest.runs`:
  - **stale / never_succeeded**: newest successful non-dry-run run per source older than 30 min (6 consecutive missed 5-min runs);
  - **stuck**: a run with `started_at` but no `finished_at` for >15 min (decision 011's started-orphan pattern).
  Staleness is measured against the DB server clock, so GitHub cron lateness only delays detection, never falsifies it.
- **Tests** — 9 new: unit tier for the predicate (thresholds, boundary ages, in-flight orphans); integration tier runs the real reads against local Supabase inside a rolled-back transaction (dry-run and failed runs excluded from freshness, orphans surfaced).

## Verification

- `npx vitest run scripts/`: 234 passed; `tsc --noEmit` clean.
- Script exercised against local DB (empty `ingest.runs` → trips `never_succeeded`, exit 1).
- Prod checked via `supabase db query --linked`: both sources' last success <1 min old, zero orphans — first scheduled run will pass.

Closes salishsea-io-89d.4 (beads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)