### PR TITLE
fix(ingest): keep the Maplify fetch timeout armed through res.json()

### DIFF
--- a/supabase/functions/ingest/fetch-maplify.ts
+++ b/supabase/functions/ingest/fetch-maplify.ts
@@ -34,32 +34,36 @@ export async function fetchMaplify(window: IngestWindow, log: Logger): Promise<u
     let lastError: unknown;
 
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-        let res: Response;
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+        let res: Response;
         try {
             res = await fetch(url, { headers: { accept: 'application/json' }, signal: controller.signal });
+            if (res.ok) {
+                // Read the body under the SAME timeout: a server can send headers
+                // and then stall, and res.json() would otherwise hang past the
+                // deadline. Clear the timer only once the body is fully consumed.
+                const data = await res.json();
+                clearTimeout(timeout);
+                return data;
+            }
         } catch (e) {
-            // network-level failure or timeout abort — retry with backoff
+            // fetch-level failure, abort (timeout), or a stalled/aborted body read
+            clearTimeout(timeout);
             lastError = e;
             if (attempt === MAX_ATTEMPTS) break;
             const delay = retryDelayMs(attempt);
             log('maplify fetch error, retrying', { attempt, delayMs: delay, error: String(e) });
             await sleep(delay);
             continue;
-        } finally {
-            clearTimeout(timeout);
         }
 
-        if (res.ok) return await res.json();
-
+        // Non-2xx: res is defined and not ok.
+        clearTimeout(timeout);
         lastError = new Error(`Maplify HTTP ${res.status}`);
-        if (!isRetryableStatus(res.status) || attempt === MAX_ATTEMPTS) {
-            // drain the body so the connection can be reused/closed cleanly
-            await res.body?.cancel();
-            break;
-        }
+        // drain the body so the connection can be reused/closed cleanly
         await res.body?.cancel();
+        if (!isRetryableStatus(res.status) || attempt === MAX_ATTEMPTS) break;
         const delay = retryDelayMs(attempt, parseRetryAfter(res.headers.get('retry-after')));
         log('maplify non-2xx, retrying', { attempt, status: res.status, delayMs: delay });
         await sleep(delay);


### PR DESCRIPTION
## Summary

Closes the last gap from PR #307's CodeRabbit review (beads salishsea-io-1wz): `fetch-maplify.ts` cleared its abort timer in a `finally` the moment headers arrived, so a server stalling mid-body could hang `res.json()` — and the whole invocation — past the 15-second deadline. That failure mode would surface only as a stuck-`started` orphan in `ingest.runs` (which the heartbeat now alerts on, but prevention beats detection).

This mirrors the structure already applied to `fetch-inaturalist.ts` in #307, comment for comment: the timer stays armed until the body is fully consumed; success, catch, and non-2xx paths each clear it explicitly.

## Verification

- `deno check` clean.
- Local serve + maplify dry-run: 283 results fetched and parsed, run recorded `success`.
- Bonus: an accidental serve without the env file confirmed the trigger-secret gate fails closed (401 on empty secret).

Closes salishsea-io-1wz (beads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when fetching external data by handling timeouts more consistently.
  * Reduced the chance of hanging requests by cleaning up failed attempts more promptly.
  * Better handling of non-success responses, helping retries behave more predictably and keep the process stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->