### PR TITLE
feat(ingest): Sentry for the ingest Edge Function

### DIFF
--- a/supabase/functions/ingest/deno.json
+++ b/supabase/functions/ingest/deno.json
@@ -1,6 +1,7 @@
 {
   "imports": {
     "zod": "npm:zod@^4.4.3",
-    "postgres": "npm:postgres@^3.4.9"
+    "postgres": "npm:postgres@^3.4.9",
+    "@sentry/deno": "npm:@sentry/deno@^10.59.0"
   }
 }

--- a/supabase/functions/ingest/index.ts
+++ b/supabase/functions/ingest/index.ts
@@ -18,6 +18,7 @@
  */
 
 import postgres, { type Sql } from 'postgres';
+import * as Sentry from '@sentry/deno';
 import { z } from 'zod';
 import { parseMaplifyResponse, isIngestable, reconcile } from '../../../scripts/ingest/maplify.ts';
 import { reconcile as reconcileInat } from '../../../scripts/ingest/inaturalist.ts';
@@ -32,6 +33,15 @@ import { fetchMaplify } from './fetch-maplify.ts';
 import { fetchAllObservationPages, resolveTaxonClosure } from './fetch-inaturalist.ts';
 
 const TRIGGER_SECRET = Deno.env.get('INGEST_TRIGGER_SECRET') ?? '';
+// Server-side Sentry surface (decision 011 / salishsea-io-vif). No DSN (local
+// dev) → the SDK disables itself and every Sentry.* call below is a no-op.
+// Complements the heartbeat: it catches silent stops; this explains loud
+// failures. A failed run is already recorded in ingest.runs either way.
+Sentry.init({
+    dsn: Deno.env.get('INGEST_SENTRY_DSN'),
+    environment: Deno.env.get('SENTRY_ENVIRONMENT') ?? 'production',
+    initialScope: { tags: { service: 'ingest-edge-function', runtime: 'deno' } },
+});
 // Prefer a dedicated privileged ingest role (INGEST_DB_URL); fall back to the
 // platform-provided connection. The dedicated role + grants land in a follow-up.
 const DB_URL = Deno.env.get('INGEST_DB_URL') ?? Deno.env.get('SUPABASE_DB_URL') ?? '';
@@ -47,8 +57,12 @@ const RequestSchema = z.object({
 const jsonResponse = (data: unknown, status: number) =>
     new Response(JSON.stringify(data), { status, headers: { 'content-type': 'application/json' } });
 
-const log = (msg: string, extra?: Record<string, unknown>) =>
+const log = (msg: string, extra?: Record<string, unknown>) => {
     console.log(JSON.stringify({ level: 'info', fn: 'ingest', msg, ...extra }));
+    // Ride the structured log as Sentry breadcrumbs so a captured failure
+    // carries the run's fetch/persist trail (decision 011: breadcrumbs per run).
+    Sentry.addBreadcrumb({ category: 'ingest', message: msg, data: extra });
+};
 
 /** Length-independent constant-time string compare. */
 function secretsMatch(a: string, b: string): boolean {
@@ -169,6 +183,14 @@ Deno.serve(async (req) => {
     } catch (e) {
         const message = e instanceof Error ? e.message : String(e);
         log('ingest failed', { source, window, error: message });
+        Sentry.withScope((scope) => {
+            scope.setTags({ source, trigger, dry_run: String(dryRun) });
+            scope.setContext('ingest_run', { runId, window, dryRun });
+            Sentry.captureException(e);
+        });
+        // Flush before responding — the isolate may be frozen/killed right after
+        // the Response returns, losing any event still in the buffer.
+        await Sentry.flush(2000).catch(() => { /* fail-open: never mask ingest */ });
         if (runId != null) {
             await sql`UPDATE ingest.runs SET finished_at = now(), outcome = 'failed', error = ${message} WHERE id = ${runId}`
                 .catch(() => { /* best-effort; do not mask the original error */ });


### PR DESCRIPTION
## Summary

Adds the server-side (Deno) Sentry surface for ingest exceptions that [decision 011](docs/decisions/011-ingest-imperative-shell.md) listed as a consequence (beads salishsea-io-vif). Complements the heartbeat shipped this morning: the heartbeat catches silent stops, Sentry explains loud failures.

- `Sentry.init` from a new `INGEST_SENTRY_DSN` Edge Function secret (already set in prod). **No DSN → the SDK disables itself**, so local dev and CI are no-ops with zero configuration.
- The existing structured `log()` now doubles as Sentry breadcrumbs — a captured failure carries the whole run's fetch/persist trail.
- The catch path tags `source`/`trigger`/`dry_run`, attaches `runId` + window context, and **awaits `Sentry.flush` before responding** (edge isolates may be frozen immediately after the Response, losing buffered events). Fail-open: a Sentry outage can never mask or break ingest.
- Events land in the existing `salishsea-io` Sentry project, distinguished by `service:ingest-edge-function` / `runtime:deno` tags and environment. The Sentry MCP can't create projects; if server events deserve their own project later, it's a one-secret swap.

## Verification (local, per decision 011's dry-run + smoke protocol)

- `deno check` clean.
- Served without DSN: maplify dry-run succeeds (disabled path).
- Served with the DSN and a deliberately broken `INGEST_DB_URL`: run fails 500 and the event appears in Sentry with the right tags ([discover link](https://beam-reach.sentry.io/explore/discover/homepage/?dataset=errors&queryDataset=error-events&query=environment%3Alocal+service%3Aingest-edge-function&statsPeriod=1h), `environment:local`).
- Served with the DSN and a working DB: iNaturalist dry-run succeeds (3 pages, 414 results), no event sent.

Closes salishsea-io-vif (beads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error tracking and logging for ingest operations, making failures easier to diagnose and recover from.
  * Added more detailed context to captured errors so troubleshooting is clearer when an ingest run fails.
  * Ensured error reports are sent before the process exits, reducing the chance of missed failure details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->