### PR TITLE
fix(ingest): pin @sentry/deno exactly; import Sentry first (CodeRabbit review of #312)

### DIFF
--- a/supabase/functions/ingest/deno.json
+++ b/supabase/functions/ingest/deno.json
@@ -2,6 +2,6 @@
   "imports": {
     "zod": "npm:zod@^4.4.3",
     "postgres": "npm:postgres@^3.4.9",
-    "@sentry/deno": "npm:@sentry/deno@^10.59.0"
+    "@sentry/deno": "npm:@sentry/deno@10.59.0"
   }
 }

--- a/supabase/functions/ingest/index.ts
+++ b/supabase/functions/ingest/index.ts
@@ -17,8 +17,8 @@
  * (salishsea-io-89d.3).
  */
 
-import postgres, { type Sql } from 'postgres';
 import * as Sentry from '@sentry/deno';
+import postgres, { type Sql } from 'postgres';
 import { z } from 'zod';
 import { parseMaplifyResponse, isIngestable, reconcile } from '../../../scripts/ingest/maplify.ts';
 import { reconcile as reconcileInat } from '../../../scripts/ingest/inaturalist.ts';


### PR DESCRIPTION
## Summary

Applies the two CodeRabbit findings from #312 that held up under verification, and documents the two rejections.

**Applied:**
- **Pin `@sentry/deno` to exactly `10.59.0`** — Deno re-resolves the npm specifier at every `supabase functions deploy` (no lockfile in the function tree), and this SDK's `Deno.serve` instrumentation has broken on runtime changes before ([sentry-javascript#21142](https://github.com/getsentry/sentry-javascript/issues/21142)). A caret range lets a routine deploy pull a startup-breaking release unreviewed; upgrades should be deliberate.
- **Import Sentry first** — the stated auto-instrumentation rationale is weak (`Deno.serve` is patched at `init()` time, which already precedes our `Deno.serve` call), but init-early is the SDK's documented convention and the reorder costs nothing.

**Rejected, with reasons:**
- *Explicit `SENTRY_ENVIRONMENT` for non-prod deploys* — there are no staging/preview deploys of this function, and events only flow where `INGEST_SENTRY_DSN` is set (prod only; locally the SDK disables itself). The `'production'` default is correct for the only environment that can emit.
- *`beforeBreadcrumb` scrubbing* — audited every `log()` call site: payloads are counts, HTTP statuses, retry metadata, window dates, and public-API error strings; no credentials or row data, and the identical JSON already goes to Supabase console logs. A scrubber for hypothetical fields is speculative complexity.

`deno check` clean with the pinned version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Locked a monitoring dependency to an exact version for more predictable builds.
  * Adjusted module import ordering in the ingest function without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->