### PR TITLE
data: mirror Bigg's ID/nickname reference sheet + record rights (D-21)

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -29,7 +29,7 @@ Pedder Bay, where the T2s were held captive in 1970"). A minority of story cells
 contain genuinely creative prose; where we surface those, we state the fact rather
 than reproduce the passage verbatim. The compilation's selection/arrangement
 belongs to its maintainer and is credited, not claimed. Policy of record:
-[../docs/rights-policy.md](../docs/rights-policy.md).
+[../docs/rights-policy.md](../docs/rights-policy.md) §7.1 (decision D-21).
 
 ### Refreshing
 

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,39 @@
+# Reference data
+
+External reference sources we **mirror** here so that changes are diffable and
+seeding is reproducible. These files are inputs, not authoritative domain data —
+our authoritative catalog lives in Postgres (see the individuals/subjects model).
+
+## `biggs-ids.tsv` — Bigg's killer whale designations & nicknames
+
+- **Source:** [Bigg's Orca/Killer Whale Nick Names](https://docs.google.com/spreadsheets/d/1fj3sA2R8LGw68-Rxb0dL6jwTKkc4AkhGKuk-jt9zmis/edit?gid=0) (Google Sheet, `gid=0`)
+- **Maintained by:** `vitalocean@gmail.com` — the curator behind the community
+  "Transient/Bigg's Orca Nick Naming Page" that recurs in the *Who Nicknamed* column.
+- **Retrieved:** 2026-07-07. Sheet last modified 2025-07-01 (slowly curated, not a live feed).
+- **Columns:** deceased flag (`D`/`PD`) · Local ID (BC/WA) · Additional Designations
+  (Alaska/California) · Gender · Birth Year · Nicknames · Story Behind the Nickname ·
+  Who Nicknamed · Notes.
+
+### Why it's committed
+
+We have no visibility into the sheet's edit history. Committing a byte-for-byte
+mirror establishes a **baseline**: re-export and diff to detect upstream changes,
+then decide per-change whether to re-seed. Refresh is periodic, not automated.
+
+### Rights
+
+The **factual** content is not subject to copyright and is what we use:
+designations, genealogy, birth years, gender, deceased status, which authority
+named an animal, and the *etymological facts* in the story column (e.g. "named for
+Pedder Bay, where the T2s were held captive in 1970"). A minority of story cells
+contain genuinely creative prose; where we surface those, we state the fact rather
+than reproduce the passage verbatim. The compilation's selection/arrangement
+belongs to its maintainer and is credited, not claimed. Policy of record:
+[../docs/rights-policy.md](../docs/rights-policy.md).
+
+### Refreshing
+
+```bash
+# Re-export the sheet as CSV and diff against this baseline (columns only, delimiter-agnostic).
+# Auth via the Drive integration or a shared export link; compare cell-by-cell keyed on Local ID.
+```

--- a/data/biggs-ids.tsv
+++ b/data/biggs-ids.tsv
@@ -1,0 +1,650 @@
+D if Deceased, PD is Presumed Deceased	Local ID designation (BC and WA)	Additional Designations (Alaska or California)	Gender	Birth Year	Nicknames	Story Behind the Nickname	Who Nicknamed	Other Notes or Comments
+	T002B	AM3	F	1979	Pedder	Pedder Bay on southern Vancouver Island where the T2s were held captive in 1970. 	VanAqua	
+								
+	T002C	AM5	F	1989	Tasu	Tasu Sound on the west coast of Haida Gwaii	VanAqua	
+	T002C1		M	2002	Rocky	Rocky Point near Victoria	VanAqua	
+D	T002C2		M	2005	Tumbo/Barabbas	Tumbo Island near Saturna Island in the Strait of Georgia	VanAqua/Dena Matkin	
+	T002C3		F	2011	Lucy/Helena	Lucy Island off the north end of Haida Gwaii	VanAqua/Dena Matkin	
+D	T002C4			2017	Kano	Kano Inlet	VanAqua	
+	T002C5			2020			OceanWise	awaiting decision (last email 2.24.25)
+	T002C6			2025			OceanWise	awaiting decision (last email 2.24.25)
+								
+	Known as the Secret Agents					for the #007 same as James Bond		
+D	T007		F	≤1961	Innis		DFO/Alexandra Morton	
+D	T007A		M	1976	Arrow		DFO/Alexandra Morton	
+	T007B		F	1982	Spiller		DFO/Alexandra Morton	
+	T007B3		M	2005	Knox	after Fort Knox the main location featured in Goldfinger movie - 007 Bond 3rd (get it 007B3 😉 ).Goldfinger is the 3rd bond movie	Nicky Smiley (Transient/Bigg's Orca Nick Naming Page)	
+	T007B4		M	2010	Moonraker	007 movie keeping with the Secret Agent theme, and B4 has many scars	Andy Scheffler (Transient/Bigg's Orca Nick Naming Page)	
+	T007B6		M	2018	Domino	after a Bond character and their colour	Nicky Smiley (Transient/Bigg's Orca Nick Naming Page)	
+	T007B7		M	2022	Spectre	after a fictional Bond organization "Special Executive for Counter-intelligence, Terrorism, Revenge, and Extortion." 	Faith Jayaram & Taylor Redmond (Transient/Bigg's Orca Nicknaming Page)	
+								
+	T010		F	≤1964	Langara	Langara Island on the northwest corner of Haida Gwaii	VanAqua	
+D	T010B		M	1983	Siwash	Siwash Cove on Flores Island on th west coast of Vancouver Island	VanAqua	
+D	T010C		M	1999	Bubba/Bones	Bubba? / Bones Bay in Clio Channel, north of West Cracroft Island near Johnstone Strait	SIMRS/VanAqua	
+								
+D	T011		F	≤1964	Wakana		DFO/Alexandra Morton	
+	T011A		M	1978	Rainy		DFO/Alexandra Morton	
+								
+D	T012A		M	1982	Nitinat	Nitinat River on the west coast of Vancouver Island	DFO	
+								
+	T018		F	≤1955	Esperanza	Esperanza Inlet on the west coast of Vancouver Island	SIMRS/DFO/VanAqua	
+	T019		F	≤1965	Nootka/Mooyah	Nootka is likely for Nootka Sound (SIMRS name listed as from DFO)/Mooyah Bay in Nootka Sound on the west coast of Vancouver Island	SIMRS/DFO/VanAqua	
+	T019B		M	1995	Galiano/Kosatka	Galiano Bay in Nootka Sound on the west coast of Vancouver Island / Killer whale	VanAqua/Dena Matkin	
+	T019C		M	2001	Spouter	Spouter Island in Nootka Sound on the west coast of Vancouver Island	VanAqua	
+								
+D	T021		F	<1968	Pandora	Pandora Head in Wells Passage, Queen Charlotte Strait	VanAqua (?)	
+D	T020		M	≤1963	Kwatsi	Kwatsi Bay near Queen Charlotte Strait	VanAqua (?)	
+								
+	Known as the Motley Crew					 60's-70'srock group - many notches and scratches  on bodies and fins of the founding animals.		
+	T023		F	≤1964	Janice/Warmsprings	Janice Joplin/SE Alaska place name	SIMRS/Dena Matkin	
+	T023D		F	1993	Axle/Brighty	Axl Rose of Guns'n'Roses/Family Burro	SIMRS/Dena Matkin	
+	T023D3		M	2012	Robin	Researcher Robin Baird	Dena Matkin	
+	T023D4			2015	Sixx	A member of Motley Crue!	Tomislav Flip (Transient/Bigg's Orca Nick Naming Page) 	
+	T023D5			2019	Wildside	after Motley Crue song, "Wild side"	 (Transient/Bigg's Orca Nick Naming Page) 	
+								
+	T023C		F	1990	Cindy/Freshwater	Cindy Lauper	SIMRS/Dena Matkin	
+	T023C3		F	2009	Durban	Researcher John Durban	Dena Matkin	
+	T023C4			2013	Bunzie	Patron saint of fun road trips	Dena Matkin	
+	T023C5		F	2018	Grym			
+	T023C6			2023	Cascade	Keeping theme w/ mother "Freshwater."	Bonnie Gretz  (Transient/Bigg's Orca Nick Naming Page) 	
+								
+	T026		F	≤1966	Saoirse	(pronounced Sur-sha), Irish for freedom. a name reflecting the capture and release of T026	Brendon Bissonnette (Transient/Bigg's Orca Nick Naming page)	
+	T026A		F	1990	Ursula	means “little bear” in Latin. Those rake marks look like bear claw marks.	Justine Buckmaster (Transient/Bigg's Orca Nick Naming page)	
+								
+	T028		F	≤1972	Khaz	SE Alaska placename	Dena Matkin	
+	T028C		F	2003	Lluvia	SE Alaska placename	Dena Matkin	
+	T028D			2007	Gwaii	Haida Gwaii	Dena Matkin	
+	T028E			2013				
+								
+	T028A		F	1994	Slocum	SE Alaska placename	Dena Matkin	
+	T028A1			2012				
+	T028A2			2018				
+	T028A3			2021				
+								
+	T028B		F	1997	Lydonia	SE Alaska placename	Dena Matkin	
+	T028B1			2015				
+	T028B2			2018				
+								
+D	T030		F	≤1967	Elwha	for the Elwha River in Washington, plus the markings on her left saddle patch look like a capital “E” for Elwha.	Talia Goodyear (Transient/Bigg's Orca Nick Naming Page)	
+	T030A		M	1986	Sequoia	Sequoia, for the tallest trees of the west, described by John Muir as "the noblest of a noble race"	Monika Wieland Shields (Transient/Bigg's Orca Nick Naming page)	
+	T030C			2005	Salix	Salix, for the willow tree, known for it's strong association to water	Monika Wieland Shields (Transient/Bigg's Orca Nick Naming page)	
+								
+	T030B		F	1993	Lyra	A small constellation in the northern hemisphere over the Salish Sea. The constellation kind of looks like a whale. 	Whitley Mike (Transient/Bigg's Orca Nick Naming Page)	
+	T030B1			2012	Vega	Vega is one of two of the brightest stars in the northern night sky over the Salish Sea, and the brightest star in the constellation Lyra.	Whitley Mike (Transient/Bigg's Orca Nick Naming Page)	
+	T030B2			2017	Capella	Capella is one of two of the brightest stars over the Salish Sea and a prominent object in the northern winter sky	Whitley Mike (Transient/Bigg's Orca Nick Naming Page)	
+	T030B3			2024	Vesper	Latin for "evening star"	Amanda Marie Colbert (Transient/Bigg's Orca Nick Naming Page)	
+								
+D	T031		M	≤1954	Yankee One/Drake	From original naming system (SIMRS info)/ Drake Island in Glacier Bay	SIMRS/Dena Matkin	
+								
+	T034		F	≤1969	Grace	Maternal Grandmother who was a teacher and inspiration	Dena Matkin	
+	T034A		F	2007	Pachamama	Mother earth.	Dena Matkin	
+D	T034A1			2019				
+	T034A2			2024	Amaru	Incan diety associated with the economy of water, the underworld, and often depicted as a winged serpant (symbolizing wisdom); Pachamama is the Incan goddess Mother Earth.	Amanda Marie Colbert (Transient/Bigg's Orca Nick Naming Page) 	
+	T034B		F	2017	Sonder	Sonder meaning- “the realization that everyone has a life they are constantly living despite others' personal lack of awareness of it.” seems fitting since we only get a glimpse of their lives.	Amanda Marie Colbert (Transient/Bigg's Orca Nick Naming Page) 	
+								
+	T035		F	≤1970	Ruby Roo	Bouncy Goat	Dena Matkin	
+	T035A		F	1998	Pearl/Lester	Mineral/gemstone theme/Lester Island in Glacier Bay	Dena Matkin/ Sara Hysong-Shimazu (Transient/Bigg's Orca Nick Naming Page) 	
+	T035A1		F	2010	Opal	Beautiful Birthstone	Dena Matkin	
+	T035A2			2013	Topaz	in keeping with the gemstone theme	Brendon Bissonnette (Transient/Bigg's Orca Nick Naming page)	
+	T035A3			2018	Garnet	in keeping with the gemstone theme	Brendon Bissonnette (Transient/Bigg's Orca Nick Naming page)	
+	T035A4			2022	Agate	gemstone theme, and for Agate Pass in Puget Sound	Sara Hysong-Shimazu (Transient/Bigg's Orca Nick Naming page)	
+								
+	T036	AB31	F	≤1970	Flapjack	An island in Glacier Bay where transients hunt for harbor seals that sometimes haul out on its beaches.	Dena Matkin	
+	T036B		F	1998	Tattertip	Physical description of its dorsal.	Dena Matkin	
+	T036B1		F	2009	Bhotia	Teacher.	Dena Matkin	
+	T036B1A		F	2025	Maple	For the 352 y.o Big Leaf Maple tree at English Camp, San Juan Island; also goes with grandmother "Flapjack's" name	Lauren Tschirhart (Transient/Bigg's Orca Nick Naming Page)	
+	T036B2			2013	Greenfelder	Photographer Mike Greenfelder	Dena Matkin	
+D	T036B3		M	2018	Chip	like the teacup from beauty and the beast, because of the nick in his dorsal	Leah Vanderwiel (Transient/Bigg's Orca Nick Naming Page) 	
+	T036B4		M	2024	Auk	For the slim and pointed eyepatches that look like an auk (alcidae seabird) sitting on the water.	Julie Massa & Amanda Marie Colbert (Transient/Bigg's Orca Nick Naming Page) 	
+								
+	T036A	AM35	F	1990	Leland	An island near Flapjack in Glacier Bay where harbor seals and harbor porpoise are commonly seen.	Dena Matkin	
+	T036A1		F	2005	Tierna	Earth.	Dena Matkin	
+	T036A1A		M	2022	Drift	nautical in nature; the concept of "drift" refers to the intrinsic movement of elements in some cultures	Elizabeth Zwamborn (Transient/Bigg's Orca Nick Naming Page) 	
+	T036A2		F	2012	Kailas	Spiritual mountain in the Himalayas.	Dena Matkin	
+	T036A3		M	2015	Storm/Mike III	for the lightning bolt looking mark on the left saddle patch/Michael Bigg	Talia Goodyear (Transient/Bigg's Orca Nick Naming Page)/Dena Matkin	
+	T036A5		M	2021	Squall	sudden increase in wind speed, often associated with a line of active/heavy thunderstorms. Goes with sibling’s name “Storm,” and some squall lines have that “cyclone-shape” like his saddle patch.	Amanda Marie Colbert (Transient/Bigg's Orca Nick Naming Page) 	
+								
+	T037		F	1979	Pizza Fin/Rocky III	There were already at least two named this (in B.C. and New Zealand).  Transients sometimes hunt close to shore among the rocks.	Dena Matkin	
+	T037B		F	1998	Harald	Harald Yurk is a resident acoustics researcher and really nice father.	Dena Matkin	
+	T037B1		M	2012	Lance	Lance Barrett-Lennard is a super-smart B.C. killer whale genetics researcher.	Dena Matkin	
+D	T037B2			2017	Trident	a three-pronged spear used as a weapon by the god of the sea (Neptune/Poseidon). Currently has a trident-shaped scratch/scar on the left side, and keeps with the "combat weapon" theme of his brother (love that double meaning of Lance in this case)	Monika Wieland Shields (Transient/Bigg's Orca Nick Naming page)	
+	T037B3		F	2022	Slice	A nod to "slice of pizza" as a grandchild of T37 who is also known as "Pizza Fin"; additionally, dorsal fins slice through the water	Monika Wieland Shields (Transient/Bigg's Orca Nick Naming page)	
+								
+	T037A		F	1994	Volker	Volker Deecke is a transient acoustics researcher extraordinaire.	Dena Matkin	
+	T037A1		F	2007	Inyo	I grew up in Inyo County.  This is a California Indian name for dwelling place of the great spirit.  Orcas have huge spirits that make us feel more alive in their presence.	Dena Matkin	
+	T037A2		M	2009	Inky	My black and white cat while growing up in Inyo County.	Dena Matkin	
+	T037A3		M	2013	Spinnaker 	A large three-cornered sail, typically bulging when full, set forward of the mainsail of a yacht when running before the wind. Sort of looks like a sailboat with open sail in the right saddle patch.	Ashley Keegan (Transient/Bigg's Orca Nick Naming page)	
+	T037A4		F	2015	Crinkle 	for that crinkly curved dorsal fin	Selena Rhodes Scofield (Transient/Bigg's Orca Nick Naming page)	
+D	T037A5		M	2019	Jib	A type of triangular sail (to match the wide triangular dorsal) and to go along with sibling T37A3 Spinnaker	Monika Wieland Shields (Transient/Bigg's Orca Nick Naming page)	
+								
+	T038		F	1980	Graeme	The one and only Graeme Ellis	Dena Matkin	Open to Renaming due to male gender name for female animal
+	T038B		F	2003	Jane		Dena Matkin	
+	T038B1			2018	Cook*		Dena Matkin	
+	T038B2			2023				
+	T038C			2008	Borrowman	Researcher Jim Borrowman	Dena Matkin	
+	T038D		M	2012	Falconer	Researcher Brian Falconer	Dena Matkin	
+	T038E			2017	Hocker*		Dena Matkin	
+	T038F			2023				
+								
+	T038A		F	2000	Dana	Graeme's daughter Dana Ellis	Dena Matkin	
+D	T038A1			2015				
+	T038A2			2020				
+	T038A3			2024				
+								
+D	T040	AL40	M	≤1961	Captian Hook	Dorsal fin has a radical hook to port		
+								
+	Known as Ted's Gang							
+	T041		F	≤1966	Lawrie	Island in SE Alaska	Dena Matkin	
+	T041A		F	1988	Jemison	Sea Lion researcher Lauri Jemison	Dena Matkin	
+D	T041A1			2011	Palm	Researcher Rod Palm	Dena Matkin	
+	T041A2			2013	Tree	Born near Tree Island in Clayoquot Sound	SIMRS	
+	T041A3			2018				
+								
+D	T046		F	≤1966	Wake	Nancy Wake was a spy, a journalist and a hero of the French Resistance in World War II. What struck me as appropriate for this whale is that at one point in her adventurous life, Nancy got stuck in a tree as her parachute got caught in the branches (T46 was part of the last live capture in Puget Sound). A nearby Frenchman said he wished all trees could bear such "beautiful fruit", to which Nancy responded, "Don't give me that French shit."  Wake for the notches in her dorsal fin	Ashley Keegan (Transient/Bigg's Orca Nick Naming page)	
+	T046D		M	2000	Strider	(like Aragorn from lotr) - Because he’s always off by himself, he’s quiet and kind of brooding, but he’s also a bad ass!	Ryleigh Whitfield (Transient/Bigg's Orca Nick Naming Page)	
+	T046E		M	2003	Thor	his dorsal fin resembles a lightning bolt.	Ashley Keegan (Transient/Bigg's Orca Nick Naming Page)	
+	T046F		M	2012	Loki	to go with his brothers name "Thor"	Ryleigh Whitfield (Transient/Bigg's Orca Nick Naming Page)	
+	T122		F	≤1982	Centeki	Centeki - one of the 13 lunar phases recognized by the Coast Salish people. T122 was originally designated T46A, but was renamed after re-appearing after a 13 year absence.	Monika Wieland Shields (Transient/Bigg's Orca Nick Naming page)	
+								
+	T046B		F	1988	Raksha	 in honour of T46B’s valiant effort to save her child, this name comes from the mother wolf (wolves of the sea!) whose name means “protection” in Hindi and who vows to fight to the death for any of her cubs	Brendon Bissonnette (Transient/Bigg's Orca Nick Naming page)	
+	T046B1		F	2003	Tread	Tire tread/tire track markings on her left saddle patch	Andy Scheffler (Transient/Bigg's Orca Nick Naming Page)	
+	T046B1A		F	2015	Tsakani	Joy/Happiness, T also goes with moms name	Brendon Bissonnette (Transient/Bigg's Orca Nick Naming page)	
+D	T046B1B		M	2018	Tl'uk	pronounced Tuh-Luke is the Bella Coola Coast Salish word for Moon	Jilann Campbell (Transient/Bigg's Orca Nick Naming Page)	may be offspring of T68
+	T046B1C		M	2022	Tide	name "Tide" honors T046B1C's late brother Tl'uk (which means moon). A poetic representation of the gravitational pull we feel to family gone before us.	Lauren Tschirhart (Transient/Bigg's Orca Nick Naming Page)	
+	T046B2		F	2008	Akela	(Ah-key-la) Asher of Hebrew origin meaning happy, blessed (Akela and Raksha - alpha and beta wolves in Jungle Book)	Nicky Smiley (Transient/Bigg's Orca Nick Naming Page)	
+D	T046B2A			2021				
+	T046B2B			2023	Takaya	the Lekwungen Coast Salish word for wolf. Also the name of a famous sea wolf who developed seal hunting skills and other incredible feats of adaptability.	Vanessa Pirtle Franz (Transient/Bigg's Orca Nick Naming Page)	
+	T046B3		F	2011	Sedna	after the goddess of the sea and marine animals in Inuit mythology	Whitley Mike (Transient/Bigg's Orca Nick Naming Page)	
+	T046B3A			2025	Munro	honors Ralph Munro who passed on the same day this calf was first seen and was an integral part of getting the Budd Inlet Six captives released (of which T46 "Wake" was part of) and ending live captures of killer whales in Washington State.	Community Choice (Transient/Bigg's Orca Nick Naming Page)	Lots of community support for this name from NGOs, volunteers, whale watchers, captains, naturalists, educators, etc!
+	T046B4		M	2013	Quiver	as his right saddle patch has arrow looking marks and a Quiver holds arrows	Ashley Keegan (Transient/Bigg's Orca Nick Naming Page)	
+D	T046B5		unknown	2015				Infanticide death by T68 and T68A (Mom and son pair)
+	T046B6		F	2019	Sol	meaning sun, in contrast to family member Tl'uk (moon) who was born around the same time.	Monika Wieland Shields (Transient/Bigg's Orca Nick Naming page)	
+	T046B7			2023	Tala	which means 'wolf' in several North American Indigenous languages, as well as 'star' in Tagalog (tying in with both the wolf and celestial themes!)	Elizabeth Zwamborn & Amanda Marie Colbert (Transient/Bigg's Orca Nick Naming page)	
+								
+	T046C		F	1994	Carmanah	for Carmanah Point, Creek and Carmanah Provincial Park out west	Brendon Bissonnette (Transient/Bigg's Orca Nick Naming page)	
+	T046C1		M	2006	Tsunami	a catastrophic ocean wave	Monika Wieland Shields (Transient/Bigg's Orca Nick Naming page)	
+	T046C2		F	2009	Sam	Named by Dr. John Ford and Graeme Ellis after they spent a night with the whale in Bent Harbour.	Dr. John Ford and Graeme Ellis	
+	T046C3			2013	Razor	for the many notches in his or her dorsal fin, plus it's gender neutral.	Brendon Bissonnette (Transient/Bigg's Orca Nick Naming page)	
+	T046C4			2018	Hobi	after Hobiton Lake, near Carmanah, name of Mum	Nicky Smiley (Transient/Bigg's Orca Nick Naming Page)	
+	T046C5			2025				
+								
+	T049A	AL12	F	1986	Nan	For Nanaimo and all the work that has been done at the Pacific Biological Station.	Dena Matkin	
+	T049A1		M	2001	Noah	Smart local kid that likes orcas.  How biblically crazy the ocean can get, as in the great flood.	Dena Matkin	
+	T049A2		M	2007	Judy/Jude	Noah's grandmother and hard-working gardener here in Gustavus.	Dena Matkin	Shortened to Jude by Transient/Bigg's Orca Nick Naming page as this animal is a male. 
+	T049A3		M	2011	Nat	Marine mammal observer on ships in Glacier Bay who has given me so many orca sightings that led to encounters.	Dena Matkin	
+	T049A4		M	2014	Neptune	Stay's with the N theme of the family names already and is the Roman God of water	Monika Wieland Sheilds (Transient/Bigg's Orca Nick Naming Page)	
+	T049A5		F	2017	Nebula	For her not completely filled in eye patch, it's a little bit hazy. Stay's with the N theme of the family names already.	Ashley Keegan (Transient/Bigg's Orca Nick Naming Page)	
+	T049A6		M	2022	Charlie II	In honor of T001 Charlie Chin (and for healed injury to lower jaw)	April Ryan & Sara Hysong-Shimazu (Transient/Bigg's Orca Nick Naming Page)	
+								
+	T049B	AL20	F	1992	Van	Vancouver	Dena Matkin	
+D	T049B1			2006	Voyageur	Traveler	Dena Matkin	
+	T049B2			2010	Skyler	unisex name of dutch origin meaning scholar	Dena Matkin	
+	T049B3			2013	CharChar	Friend Charlie	Dena Matkin	
+	T049B4			2019				
+	T049B5			2023				
+								
+	T049C		M	1998	Neilson/Janet	Humpback Whale Researcher Janet Neilson	Dena Matkin	Changed to Nielson by Transient/Bigg's Orca Nick Naming page as this animal is a male. 
+								
+	T050	AL8	F	1980	Boulder	Island in SE Alaska	Dena Matkin	
+D	T050A		M	1995	Bolder	Orca are so bold	Dena Matkin	
+	T050B		F	1999	Sita	Reef south of Boulder Island	Dena Matkin	
+	T050B1			2012	Blakeslee		Dena Matkin	
+	T050B2			2020				
+D	T050C			2005	Passage	Strawberry Passage	Dena Matkin	
+	T050D			2011	Lyrical*	?*	Dena Matkin	open to renaming
+	T050E			2013	Grandmama*	?*	Dena Matkin	open to renaming
+								
+	T051	AL9	M	1981	Roswell/Loner	Area 51, Roswell /Male usually alone	Ashley Keegan (Transient/Bigg's Orca Nick Naming Page) /Dena Matkin	
+								
+	T054		M	1972	Seaforth	an area off the Central Coast of BC. The Central Coast is where he has been seen 63 times of 75 known encounters.	Jared Towers (Transient/Bigg's Orca Nick Naming Page) /Dena Matkin	
+								
+	T055		F	≤1976				
+	T055A		M	1989				
+	T055B		F	1994				
+	T055B1		F	2021				
+	T055C		M	2004				
+								
+D	T057		F	≤1979				
+D	T057A		M	1993				
+								
+D	T058		F	<1976				
+								
+	T059		F	<1970				
+	T059A		F	1995				
+	T059A1		F	2006				
+	T059A1A			2023				
+	T059A2		F	2009				
+	T059A3			2013				
+	T059A4			2017				
+	T059A5			2020				
+								
+	T060		F	≤1980	Panthera 	genus that including tigers and some other big felines. Her left saddle patch has those deep rake marks that look kinda like a classic cat scratch, plus her left eye patch looks like the side profile of a big cat	Talia Goodyear (Transient/Bigg's Orca Nick Naming Page) 	
+	T060C		M	2001	Yelnats 	T60C has a dorsal fin the looks very similar to T123A (Stanley), basically Stanley's doppleganger. Yelnats is Stanley backwards. And Stanley Yelnats was a character in the movie Holes. 	Tomislav Flip (Transient/Bigg's Orca Nick Naming Page) 	
+	T060D		M	2004	Onca	Jaguars scientific name (Panthera Onca) in theme of Mom's name	Nicky Smiley (Transient/Bigg's Orca Nick Naming Page)	
+	T060E		M	2008	Lynx	for the little 'tuft' on his dorsal fin	Tomislav Flip (Transient/Bigg's Orca Nick Naming Page) 	
+	T060F		F	2012	Tigris	tigers scientific name Panthera Tigris, keeps in theme with mom's name	April Ryan and Nicky Smiley (Transient/Bigg's Orca Nick Naming Page)	
+	T060G			2019	Uncia	in keeping with her family’s theme, and for the little snowflake dots on her saddle patch (since P. uncia is the snow leopard)	Ellie Sawyer (Transient/Bigg's Orca Nick Naming Page)	
+								
+	T064	AM21	F	≤1971	Keku	Island in SE Alaska	Dena Matkin	
+	T064A	AM27	F	1993	Minke	Participated in a Minke kill	Dena Matkin	
+D	T064A2			2012	Tonsai	favorite dog named after a beach in Thialand	Dena Matkin	
+	T064A3			2014	Sparrow/Sparrow Rose*	Dena's grand daughter	Dena Matkin	*shorten to Sparrow?
+	T064A4			2018	Nova*		Dena Matkin	*rename/J51 is Nova?
+	T064A5			2021				
+	T064B		F	2002	Amabilidad	kindness	Dena Matkin	
+	T064B1			2013	Peaches*		Dena Matkin	*open to renaming
+	T064B1A			2024				
+	T064B2			2019	Pelosi*		Dena Matkin	*open to renaming
+								
+	T065	AM22	F	<1968	Whidbey II	Whidbey Passage in Glacier Bay	Dena Matkin	
+	T063	AM20	M	1978	Chainsaw/Zorro		?/Dena Matkin	
+	T065A	AM25	F	1986	Artemis/Fingers	Goddess of the Hunt/A small bay inside Glacier Bay that I have followed transients into to observe their kills. And bones inside pectoral fins	Traci Walter (Transient/Bigg's Orca Nick Naming Page) /Dena Matkin	
+	T065A2		M	2004	Ooxjaa	Windy in the Tlingit language.	Dena Matkin	
+	T065A3		M	2007	Amir/Amira	Changed to be more gender appropriate - In Arabic the name means prince. The word originally meant "Commander (of army)". It later became a title given to a ruler's son, and hence "prince"./ Female leader in middle eastern countries.	Transient/Bigg's Orca Nick Naming Page/ Dena Matkin	Changed to Amir by Transient/Bigg's Orca Nick Naming page as this animal is a male. 
+	T065A4		F	2011	Ellifrit	Dave Ellifrit is a long-time orca researcher who is quite good at IDs.	Dena Matkin	
+	T065A5		M	2014	Indy/Elsie	Which is sorta like adventurous Indiana Jones + an independent whale/A Tlingit grandmother of a friend of mine in the killer whale clan.	Andy Scheffler (Transient/Bigg's Orca Nick Naming Page)/Dena Matkin	
+	T065A6		F	2018	Callisto/Butterbean*	Greek mythology, a nymph and hunting attendant to Artemis	April Ryan (Transient/Bigg's Orca Nick Naming Page) / Dena Matkin	
+	T065B	AM26	F	1993	Chunk	Notch near base of dorsal fin	Dena Matkin	
+	T065B1		M	2011	Birdsall	Researcher Caitlin Birdsall	Dena Matkin	
+	T065B2			2019	Corvus/Nettle	Genus name for crows; eyepatches look like the silhouette of a crow	Monika Wieland Sheilds (Transient/Bigg's Orca Nick Naming Page)/Dena Matkin	
+	T065B3			2023	Rook	large, gregarious, black-feathered bird of the Corvid family; a powerful chess piece which has alternating high and low battlements (aka crenelations) at the top, similar to what is seen in T065B3’s eye patches. Symbolically associated with change and transformation.	Vanessa Franz, Julie Massa, Elizabeth Zwamborn (Transient/Bigg's Orca Nick Naming Page)	
+								
+	T068	AQ10	F	≤1970	Yakataga	Cape in the Gulf of Alaska	Dena Matkin	Mom and Son who participated in the infanticide death of T46B5
+	T068A	AQ11	M	1984	Ken	Researcher and professor Ken Norris	Dena Matkin	Mom and Son who participated in the infanticide death of T46B5
+								
+	T068B	AQ12	F	1987	Phylly	Ken's wife Phylly Norris	Dena Matkin	
+	T068B1		F	2001	Obsidian	Black Rock	Dena Matkin	
+	T068B1A			2013	Fern*		Dena Matkin	
+	T068B1C			2019				
+	T068B1D			2025				
+	T068B2			2004	Quartz	White Rock	Dena Matkin	
+	T068B3			2010	Wilder	Wild little boy	Dena Matkin	
+	T068B4			2014	Chiak/Penumbra	?/for the moon shaped dorsal fin (a penumbra is the outer shadow of the moon during an eclipse)	Dena Matkin/Ellie Sawyer (Transient/Bigg's Nick Naming Page	
+	T068B5			2019	Venture*		Dena Matkin	
+								
+	T068C	AQ14	F	1992	Bazan	SE Alaska placename	Dena Matkin	
+	T068C1			2007	Sila	SE Alaska placename	Dena Matkin	
+	T068C3		F	2012	Jacobsen	Researcher Jeff Jacobsen	Dena Matkin	open to renaming depending on gender 
+	T068C3A			2024				
+	T068C4			2014	Rich*		Dena Matkin	open to renaming depending on gender 
+D	T068C5			2020				
+	T068C6			2023				
+								
+	T069		F	≤1974	Komox	First Nations word for Comox, meaning plenty, abundant and wealth	Ella Smiley (Transient/Bigg's Orca Nick Naming Page)	
+	T069C		M	1995	Kye	For Kye Bay/Kye Reef near Comox, as he often comes in close to shore when he goes past this beach.	Ella Smiley (Transient/Bigg's Orca Nick Naming Page)	
+	T069E		M	2004	Kodiak	meaning Island, also in keeping with the K theme of Mum and brother	Ella Smiley (Transient/Bigg's Orca Nick Naming Page)	
+	T069F		M	2010	Kin	after Kin Beach a beach just north of Kye Bay, in keeping with Mum and brothers name.	Ella Smiley (Transient/Bigg's Orca Nick Naming Page)	
+								
+	T069A		F	1989	Kitimat	after the village near Hartley Bay where T069A2 was stranded.	Ella Smiley (Transient/Bigg's Orca Nick Naming Page)	
+	T069A2		M	2006	Hartley	to commemorate his rescue after he stranded outside Hartley Bay in 2015	Brendon Bissonnette (Transient/Bigg's Orca Nick Naming page)	
+	T069A3			2011	Kʷiisahii	Pronounced (Quii-Sa-Hey); because any Nuu-chah-nulth hunter hopes to have the kakawin’s grace, respect and knowledge of their environment.	Andrew McCurdy and Ali Ca (Transient/Bigg's Orca Nick Naming Page)	This note applies to T69A3 and T69A4: Andrew McCurdy and I (Ali Ca), are the lucky freedivers who saw these guys from way too close for my liking… Please, don’t try this at home! hehe Through my work, I’m interacting often with Nuu-chah-nulth Knowledge Holders. When I mentioned our great encounter, a lot of stories started to be shared with us. Kakawin (orcas) are sacred animal for the NCN peoples. Also called the silent hunters, they are an inspiration for Nuu-chah-nulth Nations regarding their community structures. They also believe that because of their strength, kakawin can hold the knowledge of the universe and are part of a reincarnation cycle involving the hereditary chiefs.
+	T069A4			2016	Našuk	Pronounced (Na-Shook), refers to the strength that these beings have. Not only the strength of surviving in this changing environment, but the strength required to hold all the knowledge they acquire through their life	Andrew McCurdy and Ali Ca (Transient/Bigg's Orca Nick Naming Page)	
+D	T069A5			2018	Kismet	a word meaning destiny or providence, for the good fortune of these whales in their baby boom	Ellie Sawyer (Transient/Bigg's Orca Nick Naming Page)	
+	T069A6			2023				
+								
+	T069D		F	2001				
+	T069D1		M	2013				
+	T069D2			2016				
+	T069D3			2020				
+	T069D4			2024				
+								
+	T071		F	1980	Bonkers	A lobtailing female...???	Dena Matkin	
+D	T071A		F	1995	Hopkins	John Hopkins Inlet and Glacier	Dena Matkin	
+	T071C			2007	Jared	Jared Towers our ID man	Dena Matkin	Open to renaming (depending on gender)
+	T071D			2011	Heise	Researcher and Mom Kathy Heise	Dena Matkin	
+	T071E			2017	Sutton	For Gary Sutton	Dena Matkin	
+								
+	T071B		F	2000	Hood	Hood Canal	Dena Matkin	
+	T071B1			2013	Zengo	Careful thought to the future	Dena Matkin	
+	T071B2			2018	Tasli	for Tasli Shaw	Dena Matkin	
+	T071B3			2024				
+								
+	T072	AQ2	M	1974	Young	Island in Glacier Bay	Dena Matkin	
+								
+	T073		F	<1969	Doris	Doris Haskell (Mom)	Dena Matkin	
+	T074	AQ32	M	1979	Andy Bigg	Mike's father Andy Bigg	Dena Matkin	
+	T073D			2005	Steve	Researcher Steve Lewis	Dena Matkin	Open to renaming (depending on gender)
+								
+	Known as the Sea Monster Family							
+	T073A		F	1987	Nessie/Greg	For the Loch Ness monster/Researcher and teacher Greg Streveler	Orca Behavior Institute/Dena Matkin	Renamed due to being female; family theme to follow suit
+	T073A1		M	2005	Caddy/Paws	short for 'Cadbororsaurus,' a PNW sea serpent/Their pectoral fins are like paws	Orca Behavior Institute/Dena Matkin	
+	T073A2			2010	Ogopogo/Trites	First Nation's folklore of a lake monster that is said to inhabit Okanagan Lake in BC/Researcher Andrew Trites	Orca Behavior Institute/Dena Matkin	
+	T073A3			2015	Champ/Jessica*	Indigenous legends about a large creature inhabiting Lake Champlain/?*	Orca Behavior Institute/Dena Matkin	
+								
+	T073B	AQ35	M	1991	Blur/Kwénis	Too fast to photograph/K'ómox First Nations word for the Comox Glacier meaning whale. This name was also verified with the First Nations band.	Dena Matkin/Nicky Smiley (Transient/Bigg's Orca Nick Naming page) 	Dena also believes T103 may be the father of this whale
+								
+	T073C		F	1998	Vicky	Dedicated environmentalist	Dena Matkin	
+	T073C1			2012	Guba	Powerful storm	Dena Matkin	
+	T073C2			2021				
+								
+	T075	AQ3	F	≤1971	Kidney	Island in Wilderness Waters	Dena Matkin	
+	T075A	AQ9	M	1991	Stone	Island near Kidney	Dena Matkin	
+								
+	T075B	AQ15	F	1995	Pebbles	Smaller than Stone	Dena Matkin	
+D	T075B1		F	2007	Scars	Lines all over body	Dena Matkin	
+	T075B2			2015	Jasper/Fifi	Keeps in line with moms name Pebbles and is a beautiful semi-precious pebble found on on the beaches in their home range!/Nickname for Findlay Kilcher	Sarah McCullagh (Transient/Bigg's Orca Nick Naming Page) /Dena Matkin	
+	T075B3			2017	Rubble/Kasnikyu*	keeping with Flintstone theme of family names so far, (Barney and Bettys last name)	Ang Nicholson (Transient/Bigg's Orca Nick Naming Page)/Dena Matkin	
+	T075B4			2021	Petra	Greek meaning: rock or stone, associated with strength; some of her rake marks are columnar like the main architectural structure in Petra, Jordan	Kelly Dawson & Padmini Harchandrai (Transient/Bigg's Orca Nick Naming Page)	
+								
+	T075C			1998	Bam-Bam	When orcas hit the water	Dena Matkin	
+D	T075C1			2017	Carlos*		Dena Matkin	
+D	T075C2			2019	Gavin*		Dena Matkin	
+	T075C3			2021	Flint	Short for "Flintstone" - following family theme name	Elizabeth Zwamborn (Transient/Bigg's Orca Nick Naming Page)	
+	T075C4		M	2023	Slate	After Mr. Slate (Fred Flintstone's boss) and a dark metamorphic rock	Elizabeth Zwamborn & Monika Wieland Shields (Transient/Bigg's Orca Nick Naming Page)	
+								
+	T077	AQ7	F	≤1981	Asja	Eva's Latvian grandmother	Dena Matkin	
+PD	T077A		M	1996	Eva/Saulitis	Pay tribute to Eva Saulitis	Dena Matkin /TransientBigg's Nick Naming Page	Wanted to keep the tribute to Eva but wanted a name more appropriate to a male
+D	T077B			2000	The Chuch	Eva's neice...?	Dena Matkin	
+	T077C		M	2006	Neftali	Chilean revolutionary poet-struggle	Dena Matkin	
+	T077D		F	2009	Alcyon	God of calm water	Dena Matkin	
+	T077E			2016	Misneach	stay with the boat in Scottish	Dena Matkin	
+								
+	T085		F	≤1977	Eve	Dena's daughter	Dena Matkin	
+D	T085A		M	1992	Zoe	Egg of life	Dena Matkin	
+	T085B		M	1995	Alison/Ali	Powerful child; "Ali" shortened for male name	Dena Matkin	
+D	T085C			2005	Jasmine	Sweetness	Dena Matkin	
+	T085D			2014	Farenorth/*Findlay Farenorth	Dena's Grandson	Dena Matkin	
+								
+	T086A	AL15	F	1988	Eider	Island in Glacier Bay	Dena Matkin	
+	T086A1		F	2001	Nahanni	Wild river in British Columbia	Dena Matkin	
+D	T086A1A			2019				
+	T086A1B			2023	Denali	highest mountain peak in North America (Alaska), Indigenous peoples of Alaska have revered Denali, considering it a sacred place.	Ryatt Moore (Transient/Bigg's Orca Nick Naming Page)	
+	T086A3		F	2011	Tyndall	Deep hidden cove in Glacier Bay; the scattering of light by small suspended particles in a colloid or fine suspension, making the light beam visible	Dena Matkin	
+	T086A3A			2024	Tenakee	(tuh-NAH-key) for Tenakee Springs where the Tlingit say they lost three shields in a storm - saddle patch sort of has a shield profile shape to it	Ellie Sawyer (Transient/Bigg's Orca Nick Naming Page)	
+	T086A4		F	2016	Akia	associated with strength and resilience, symbolizing a powerful and determined individual	Dena Matkin	
+	T086A5		M	2024	Siku	Inuit word for "sea ice." Eyepatches resemble chunks of pack ice	Elizabeth Zwamborn (Transient/Bigg's Orca Nick Naming Page)	
+								
+	T087	AO1	M	≤1962	Harbeson	Old hermit in Dundas Bay	Dena Matkin	
+								
+	T090	AO4	F	1980	Eagle	Black and white predator	Dena Matkin	
+	T090B		M	2006	Piglet	Winnie the Pooh's friend	Dena Matkin	
+	T090C		F	2010	Tigger	Pooh's Bouncy Friend	Dena Matkin	
+	T090D		F	2017	Kanga		Dena Matkin	
+								
+	T091		F	≤1959	Sebree	Cove in Glacier Bay	Dena Matkin	
+								
+PD	T093	AH1	M	≤1964	Joanna	Mentor Joanna Hughes	Dena Matkin	
+								
+	T097	AH5	M	1980	Gull	Cove in Icy Strait	Dena Matkin	
+								
+	The Gretzky's							
+	T099	AM34	F	≤1984	Bella	For Bella Coola in British Columbia	Dena Matkin	
+D	T099A			2003	Kirk	Smart brother Kirk Haskell	Dena Matkin	
+	T099B		F	2007	Holly	Powerful woman	Dena Matkin	
+	T099B1?			2024				
+	T099C		M	2009	Barakat	spiritual wonderfulness	Dena Matkin	
+	T099D		M	2015	Puck	We often refer to this family as “the gretzkys” so we gotta have a hockey reference in there at some point!? Also, double meaning, “Puck” from Shakespeare’s “A midsummers nights dream” is considered a little mischievous character, which 99D really is	Gary Sutton (Transient/Bigg's Orca Nick Naming page)	
+	T099E		F	2021	Qwiin qwiin oo qwii la	 (pronounced kwin kwin oh kwee la) means - "breath you see when a killer whale exhales at the surface)	named by the Tulalip Tribe -Ray Fryberg's wife Sheryl Nuchanulth	
+								
+	T100	AL41	F	≤1979	Hutchins	Bay deep inside Wilderness Waters	Dena Matkin	
+	T100C		M	2002	Laurel	Best friend	Dena Matkin	
+	T100E		F	2009	Tharaya	she who illuminates the world	Dena Matkin	
+	T100F			2014	Estrella	Of the stars in the sky	Dena Matkin	Open to renaming (depending on gender)
+								
+	T100B		F	1997	Freya	Norse goddess of fertility	Dena Matkin	
+	T100B1			2010	Seidr	(SAY-der) - Norse magic related to shaping and telling the future; Freya was the Goddess of Seidr	Monika Wieland Sheilds (Transient/Bigg's Orca Nick Naming Page)	
+D	T100B2			2017	Potnia	Minoan goddess of birth	Dena Matkin	
+	T100B3			2024	Selkie	Celtic and Norse folklore name for "seal folk," Irish name for "mermaids." T100B3's right eye patch resembles a pinniped.	Julie Massa (Transient/Bigg's Orca Nick Naming Page)	
+								
+	T101	AL42	F	<1969	Reef	Harbor seal refuge	Dena Matkin	
+D	T102		M	1984	Beardslee	Beardslee Islands Wilderness Waters	Dena Matkin	
+	T101A	AL45	M	1993	Rush	Point of many tide rips in Glacier Bay	Dena Matkin	
+	T101B		M	1997	Lagoon	Island in Glacier Bay	Dena Matkin	
+								
+	T103	AM23	M	≤1968	Stephens	Passage in southeastern Alaska	Dena Matkin	
+								
+	T109		F	≤1977	Noyes/Big Momma	SE Alaska placename/	Dena Matkin/SIMRS	
+	T109D		F	2007	Eivin	Island Wind in Icelandic	Dena Matkin	
+	T109D1			2018	Tazzie	Tasmanian Devil	Dena Matkin	
+	T109D2			2021				
+	T109E		M	2013	Yoda		Dena Matkin	
+								
+	Known as the Runaway's							
+	T109A		F	1990	Frio/Runaway	Cold in Spanish/America, all-female rock band	Dena Matkin/SIMRS	
+D	T109A3		F	2009	Spong	Acoustics researcher Paul Spong	Dena Matkin	*live stranded & drowned near Zeballos, BC 3.23.2024
+	T109A3A		F?	2022	Kʷiisaḥiʔis	the First Nation has named  kʷiisaḥiʔis, which means ‘Brave Little Hunter’.	received name from the Ehattesaht Nation.	
+	T109A4		M	2012	Garrett	Researcher Howard Garrett	Dena Matkin	
+	T109A5			2014	Argyle	for the Argyle islets in Beecher Bay	Brendon Bissonnette (Transient/Bigg's Orca Nick Naming page)	
+	T109A6			2018	Riley	for a cove near the area we witnessed their birth! is within Clayoquot Sound, an area where they are frequent visitors.	Marcie Callewaert John (Transient/Bigg's Orca Nick Naming page)	
+	T109A7			2021	Wieland	named in honor of Monika Wieland Shields, orca researcher	Rebecca Berger (Transient/Bigg's Orca Nick Naming page)	
+	T109A8			2024	Weiss	named in honor of Michael Weiss, orca researcher	Monika Wieland Shields (Transient/Bigg's Orca Nick Naming page)	
+								
+	T109A2		F	2005	Fuser	Nickname for Che Guevara	Dena Matkin	
+	T109A2A		M	2016	Seekah	for Seekah Passage near Bamfield	Brendon Bissonnette (Transient/Bigg's Orca Nick Naming page)	
+	T109A2B		F	2018	Macoah	for Macoah Passage near Ucluelet	Brendon Bissonnette (Transient/Bigg's Orca Nick Naming page)	
+	T109A2C		F	2021	Keeha	for Keeha Beach just S of Bamfield	Brendon Bissonnette (Transient/Bigg's Orca Nick Naming page)	
+	T109A2D		M	2023	Cordova	for Cordova Bay, and rhyming with siblings names ending in “-ha” and “-ah”	Brendon Bissonnette (Transient/Bigg's Orca Nick Naming page)	
+								
+	T109B		F	1996	Sem	psyche	Dena Matkin	
+	T109B3		F	2013				
+	T109B4			2015				
+	T109B5			2018				
+	T109B6			2024				
+								
+	T109C		F	2002	Boca	Mouth or Bay in Spanish	Dena Matkin	
+	T109C1			2012				
+	T109C2			2017				
+	T109C3			2022				
+								
+?	T112		F	≤1974				Not in the Catalogue
+?	T114		M	1975				Not in the Catalogue
+								
+	T111		F	≤1975				Not in the Catalogue
+	T111A		F	1990				Not in the Catalogue
+	T111A1			2006				Not in the Catalogue
+	T111B		F	2000				Not in the Catalogue
+	T111B2			?				*sighted for first time in Sept 2024
+	T111B3			?				*sighted for first time in Sept 2024
+	T111C			2007				Not in the Catalogue
+								
+D	T115		F	<1974				
+	T113		M	≤1975				
+								
+	T116				Sandy 		Dena Matkin	Not in the Catalogue/Not on Finwave
+	T116A				Sturgess		Dena Matkin	Not in the Catalogue/Not on Finwave
+	T116B				Garforth		Dena Matkin	Not in the Catalogue/Not on Finwave
+								
+	T117		F	<1976				
+	T120		M	1986				
+								
+	T117A		M	1992				
+								
+	T117B		F	2005				
+	T117B1			2023				
+								
+PD	T118		F	<1960				
+	T070		M	1970				
+								
+	T121A		F	1998				
+D	T121A1			2015	Fortune	For Fortune Channel where they were born	SIMRS	Born June 10th
+	T121A2			2018				
+	T121A3			2024				
+								
+	T123		F	1985	Sidney	Sidney Island off the east side of southern Vancouver Island	VanAqua	
+	T123A		M	2000	Stanley	Stanley Park in downtown Vancouver	VanAqua	
+	T123C		F	2012	Lucky	Lucky Creek which flows into Clayquot Sound	VanAqua	
+	T123D		F	2018	D'Arcy	D'Arcy Shoals off the south coast of Vancouver Island	VanAqua	
+								
+D	T124		F	≤1967	Myrtle (Fertile Myrtle)	Now a great-grandmother!	Dena Matkin	
+	T124C	AL18	M	1992	Cooper	Glacier Bay Researcher William Cooper	Dena Matkin	
+								
+	T124A		F	1984	Kittiwake	Black and white gulls in colonies	Dena Matkin	
+D	T124A3		F	2006	Wasini	Island in the Indian Ocean	Dena Matkin	
+D	T124A3A		M	2019	Spindrift/Alethia*	the spray blown from the crest of waves by the wind /truth	Ashley Keegan (Transient/Bigg's Orca Nick Naming page)/Dena Matkin	
+	T124A4		F	2010	Sabio	Wise one	Dena Matkin	
+	T124A4A		F	2021	Strix	Genus of owls, symbol of wisdom, knowledge, and intuition . "S" stays with mom's name "Sabio," as does the wisdom/intuition component. Owls keep with some of the bird names of this family group.	Amanda Marie Colbert (Transient/Bigg's Orca Nick Naming page)	
+	T124A6		M	2016	Kasuun	beautiful	Dena Matkin	
+	T124A7		F	2021	Kite	Beautiful black and white raptor (to go with 'Kittiwake'). Eyepatches look like a toy kite, and the word "kite" aligns with the K theme of her mom and brother.	Yifan Ling (Transient/Bigg's Orca Nick Naming page)	
+								
+	T124A1		F	1996	Bonapartes	Another black and white gull	Dena Matkin	
+	T124A1A			2024	Sabine	Sabine’s gulls look similar to Bonaparte’s gulls, and also shares the first four letters of T124A4’s name “Sabio”. A fitting tribute to both females. Sabine also relates to the sound of Sabio's name. Can be pronounced Suh-bee-nah or Sa-ben.	Sara Hysong-Shimazu & Donna Green Van Renselaar (Transient/Bigg's Orca Nick Naming page)	*Traveling with T124A4 for bulk of 2024; still with T124A4 in early 2025
+								
+	T124A2		F	2001	Elkugu	Island in southeastern Alaska	Dena Matkin	
+	T124A2A		M	2013	Agafia	Hardworking Russian woman	Dena Matkin	
+	T124A2B		F	2016	Litton	Photographer Jeff Litton	Dena Matkin	
+								
+	T124D		F	1996	Field	Glacier Bay Researcher Bill Field	Dena Matkin	
+	T124D1			2014	Salish II	because Jared Towers at the Pacific Biological Station in Nanaimo (who I send all my transient data to for final identification) had told me about the T124's frequent presence in the Salish Sea.	Dena Matkin	
+D	T124D2			2017	Seretse	Beloved African leader	Dena Matkin	
+	T124D3			2021	Lupine	a PNW native wildflower, playing off Field and Myrtle	Kelly Dawson (Transient/Bigg's Orca Nick Naming page)	
+	T124D4			2024	Dune	first sighted near Dune Peninsula on Dec 11 2024, the word "Dune" has a similar vibe as T124D's name "Field".	Yifan Ling (Transient/Bigg's Orca Nick Naming page)	
+								
+D	T124E		M	1999	Murk	Congressional rogue...???	Dena Matkin	
+								
+								
+	T125	AV52	F	<1979				
+	T127	AV53	M	1984				
+	T128	AV51	M	1988	Flotsam	one of Ursula's eel henchmen	Pascale Campagna-Slater (Transient/Bigg's Orca Nick Naming page)	
+	T125A			1998	Jetsam	one of Ursula's eel henchmen	Pascale Campagna-Slater (Transient/Bigg's Orca Nick Naming page)	
+								
+?	T131		F	≤1982				Not in Catalogue
+?	T129	CA52	M	≤1971				Not in Catalogue
+?	T130	CA59	M	≤1971				Not in Catalogue
+								
+	T132	AO10/CA20	M	<1969	Scott	Humpback whale researcher Scott Baker	Dena Matkin	
+?	T133	CA18			Finn		Dena Matkin	Not in Catalogue
+	T134	CA54		≤1959	Jan		Dena Matkin	
+?	T135	CA27			Dawn		Dena Matkin	Not in Catalogue
+								
+	T137		F	1984	Loon	I have observed transients use seabirds such as loons to teach their young hunting skiils.	Dena Matkin	
+	T137A		M	2002	Jack/Barb	For inappropriately using the jet wash of boats to feel good and taking on 2 grey whales all by himself/ For Dena's sister Barbara who died of cancer	Jilann Campbell/Dena Matkin	
+	T137B		F	2006	Tempest	Terry Tempest Williams writes beautifully about environmental toxins that harm all living things. The sea can quickly go from calm into a wild tempest.	Dena Matkin	
+	T137D		F	2012	Wright	Mt. Wright in Glacier Bay	Dena Matkin	
+								
+	T139		F	<1973				
+	T141		F	1989				
+D	T141A			2004				
+	T141B			2012				
+	T141C			2017				
+								
+	T140		F	≤1983				
+	T140B		M	2004				
+	T140C			2008				
+								
+?	T143		F	<1978	Ian	Canadian cowboy singer Ian Tyson	Dena Matkin	Not in Catalogue/not on Finwave
+?	T142		M	≤1967	Ty/Tyeen	Tyeen Glacier in Glacier Bay	Dena Matkin	Not in Catalogue/not on Finwave
+								
+	T146		F	1987	Oamaru	Place in New Zealand	Dena Matkin	
+	T146A		F	1999	Oma	A friend's grandmother	Dena Matkin	
+	T146A1			2018				
+	T146A2			2023				
+	T146B		M	2002	Chiloe	Island in Chile	Dena Matkin	
+	T146C		F	2004	Svaha!	cry of joy or excitement	Dena Matkin	
+	T146C1			2019				
+	T146D			2008	Leah	Aussie woman	Dena Matkin	Open to renaming depending on gender
+D	T146E			2011	Basho	Wild ancient poet	Dena Matkin	
+								
+PD	T147		F	<1965				
+PD	T148		M	≤1975				
+?	T149			1992				Not in Catalogue/not on Finwave
+								
+								
+								
+								
+	T151		F	<1980	Capricho	Capricious in Spanish	Dena Matkin	
+	T150		M	1990	Mardy	Margaret Murie	Dena Matkin	
+	T151A		F	2005	Batalla	Southeastern Alaska placename	Dena Matkin	
+	T151A1			2019				
+	T151B			2010	Pelagia	Of the sea	Dena Matkin	
+	T151C			2014				
+	T151D			2019				
+								
+	T152		F	1995				
+	T152A			2012				
+	T152B			2018				
+	T152C			2022				
+								
+	T157		F	1990				Not in Catalogue
+								
+?	T160	CA28	M	≤1972				Not in Catalogue
+								
+?	T161	CA38	F					Not in Catalogue
+								
+	T162		M	≤1972	Sitka	Southeastern Alaska placename	Dena Matkin	
+								
+	T166		F	≤1966	Hobart*		Dena Matkin	
+	T165		M	≤1976	Thatcher*		Dena Matkin	
+	T166A		F	1994	Gusty*		Dena Matkin	
+	T166A1			2012				
+								
+	T167		F	1992	Walpole*		Dena Matkin	
+	T167A		M	2010	Doniol*	Thomas Doniol-Valcroze	Dena Matkin	
+	T167B			2015	Valcroze*	Thomas Doniol-Valcroze	Dena Matkin	
+	T167C		F	2020				
+								
+	T168A		F	1992	Bean	Southeastern Alaska placename	Dena Matkin	
+	T168A1			2013				
+	T168A2			2021				
+								
+?	T169		M	1978	Chacon	Southeastern Alaska placename	Dena Matkin	Not in Catalogue/Not on Finwave
+								
+PD	T170		M	≤1974	Capilano	Capilano was a Musqueam warrior and the name would also closely tie in to the local area (Capilano suspension bridge, UBC, etc.)	Sara Hysong-Shimazu (Transient/Bigg's Orca Nick Naming Page)	
+								
+D	T171		F	<1984				
+								
+	T172		F	1989	Katmai	for the national park in Alaska	Brendon Bissonnette (Transient/Bigg's Orca Nick Naming page)	
+								
+PD	T173		F	<1972				
+	T175		M	1982				
+								
+	T174		F	≤1988	Dixon	Dixon Entrance	Dena Matkin	
+	T174A		F	1998	Solita	Woman alone in Spanish	Dena Matkin	
+	T174A1			2015				
+	T174A2			2019				
+	T174B		F	2005	Jitterbug John	Enthusiastic field assistant	Dena Matkin	open to dropping the John... 
+D	T174B1			2019				
+D	T174C			2015				
+								
+	T176		F	1994				
+	T176A			2007				
+	T176B			2013				Is the animal in the catalogue listed as T176B b. 2013 actually T176C? also in SIMRS as 2009 calf
+								
+?	T177	AT30			Chubby Rain		Dena Matkin	Not in Catalogue/Not on Finwave
+?	T178	AT32			Heavy Rain		Dena Matkin	Not in Catalogue/Not on Finwave
+								
+	T179	AT74	F	1984	Kimshan		Dena Matkin	Not in Catalogue
+	T179A	AT74A		1999	Islet		Dena Matkin	Not in Catalogue
+	T179B			2010				Not in Catalogue
+								
+	T180	U41	M	1989	Cecil		Dena Matkin	Not in Catalogue
+								
+?	T181				Pacific		Dena Matkin	Not in Catalogue/Not on Finwave
+?	T181A				Tasman		Dena Matkin	Not in Catalogue/Not on Finwave
+?	T182				Alexandra	Researcher Alexandra Morton	Dena Matkin	Not in Catalogue/Not on Finwave
+?	T183				Spencer		Dena Matkin	Not in Catalogue/Not on Finwave
+?	T183A				Oceania		Dena Matkin	Not in Catalogue/Not on Finwave
+?	T184				Biorka		Dena Matkin	Not in Catalogue/Not on Finwave
+								
+	T185		F	≤1983				Not in Catalogue
+	T186		M	1995				Not in Catalogue
+	T187			1999				Not in Catalogue
+	T185A			2007				Not in Catalogue
+								
+?	T188	U47			Dorothy		Dena Matkin	Not in Catalogue/Not on Finwave
+?	T188A	U48			Craig		Dena Matkin	Not in Catalogue/Not on Finwave
+								
+	T196	CA154	F	UNK				Not in Catalogue
+	T197	CA079	M	UNK				Not in Catalogue
+								
+	T199		F	1993				
+	T199A			2008				
+	T199B			?				*First sighting in 2023
+	T199C			?				*First sighting in 2023
+								
+	T221B	CA171B	M	1997				Not in Catalogue
+								
+	T223		F	≤1966				
+	T224		F	1998				
+	T224A			2013				
+D	T224B			2017				
+	T225			2003				
+								
+	T227		M	≤1984				
+								
+	T252	CA173	F	≤1972				
+	T251	CA166	M	1982				
+	T250	CA172	F	1989				
+	T250C	CA172C		2017				
+	T250D	CA172D						
+	T253		F	2001				
+	T253A			2019				

--- a/docs/rights-policy.md
+++ b/docs/rights-policy.md
@@ -424,6 +424,25 @@ Phase 5 owns:
 
 ---
 
+## 7. Reference & Catalog Source Rights
+
+*Governs rights for external **reference/catalog** sources mirrored as ingest inputs — distinct from the occurrence-record redistribution question in §4. Added 2026-07-07.*
+
+### 7.1 Bigg's Killer Whale Designation & Nickname Sheet (D-21)
+
+**Source.** The community-maintained Google Sheet "Bigg's Orca/Killer Whale Nick Names" (maintainer `vitalocean@gmail.com`, the curator behind the "Transient/Bigg's Orca Nick Naming Page"). Mirrored at [`data/biggs-ids.tsv`](../data/biggs-ids.tsv); provenance and refresh notes in [`data/README.md`](../data/README.md).
+
+**Determination (D-21).** The **factual** content is not subject to copyright (facts are uncopyrightable — *Feist v. Rural*) and is what we use: local (BC/WA) and regional (Alaska/California) designations, genealogy (matriline / mother), birth years, sex, deceased status, the naming authority, and the *etymological facts* recorded in the story column (e.g. an animal "named for Pedder Bay, where the T2s were held captive in 1970"). These may be mirrored, stored in the individuals/subjects catalog, and surfaced in the app.
+
+**Two carve-outs preserved:**
+
+1. **Creative prose.** A minority of story cells contain original expression (short essays, personal narrative) that carries a thin copyright as authored text. Where we surface such an entry, we **state the underlying fact in our own words** rather than reproduce the passage verbatim.
+2. **Compilation.** The selection and arrangement of the sheet is the maintainer's compilation. We do not republish the sheet wholesale as a product; the mirror is an internal baseline for change-detection and seeding. The maintainer / naming page is **credited** as the source of nickname provenance wherever nickname or story facts are surfaced — this credit rides on the naming-authority (`parties`) in the catalog model.
+
+**Scope note.** This is an **ingest-side reference source**, not an occurrence-record redistribution question. If catalog/individual data derived from it is ever *exported* (e.g. a validated `organismID` to GBIF/OBIS), that export gets its own rights pass at that time — §7 authorizes internal use and in-app surfacing, not third-party redistribution of the compilation.
+
+---
+
 ## Decision Index
 
 All D-numbers are cited in the sections above. For reference:
@@ -450,11 +469,13 @@ All D-numbers are cited in the sections above. For reference:
 | D-18 | 6.4 | Publisher = SalishSea.io (organizational); Contact = Peter Abrahamsen (individual); contact email lives in `dwc.datasets`, not this document |
 | D-19 | 1.2, 1.4 | `license_code = 'none'` and `IS NULL` are semantically distinct (`none` = "no license" terminal; NULL = "unknown" non-terminal); both excluded in v1.2; Phase 5 emits separate CASE branches |
 | D-20 | 1.1, 2.2, 3.2, 4.1–4.5 | Per-record `license` is per-source: native = CC-BY-NC 4.0; Maplify = CC-BY 4.0 (asserted upstream at Acartia cooperative). Resolves the rights gate for the Maplify branch; reframes §4 conferral as courtesy + reframes D-05 hold as data-QA gate. |
+| D-21 | 7.1 | Bigg's reference sheet: factual content (designations, genealogy, nickname etymology) is uncopyrightable and used freely; creative story prose stated as fact, not reproduced; compilation credited, not republished; ingest-side reference — any future export gets its own rights pass. |
 
 ---
 
 *Policy authored: 2026-06-10*
 *§6 (Dataset Identity & EML Content) added: 2026-06-17*
 *D-19 (NULL ≠ none semantics) and D-20 (per-source license, Acartia CC-BY for Maplify) added: 2026-06-17*
+*§7 (Reference & Catalog Source Rights) and D-21 (Bigg's reference sheet) added: 2026-07-07*
 *Phase: 04-rights-data-model-policy-gate*
 *Document home: `docs/rights-policy.md` (authored as `.planning/phases/04-rights-data-model-policy-gate/04-POLICY.md` in the v1.2 policy-gate phase; moved here in the 2026-07 GSD migration)*


### PR DESCRIPTION
## What

Commit a byte-for-byte mirror of the community-maintained **"Bigg's Orca/Killer Whale Nick Names"** Google Sheet as a diffable baseline, and record the rights determination that lets us use it.

- **`data/biggs-ids.tsv`** — the mirror, in a new `data/` home for external reference sources.
- **`data/README.md`** — provenance (source sheet, maintainer `vitalocean@gmail.com`, retrieved 2026-07-07 / upstream last modified 2025-07-01), rights summary, and refresh/diff instructions.
- **`docs/rights-policy.md`** — new **§7 (Reference & Catalog Source Rights)** and decision **D-21**.

## Why

The sheet is the authoritative source for Bigg's designations, genealogy, and nickname provenance, but exposes no edit history. Committing a mirror gives every future re-export a reference point to diff against, so we can *detect* upstream changes and decide per-change how to reconcile.

## Rights (D-21)

The **factual** content — designations, genealogy, birth years, sex, deceased status, naming authority, and nickname etymology — is not copyrightable and is what we use. Two carve-outs: creative story prose is stated as fact, not reproduced verbatim; and the compilation is credited to its maintainer, not republished wholesale. This is an ingest-side reference source; any future *export* of derived catalog data gets its own rights pass.

## Follow-up

Refresh policy + seeding the individuals/subjects catalog from this sheet is tracked in bd `salishsea-io-551` (depends on `salishsea-io-fub`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for mirrored reference data, including where it comes from, how it’s maintained, and how to refresh it consistently.
  * Expanded rights-policy notes for external reference and catalog sources, clarifying how factual content and quoted prose are handled.
  * Updated policy tracking to include the new reference-data decision and document metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->