### PR TITLE
feat(ingest): dedicated least-privilege DB role for the Edge Function

### DIFF
--- a/supabase/migrations/20260706130000_ingest_role.sql
+++ b/supabase/migrations/20260706130000_ingest_role.sql
@@ -1,0 +1,58 @@
+-- Dedicated least-privilege login role for the ingest Edge Function
+-- (decision 011 / salishsea-io-wco). The shell currently falls back to the
+-- platform superuser DSN (SUPABASE_DB_URL); this role carries exactly what
+-- fetch → reconcile → persist touches, and nothing else.
+--
+-- NO password here — secrets never ship in migrations, so the role cannot log
+-- in until one is set out-of-band in prod:
+--   ALTER ROLE ingest PASSWORD '...';
+-- and delivered to the function as the INGEST_DB_URL secret (which index.ts
+-- already prefers over the superuser fallback).
+--
+-- Privilege surface (from scripts/ingest/persist.ts + functions/ingest/index.ts):
+--   ingest.runs                     SELECT, INSERT, UPDATE (audit row protocol)
+--   maplify.sightings               SELECT, INSERT, UPDATE, DELETE (reconcile)
+--   maplify.collection_rule         SELECT — read via maplify.resolve_collection,
+--                                   which is SECURITY INVOKER (LANGUAGE SQL STABLE)
+--   inaturalist.taxa                SELECT, INSERT, UPDATE (mirror upsert; no delete)
+--   inaturalist.observations        SELECT, INSERT, UPDATE, DELETE (reconcile)
+--   inaturalist.observation_photos  SELECT, INSERT, UPDATE, DELETE (reconcile)
+-- Not needed:
+--   public.collections — the sightings.collection_id FK check runs as the table
+--     owner, not the inserting role.
+--   realtime.* — notify_occurrences_changed triggers are SECURITY DEFINER.
+--   sequences — id columns are GENERATED ... AS IDENTITY (no separate USAGE).
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ingest') THEN
+    -- NOINHERIT: the role holds only its direct grants. Connection limit is a
+    -- guardrail: the function opens max 2 conns per invocation, two sources.
+    CREATE ROLE ingest LOGIN NOINHERIT CONNECTION LIMIT 10;
+  END IF;
+END $$;
+
+-- gis: persist.ts builds location values via gis.ST_Point(...)::gis.geography,
+-- and the geography TYPE itself lives in schema gis — both need schema USAGE
+-- (function EXECUTE stays at its PUBLIC default).
+GRANT USAGE ON SCHEMA ingest, maplify, inaturalist, gis TO ingest;
+
+GRANT SELECT, INSERT, UPDATE ON ingest.runs TO ingest;
+GRANT SELECT, INSERT, UPDATE, DELETE ON maplify.sightings TO ingest;
+GRANT SELECT ON maplify.collection_rule TO ingest;
+GRANT SELECT, INSERT, UPDATE ON inaturalist.taxa TO ingest;
+GRANT SELECT, INSERT, UPDATE, DELETE ON inaturalist.observations TO ingest;
+GRANT SELECT, INSERT, UPDATE, DELETE ON inaturalist.observation_photos TO ingest;
+
+-- Explicit (EXECUTE defaults to PUBLIC, but document the dependency).
+GRANT EXECUTE ON FUNCTION maplify.resolve_collection(text, text) TO ingest;
+
+-- inaturalist.taxa is the one ingest-touched table with RLS enabled (its only
+-- policy is anon/authenticated SELECT); without this, the taxa mirror upsert
+-- would silently see zero rows / fail its WITH CHECK.
+CREATE POLICY "Ingest worker may maintain the taxa mirror."
+  ON inaturalist.taxa FOR ALL TO ingest
+  USING (true) WITH CHECK (true);
+
+COMMENT ON ROLE ingest IS
+  'Least-privilege login role for the ingest Edge Function (decision 011). Password set out-of-band; reaches only the mirror schemas + ingest.runs.';


### PR DESCRIPTION
## Summary

Implements the dedicated ingest role from [decision 011](docs/decisions/011-ingest-imperative-shell.md) (beads salishsea-io-wco). One migration creating an `ingest` login role with exactly the privilege surface of `scripts/ingest/persist.ts` + `supabase/functions/ingest`:

- `USAGE` on `ingest`, `maplify`, `inaturalist`, and `gis` (the `geography` column type and `gis.ST_Point` live there — found by running the real persist SQL as the role)
- DML grants on `ingest.runs`, `maplify.sightings`, `inaturalist.observations`/`observation_photos`; `SELECT`+`INSERT`+`UPDATE` only on `inaturalist.taxa` (the shell never deletes taxa); `SELECT` on `maplify.collection_rule` (read via SECURITY INVOKER `resolve_collection`)
- An RLS policy on `inaturalist.taxa` — the one ingest-touched table with RLS enabled
- **No password in the migration** — the role can't log in until `ALTER ROLE ingest PASSWORD` is run out-of-band; `index.ts` already prefers `INGEST_DB_URL` and falls back to the platform DSN, so merging this is a no-op for the running pipeline

Explicitly *not* granted, with reasons in the migration comments: `public.contributors` (`mint_contributor` is SECURITY DEFINER), `public.collections` (FK checks run as table owner), `realtime.*` (notify triggers are SECURITY DEFINER), sequences (identity columns).

## Verification

- Served the real Edge Function locally with `INGEST_DB_URL` pointing at this role: **dry-run maplify (277/282 upserts) and inaturalist (413/414, 3 pages) both succeed**, exercising the full fetch → reconcile → persist statement set including the taxa mirror and audit-row writes.
- Maplify persist integration tests (including the window-bounded DELETE) pass when run as the role.
- Full suite as postgres: 292 passed; `tsc` clean.

## Rollout (after merge)

1. Deploy applies the migration (role exists, cannot log in — pipeline unaffected on superuser fallback).
2. Set the role's password out-of-band and set `INGEST_DB_URL` as an Edge Function secret.
3. Confirm subsequent cron runs in `ingest.runs` succeed under the new role (heartbeat guards regressions).

Closes salishsea-io-wco (beads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)