### PR TITLE
Individual profile pages at /individuals/<designation>

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,12 +92,12 @@ Node version is pinned in `.nvmrc`. The DwC-A build's CI gate needs the Supabase
 
 ## Architecture Overview
 
-Static SPA (Lit web components + Vite + TypeScript, OpenLayers maps) on AWS S3/CloudFront, Supabase backend (Postgres + auth + storage), AWS CDK infra in `infra/`, deployed by GitHub Actions on push to `main`. A Lambda@Edge function serves OG meta tags to crawlers for rich link previews (fail-open; `/dwca/*` carved out). A nightly workflow regenerates the DarwinCore Archive from the read-only `dwc` Postgres schema. Details: [docs/decisions/](docs/decisions/), [docs/data-provenance.md](docs/data-provenance.md).
+Static SPA (Lit web components + Vite + TypeScript, OpenLayers maps) on AWS S3/CloudFront, Supabase backend (Postgres + auth + storage), AWS CDK infra in `infra/`, deployed by GitHub Actions on push to `main`. A Lambda@Edge function serves OG meta tags to crawlers for rich link previews and rewrites `/individuals/<designation>` profile-page paths to the `individual.html` shell (fail-open; `/dwca/*` carved out; decision 015). A nightly workflow regenerates the DarwinCore Archive from the read-only `dwc` Postgres schema. Details: [docs/decisions/](docs/decisions/), [docs/data-provenance.md](docs/data-provenance.md).
 
 ## Conventions & Patterns
 
 - Coordinates: decimal lon/lat WGS84, map projection EPSG:3857. Time: UNIX epoch seconds.
-- URL state: `d` (date), `x/y/z` (map), `o` (occurrence).
+- URL state: `d` (date), `x/y/z` (map), `o` (occurrence); `/individuals/<designation>` for profile pages.
 - Migrations: SELECT grants ship in the same migration that creates a table (Supabase RLS defaults silently zero out joins otherwise).
 - `maplify.sightings.comments` is immutable — parse at read time, never UPDATE it.
 - Keep the project "light, nimble, and maintainable, minimizing abstractions and volatile dependencies" (README).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,7 +19,7 @@ Shared vocabulary for SalishSea.io. Use these terms as defined here, in code and
 
 ## Individuals
 
-- **Individual** *(planned)* — a specific animal in **our own authoritative catalog** (designation e.g. `T065A`, aliases, species, matriline/pod). Distinct from the `happywhale.individuals` **Upstream mirror** and from **candidate identifiers** — both are *inputs*, never the source of truth (decision 008).
+- **Individual** — a specific animal in **our own authoritative catalog** (`public.individuals`: designation e.g. `T065A`, aliases, species, matriline/pod). Distinct from the `happywhale.individuals` **Upstream mirror** and from **candidate identifiers** — both are *inputs*, never the source of truth (decision 008). Each has a profile page at `/individuals/<designation>` (decision [015](docs/decisions/015-individual-profile-pages.md)).
 - **Identification** — a *claim* linking an occurrence to an Individual (or group), each with decomposed provenance: subject, presence/absence, **evidence** (text mention / photo / CV match / field obs), **method** (how we captured it), **status** (candidate / validated / rejected), and asserting authority. Lives in `public.identifications`; regex hits enter as `candidate`/`text_mention` and are one input among curated/CV claims. Trust is governed by decision [014](docs/decisions/014-trust-and-curation-model.md).
 - **Status** (of a claim) — its trust level: `candidate` (unvalidated, e.g. a regex mention), `validated`, or `rejected`. Set by a curator; a stored claim overrides the raw candidate for the same occurrence+subject. Vocabulary may grow (decision 014).
 - **Reputation** *(planned)* — a party's standing that weights how much their claims are trusted. Not yet modeled (decision 014).

--- a/database.types.ts
+++ b/database.types.ts
@@ -671,6 +671,7 @@ export type Database = {
             | null
           individual_id: number | null
           is_present: boolean | null
+          location: Database["public"]["CompositeTypes"]["lon_lat"] | null
           observed_at: string | null
           occurrence_id: string | null
           status: Database["public"]["Enums"]["identification_status"] | null

--- a/database.types.ts
+++ b/database.types.ts
@@ -663,6 +663,21 @@ export type Database = {
       }
     }
     Views: {
+      individual_occurrences: {
+        Row: {
+          code: string | null
+          evidence:
+            | Database["public"]["Enums"]["identification_evidence"]
+            | null
+          individual_id: number | null
+          is_present: boolean | null
+          observed_at: string | null
+          occurrence_id: string | null
+          status: Database["public"]["Enums"]["identification_status"] | null
+          via_group: string | null
+        }
+        Relationships: []
+      }
       occurrence_identifications: {
         Row: {
           asserted_by_party_id: number | null

--- a/docs/decisions/015-individual-profile-pages.md
+++ b/docs/decisions/015-individual-profile-pages.md
@@ -25,23 +25,34 @@ weaker for sharing/SEO — the whole point of the page is to be a reason to visi
 ### Read path: one view, live resolution
 
 A new `public.individual_occurrences` view flattens `occurrence_identifications`
-to one row per (individual, occurrence), reaching every **current member** of a
-group named in a group claim (`via_group` labels the weaker inference). One
-PostgREST filter on `individual_id` powers both the recent-sightings list and
-the presence-by-month grid. Resolution stays **live** (regex over sighting text
-at read time, ~2s/query on prod) — acceptable for an async page section today;
-indexing candidates ahead of time is deliberately deferred until the live path
-actually hurts (bd `salishsea-io-*`, see follow-ups).
+to one row per (individual, occurrence, location), reaching every **current
+member** of a group named in a group claim (`via_group` labels the weaker
+inference). One PostgREST filter on `individual_id` powers the whole sightings
+section: a presence-by-month grid plus a **static map** of everywhere the
+animal has been reported (most recent emphasized; dots click through to the
+main map on that day). Re-rendering `<obs-summary>` rows was tried and
+rejected — a wall of borrowed sighting cards read poorly on a profile.
+Resolution stays **live** (regex over sighting text at read time, ~2s/query on
+prod) — acceptable for an async page section today; indexing candidates ahead
+of time is deliberately deferred until the live path actually hurts (bd
+`salishsea-io-be4`).
 
 ### Honesty invariant carried to the UI
 
-Per decisions 008/014 and the rights policy, regex-derived links are presented
-as **"unverified mention"** (with "mentioned as `<group>`" for via-group rows);
-only `validated` claims render as verified. Absence claims and `rejected`
-identifications are excluded from the page. Identifier codes in sighting text
-site-wide become links to profile pages (`injectIndividualLinks`) — a
-navigation aid, never an identification claim; matriline (`…s`) and
-non-catalog codes stay plain text.
+Per decisions 008/014 and the rights policy, the sightings section states that
+its counts are mostly **unverified mentions** in sighting text (with "as
+`<group>`" when the latest link is a via-group inference). Absence claims and
+`rejected` identifications are excluded from the page. Identifier codes in
+sighting text site-wide become links to profile pages
+(`injectIndividualLinks`) — a navigation aid, never an identification claim;
+matriline (`…s`) and non-catalog codes stay plain text.
+
+Per **D-21** (rights-policy §7.1), nickname *stories* and `individuals.notes`
+are verbatim Bigg's-sheet cells, a minority of which are creative prose — they
+are **not rendered**, and the `nicknames.story` column is revoked from the
+anon/authenticated API roles (column-level GRANT). Naming *facts* (name,
+namer, year, theme, status) remain public. Restoring stories requires either
+restating them as facts or securing permission.
 
 ## Consequences / follow-ups
 

--- a/docs/decisions/015-individual-profile-pages.md
+++ b/docs/decisions/015-individual-profile-pages.md
@@ -1,0 +1,55 @@
+# 015 — Individual profile pages
+
+**Status:** accepted (2026-07-07)
+**Context:** GitHub [#49](https://github.com/salish-sea/salishsea-io/issues/49); builds on the catalog (decision 014, migrations `20260707200852` / `20260707220211`).
+
+## Decision
+
+Give every catalog individual a full page at **`/individuals/<primary_designation>`**
+(e.g. `/individuals/T065A`), rendered client-side from a third Vite HTML entry
+(`individual.html` + `<individual-page>`), following the `about.html` precedent —
+no client-side router.
+
+### URL scheme: path-based, resolved at the edge
+
+CloudFront/S3 has no object at `/individuals/*`, so the existing viewer-request
+Lambda@Edge (`infra/lib/edge-handler`) rewrites those paths to `/individual.html`
+for humans and synthesizes catalog-driven OG meta for crawler user-agents (same
+fail-open contract as `?o=`; unknown designations get the generic site card).
+The Vite dev/preview servers mirror the rewrite via a small middleware in
+`vite.config.js`.
+
+*Rejected:* `individual.html?id=T065A` (no infra change, but unattractive and
+weaker for sharing/SEO — the whole point of the page is to be a reason to visit).
+
+### Read path: one view, live resolution
+
+A new `public.individual_occurrences` view flattens `occurrence_identifications`
+to one row per (individual, occurrence), reaching every **current member** of a
+group named in a group claim (`via_group` labels the weaker inference). One
+PostgREST filter on `individual_id` powers both the recent-sightings list and
+the presence-by-month grid. Resolution stays **live** (regex over sighting text
+at read time, ~2s/query on prod) — acceptable for an async page section today;
+indexing candidates ahead of time is deliberately deferred until the live path
+actually hurts (bd `salishsea-io-*`, see follow-ups).
+
+### Honesty invariant carried to the UI
+
+Per decisions 008/014 and the rights policy, regex-derived links are presented
+as **"unverified mention"** (with "mentioned as `<group>`" for via-group rows);
+only `validated` claims render as verified. Absence claims and `rejected`
+identifications are excluded from the page. Identifier codes in sighting text
+site-wide become links to profile pages (`injectIndividualLinks`) — a
+navigation aid, never an identification claim; matriline (`…s`) and
+non-catalog codes stay plain text.
+
+## Consequences / follow-ups
+
+- Matriline & pod (social-group) pages don't exist yet; group codes are
+  deliberately unlinked until they do.
+- Individual pages are not in `sitemap.xml` (it's built statically at deploy
+  time; the catalog lives in the DB).
+- Only Bigg's individuals are seeded; SRKW pages await the J/K/L catalog
+  ingest (bd `salishsea-io-lzi`).
+- Life events (births, deaths, notable sightings) have no schema — the page
+  shows `life_status` and birth-year ranges only.

--- a/e2e/og-previews.spec.ts
+++ b/e2e/og-previews.spec.ts
@@ -26,3 +26,28 @@ test('regular browser UA on homepage receives SPA', async ({ request }) => {
   // not the synthesized, empty-body bot preview page.
   expect(body).toContain('<salish-sea>');
 });
+
+test('bot UA on an individual page receives profile OG meta tags', async ({ request }) => {
+  const response = await request.get('/individuals/T065A', {
+    headers: { 'User-Agent': 'facebookexternalhit/1.1' },
+  });
+
+  expect(response.status()).toBe(200);
+  const body = await response.text();
+  expect(body).toContain('T065A');
+  expect(body).toContain('og:title');
+  expect(body).toContain('content="profile"');
+  expect(body).toContain('https://salishsea.io/individuals/T065A');
+});
+
+test('regular browser UA on an individual page receives the page shell', async ({ request }) => {
+  const response = await request.get('/individuals/T065A', {
+    headers: { 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36' },
+  });
+
+  expect(response.status()).toBe(200);
+  const body = await response.text();
+  // The viewer-request function rewrites /individuals/* to the individual.html
+  // shell (there is no S3 object at the path itself).
+  expect(body).toContain('<individual-page>');
+});

--- a/individual.html
+++ b/individual.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self';
+      script-src 'self';
+      style-src 'self' 'unsafe-inline';
+      img-src 'self' https: data:;
+      font-src 'self';
+      connect-src 'self' %VITE_SUPABASE_URL% %VITE_SUPABASE_WS_URL% https://o4509634382331904.ingest.us.sentry.io;
+      object-src 'none';
+      media-src 'self';
+      worker-src 'self';
+      base-uri 'self';
+      form-action 'none';
+      upgrade-insecure-requests;
+    ">
+    <title>Individual — SalishSea.io</title>
+    <meta name="description" content="Profile of an individual whale in the Salish Sea: names and naming stories, family, matriline, and recent sighting reports.">
+    <meta property="og:site_name" content="SalishSea.io">
+    <meta property="og:type" content="profile">
+    <meta property="og:title" content="Individual — SalishSea.io">
+    <meta property="og:description" content="Profile of an individual whale in the Salish Sea: names and naming stories, family, matriline, and recent sighting reports.">
+    <meta property="og:image" content="https://salishsea.io/preview.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <!-- Root-absolute URLs: this shell is served at /individuals/<designation>,
+         so relative paths would resolve under /individuals/. -->
+    <link href="/src/assets/favicon.ico" rel="icon" type="image/x-icon">
+    <style>
+      :root {
+        font-family: Mukta,Helvetica,Arial,sans-serif;
+        line-height: 1.5;
+        font-weight: 400;
+        color: #213547;
+        background-color: #ffffff;
+        font-synthesis: none;
+        text-rendering: optimizeLegibility;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+      body {
+        margin: 0;
+      }
+    </style>
+    <script type="module" src="/src/individual-page.ts"></script>
+  </head>
+  <body>
+    <individual-page></individual-page>
+  </body>
+</html>

--- a/infra/lib/edge-handler/index.test.ts
+++ b/infra/lib/edge-handler/index.test.ts
@@ -434,6 +434,18 @@ describe('/individuals/<designation> profile pages', () => {
     expect(apiUrl).toContain('/rest/v1/individuals?primary_designation=eq.T065A');
   });
 
+  it('includes "born after" vitals when only born_earliest is known', async () => {
+    mockSsmCredentials();
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => [{ ...sampleIndividual, born_earliest: 1990, born_latest: null }],
+    } as Response);
+
+    const event = makeEvent('facebookexternalhit/1.1', '', '/individuals/T065A');
+    const result = await handler(event) as { body: string };
+    expect(result.body).toContain('born after 1990');
+  });
+
   it('falls back to designation-only title when there is no usable nickname', async () => {
     mockSsmCredentials();
     jest.spyOn(global, 'fetch').mockResolvedValue({

--- a/infra/lib/edge-handler/index.test.ts
+++ b/infra/lib/edge-handler/index.test.ts
@@ -375,3 +375,115 @@ describe('Image-asset carve-out: og:image must serve bytes, not OG HTML', () => 
     expect(result.body).toContain('og:title');
   });
 });
+
+describe('/individuals/<designation> profile pages', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    _clearCredentialCache();
+    jest.spyOn(global, 'fetch').mockReset();
+  });
+
+  const sampleIndividual = {
+    primary_designation: 'T065A',
+    sex: 'female',
+    born_earliest: 1986,
+    born_latest: 1986,
+    life_status: 'alive',
+    nicknames: [
+      { name: 'Old Name', status: 'deprecated' },
+      { name: 'Artemis', status: 'official' },
+    ],
+  };
+
+  it('rewrites the URI to /individual.html for a human user-agent', async () => {
+    const event = makeEvent('Mozilla/5.0 (Macintosh)', '', '/individuals/T065A');
+    const result = await handler(event);
+    expect(result).toBe(event.Records[0].cf.request);
+    expect(result.uri).toBe('/individual.html');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('leaves non-individual paths alone for a human user-agent', async () => {
+    const event = makeEvent('Mozilla/5.0 (Macintosh)', '', '/about.html');
+    const result = await handler(event);
+    expect(result.uri).toBe('/about.html');
+  });
+
+  it('does not rewrite deeper paths under /individuals/', async () => {
+    const event = makeEvent('Mozilla/5.0 (Macintosh)', '', '/individuals/T065A/photos');
+    const result = await handler(event);
+    expect(result.uri).toBe('/individuals/T065A/photos');
+  });
+
+  it('returns individual-specific OG tags for a bot', async () => {
+    mockSsmCredentials();
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => [sampleIndividual],
+    } as Response);
+
+    const event = makeEvent('facebookexternalhit/1.1', '', '/individuals/T065A');
+    const result = await handler(event) as { status: string; body: string };
+    expect(result.status).toBe('200');
+    expect(result.body).toContain('content="Artemis (T065A)"');
+    expect(result.body).toContain('born 1986');
+    expect(result.body).toContain('content="https://salishsea.io/individuals/T065A"');
+    expect(result.body).toContain('content="profile"');
+
+    const apiUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+    expect(apiUrl).toContain('/rest/v1/individuals?primary_designation=eq.T065A');
+  });
+
+  it('falls back to designation-only title when there is no usable nickname', async () => {
+    mockSsmCredentials();
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => [{ ...sampleIndividual, nicknames: [] }],
+    } as Response);
+
+    const event = makeEvent('facebookexternalhit/1.1', '', '/individuals/T065A');
+    const result = await handler(event) as { body: string };
+    expect(result.body).toContain('<title>T065A</title>');
+    expect(result.body).not.toContain('Artemis');
+  });
+
+  it('returns the generic preview for an unknown designation', async () => {
+    mockSsmCredentials();
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    } as Response);
+
+    const event = makeEvent('facebookexternalhit/1.1', '', '/individuals/NOPE');
+    const result = await handler(event) as { status: string; body: string };
+    expect(result.status).toBe('200');
+    expect(result.body).toContain('Salish Sea');
+    expect(result.body).not.toContain('NOPE');
+  });
+
+  it('fail-open for a bot still rewrites to the page shell when fetch throws', async () => {
+    mockSsmCredentials();
+    jest.spyOn(global, 'fetch').mockRejectedValue(new Error('network down'));
+
+    const event = makeEvent('facebookexternalhit/1.1', '', '/individuals/T065A');
+    const result = await handler(event);
+    expect(result).toBe(event.Records[0].cf.request);
+    expect(result.uri).toBe('/individual.html');
+  });
+
+  it('escapes HTML in OG tag content built from catalog data', async () => {
+    mockSsmCredentials();
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => [{
+        ...sampleIndividual,
+        nicknames: [{ name: '<script>alert(1)</script>', status: 'official' }],
+      }],
+    } as Response);
+
+    const event = makeEvent('facebookexternalhit/1.1', '', '/individuals/T065A');
+    const result = await handler(event) as { body: string };
+    expect(result.body).not.toContain('<script>alert(1)</script>');
+    expect(result.body).toContain('&lt;script&gt;');
+  });
+});

--- a/infra/lib/edge-handler/index.ts
+++ b/infra/lib/edge-handler/index.ts
@@ -130,7 +130,8 @@ function individualPreviewTags(individual: Individual): OgTags {
       ? (individual.born_earliest === individual.born_latest
         ? `born ${individual.born_earliest}`
         : `born ${individual.born_earliest}–${individual.born_latest}`)
-      : individual.born_latest !== null ? `born by ${individual.born_latest}` : null,
+      : individual.born_latest !== null ? `born by ${individual.born_latest}`
+      : individual.born_earliest !== null ? `born after ${individual.born_earliest}` : null,
   ].filter(Boolean).join(', ');
   const description = `${vitals ? `${vitals} · ` : ''}Names, family, and sighting history of ${title} in the Salish Sea.`;
   return {

--- a/infra/lib/edge-handler/index.ts
+++ b/infra/lib/edge-handler/index.ts
@@ -106,12 +106,73 @@ interface Occurrence {
   photos: Photo[];
 }
 
+interface Individual {
+  primary_designation: string;
+  sex: 'female' | 'male' | null;
+  born_earliest: number | null;
+  born_latest: number | null;
+  life_status: string;
+  nicknames: { name: string; status: string }[];
+}
+
+// /individuals/<designation> — an individual-animal profile page, rendered
+// client-side from the individual.html shell (see src/individual-page.ts).
+const INDIVIDUAL_PATH_RE = /^\/individuals\/([^/]+)\/?$/;
+
+function individualPreviewTags(individual: Individual): OgTags {
+  const name = individual.nicknames.find(n => n.status === 'official')?.name
+    ?? individual.nicknames.find(n => n.status !== 'deprecated')?.name;
+  const designation = individual.primary_designation;
+  const title = name ? `${name} (${designation})` : designation;
+  const vitals = [
+    individual.sex === 'female' ? 'Female' : individual.sex === 'male' ? 'Male' : null,
+    individual.born_earliest !== null && individual.born_latest !== null
+      ? (individual.born_earliest === individual.born_latest
+        ? `born ${individual.born_earliest}`
+        : `born ${individual.born_earliest}–${individual.born_latest}`)
+      : individual.born_latest !== null ? `born by ${individual.born_latest}` : null,
+  ].filter(Boolean).join(', ');
+  const description = `${vitals ? `${vitals} · ` : ''}Names, family, and sighting history of ${title} in the Salish Sea.`;
+  return {
+    'og:site_name': 'SalishSea.io',
+    'og:type': 'profile',
+    'og:url': `https://salishsea.io/individuals/${encodeURIComponent(designation)}`,
+    'og:title': title,
+    'og:description': description,
+    'og:image': FALLBACK_IMAGE,
+    'twitter:card': 'summary_large_image',
+    'fb:app_id': FB_APP_ID,
+  };
+}
+
 // Only cc0 and cc-by are unambiguously open for re-use
 const OPEN_LICENSES = ['cc0', 'cc-by'];
 const FALLBACK_IMAGE = 'https://salishsea.io/preview.jpg';
 // Public Facebook App ID — links shared content to our FB app for Domain Insights.
 // Not a secret; it appears in page meta by design.
 const FB_APP_ID = '678644427974059';
+
+// OG-meta response for a bot fetching an individual's profile page. Unknown
+// designations fall back to the generic site card — same contract as ?o=.
+async function individualPreview(designation: string): Promise<any> {
+  const htmlResponse = (tags: OgTags) => ({
+    status: '200',
+    headers: { 'content-type': [{ key: 'Content-Type', value: 'text/html; charset=utf-8' }] },
+    body: buildOgHtml(tags),
+  });
+
+  const { url, key } = await getCredentials();
+  const apiUrl = `${url}/rest/v1/individuals?primary_designation=eq.${encodeURIComponent(designation)}`
+    + '&select=primary_designation,sex,born_earliest,born_latest,life_status,nicknames(name,status)&limit=1';
+  const res = await fetch(apiUrl, {
+    headers: { 'apikey': key, 'Authorization': `Bearer ${key}` },
+  });
+  if (!res.ok) return htmlResponse(genericPreviewTags());
+  const individuals = await res.json() as Individual[];
+  const individual = individuals[0];
+  if (!individual) return htmlResponse(genericPreviewTags());
+  return htmlResponse(individualPreviewTags(individual));
+}
 
 export const handler = async (event: any): Promise<any> => {
   const request = event.Records[0].cf.request;
@@ -140,12 +201,22 @@ export const handler = async (event: any): Promise<any> => {
   }
 
   const ua = request.headers['user-agent']?.[0]?.value ?? '';
+  const individualMatch = request.uri.match(INDIVIDUAL_PATH_RE);
 
   if (!isBot(ua)) {
+    // Humans get the SPA shell; the page reads the designation from the path.
+    // S3 has no object at /individuals/*, so without this rewrite the path 404s.
+    if (individualMatch) {
+      request.uri = '/individual.html';
+    }
     return request;
   }
 
   try {
+    if (individualMatch) {
+      return await individualPreview(decodeURIComponent(individualMatch[1]!));
+    }
+
     const qs = new URLSearchParams(request.querystring ?? '');
     const occurrenceId = qs.get('o');
 
@@ -218,7 +289,12 @@ export const handler = async (event: any): Promise<any> => {
       body: buildOgHtml(tags),
     };
   } catch {
-    // Fail-open: return the original request so CloudFront serves index.html normally
+    // Fail-open: return the original request so CloudFront serves index.html
+    // normally — except individual paths, which have no S3 object and must
+    // still be rewritten to the page shell.
+    if (individualMatch) {
+      request.uri = '/individual.html';
+    }
     return request;
   }
 };

--- a/src/catalog.test.ts
+++ b/src/catalog.test.ts
@@ -38,6 +38,7 @@ const link = (over: Partial<IndividualOccurrence>): IndividualOccurrence => ({
   individual_id: 1,
   occurrence_id: 'maplify:1',
   observed_at: '2026-06-14T17:36:00+00:00',
+  location: { lon: -123.07, lat: 48.6 },
   is_present: true,
   status: 'candidate',
   evidence: 'text_mention',
@@ -76,12 +77,14 @@ test('sorts deduped links newest first', () => {
 });
 
 test('aggregates presence by PST8PDT calendar month', () => {
+  const at = (occurrence_id: string, observed_at: string): OccurrenceLink =>
+    ({ occurrence_id, observed_at, location: null, is_present: true, status: 'candidate', via_group: null });
   const links: OccurrenceLink[] = [
     // 2026-01-01T02:00Z is still 2025-12-31 in PST8PDT
-    { occurrence_id: 'a', observed_at: '2026-01-01T02:00:00+00:00', is_present: true, status: 'candidate', via_group: null },
-    { occurrence_id: 'b', observed_at: '2026-06-14T17:36:00+00:00', is_present: true, status: 'candidate', via_group: null },
-    { occurrence_id: 'c', observed_at: '2026-06-20T17:36:00+00:00', is_present: true, status: 'candidate', via_group: null },
-    { occurrence_id: 'd', observed_at: '2020-06-20T17:36:00+00:00', is_present: true, status: 'candidate', via_group: null },
+    at('a', '2026-01-01T02:00:00+00:00'),
+    at('b', '2026-06-14T17:36:00+00:00'),
+    at('c', '2026-06-20T17:36:00+00:00'),
+    at('d', '2020-06-20T17:36:00+00:00'),
   ];
   const grid = monthlyPresence(links, 2, 2026);
   expect(grid).toHaveLength(2);

--- a/src/catalog.test.ts
+++ b/src/catalog.test.ts
@@ -1,0 +1,117 @@
+import { expect, test } from 'vitest';
+import {
+  dedupeOccurrenceLinks, displayName, groupChain, individualPath, monthlyPresence,
+  normalizeDesignation, parseIndividualPath,
+  type IndividualOccurrence, type OccurrenceLink, type SocialGroup,
+} from './catalog.ts';
+
+test('parses /individuals/<designation> paths', () => {
+  expect(parseIndividualPath('/individuals/T065A')).toBe('T065A');
+  expect(parseIndividualPath('/individuals/T065A/')).toBe('T065A');
+  expect(parseIndividualPath('/individuals/T065A5')).toBe('T065A5');
+  expect(parseIndividualPath('/individuals/')).toBeNull();
+  expect(parseIndividualPath('/individuals/T065A/photos')).toBeNull();
+  expect(parseIndividualPath('/')).toBeNull();
+  expect(parseIndividualPath('/about.html')).toBeNull();
+});
+
+test('individualPath round-trips through parseIndividualPath', () => {
+  for (const designation of ['T065A', 'CA20', 'AM25 X']) {
+    expect(parseIndividualPath(individualPath(designation))).toBe(designation);
+  }
+});
+
+// Mirrors public.normalize_designation (20260707220211_identifications.sql)
+test('normalizes sighting codes to padded catalog keys', () => {
+  expect(normalizeDesignation('T65A5')).toBe('T065A5');
+  expect(normalizeDesignation('t65a5')).toBe('T065A5');
+  expect(normalizeDesignation('T65')).toBe('T065');
+  expect(normalizeDesignation('T065A')).toBe('T065A');
+  expect(normalizeDesignation('T2B')).toBe('T002B');
+  expect(normalizeDesignation(' T137 ')).toBe('T137');
+  expect(normalizeDesignation('CRC56')).toBe('CRC56');
+  expect(normalizeDesignation('J26')).toBe('J26');
+  expect(normalizeDesignation('CA20')).toBe('CA20');
+});
+
+const link = (over: Partial<IndividualOccurrence>): IndividualOccurrence => ({
+  individual_id: 1,
+  occurrence_id: 'maplify:1',
+  observed_at: '2026-06-14T17:36:00+00:00',
+  is_present: true,
+  status: 'candidate',
+  evidence: 'text_mention',
+  code: 'T65A',
+  via_group: null,
+  ...over,
+});
+
+test('dedupes occurrence links, preferring direct claims over via-group', () => {
+  const rows = [
+    link({ occurrence_id: 'a', via_group: 'T065s' }),
+    link({ occurrence_id: 'a', via_group: null }),
+    link({ occurrence_id: 'b', via_group: 'T065s' }),
+  ];
+  const deduped = dedupeOccurrenceLinks(rows);
+  expect(deduped).toHaveLength(2);
+  expect(deduped.find(l => l.occurrence_id === 'a')?.via_group).toBeNull();
+  expect(deduped.find(l => l.occurrence_id === 'b')?.via_group).toBe('T065s');
+});
+
+test('drops absence claims and rejected identifications', () => {
+  const rows = [
+    link({ occurrence_id: 'a', is_present: false }),
+    link({ occurrence_id: 'b', status: 'rejected' }),
+    link({ occurrence_id: 'c' }),
+  ];
+  expect(dedupeOccurrenceLinks(rows).map(l => l.occurrence_id)).toEqual(['c']);
+});
+
+test('sorts deduped links newest first', () => {
+  const rows = [
+    link({ occurrence_id: 'old', observed_at: '2024-01-01T00:00:00+00:00' }),
+    link({ occurrence_id: 'new', observed_at: '2026-06-01T00:00:00+00:00' }),
+  ];
+  expect(dedupeOccurrenceLinks(rows).map(l => l.occurrence_id)).toEqual(['new', 'old']);
+});
+
+test('aggregates presence by PST8PDT calendar month', () => {
+  const links: OccurrenceLink[] = [
+    // 2026-01-01T02:00Z is still 2025-12-31 in PST8PDT
+    { occurrence_id: 'a', observed_at: '2026-01-01T02:00:00+00:00', is_present: true, status: 'candidate', via_group: null },
+    { occurrence_id: 'b', observed_at: '2026-06-14T17:36:00+00:00', is_present: true, status: 'candidate', via_group: null },
+    { occurrence_id: 'c', observed_at: '2026-06-20T17:36:00+00:00', is_present: true, status: 'candidate', via_group: null },
+    { occurrence_id: 'd', observed_at: '2020-06-20T17:36:00+00:00', is_present: true, status: 'candidate', via_group: null },
+  ];
+  const grid = monthlyPresence(links, 2, 2026);
+  expect(grid).toHaveLength(2);
+  expect(grid[0]).toEqual({ year: 2026, months: [0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0] });
+  expect(grid[1]!.year).toBe(2025);
+  expect(grid[1]!.months[11]).toBe(1); // the UTC-January row lands in December
+});
+
+const group = (id: number, designation: string, parent: number | null): SocialGroup => ({
+  id, designation, parent_group_id: parent, kind: 'matriline', anchor_individual_id: null, notes: null,
+});
+
+test('walks the group chain to the root and survives cycles', () => {
+  const groups = new Map([
+    [1, group(1, 'T065A', 2)],
+    [2, group(2, 'T065', 3)],
+    [3, { ...group(3, 'Biggs', null), kind: 'ecotype' as const }],
+  ]);
+  expect(groupChain(1, groups).map(g => g.designation)).toEqual(['T065A', 'T065', 'Biggs']);
+
+  const cyclic = new Map([[1, group(1, 'A', 2)], [2, group(2, 'B', 1)]]);
+  expect(groupChain(1, cyclic).map(g => g.designation)).toEqual(['A', 'B']);
+});
+
+test('picks the display name by nickname status', () => {
+  expect(displayName([
+    { name: 'Old', status: 'deprecated' },
+    { name: 'Whidbey', status: 'official' },
+  ])).toBe('Whidbey');
+  expect(displayName([{ name: 'Proposed', status: 'proposed' }])).toBe('Proposed');
+  expect(displayName([{ name: 'Old', status: 'deprecated' }])).toBeNull();
+  expect(displayName([])).toBeNull();
+});

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -1,7 +1,6 @@
 import { supabase } from './supabase.ts';
 import { Temporal } from 'temporal-polyfill';
 import type { Database } from '../database.types.ts';
-import type { Occurrence } from './types.ts';
 
 type PublicSchema = Database['public'];
 export type Individual = PublicSchema['Tables']['individuals']['Row'];
@@ -13,9 +12,19 @@ export type IndividualOccurrence = PublicSchema['Views']['individual_occurrences
 export interface OccurrenceLink {
   occurrence_id: string;
   observed_at: string;
+  location: { lon: number; lat: number } | null;
   is_present: boolean;
   status: PublicSchema['Enums']['identification_status'];
   via_group: string | null;
+}
+
+export function observedDate(observedAt: string): Temporal.PlainDate {
+  return Temporal.Instant.from(observedAt).toZonedDateTimeISO('PST8PDT').toPlainDate();
+}
+
+// The main map, opened on the link's day and focused on its occurrence.
+export function mapUrl(link: Pick<OccurrenceLink, 'observed_at' | 'occurrence_id'>): string {
+  return `/?d=${observedDate(link.observed_at).toString()}&o=${encodeURIComponent(link.occurrence_id)}`;
 }
 
 export function individualPath(designation: string): string {
@@ -51,7 +60,7 @@ export function normalizeDesignation(code: string): string {
 export function dedupeOccurrenceLinks(rows: IndividualOccurrence[]): OccurrenceLink[] {
   const byOccurrence = new Map<string, OccurrenceLink>();
   for (const row of rows) {
-    const { occurrence_id, observed_at, is_present, status, via_group } = row;
+    const { occurrence_id, observed_at, location, is_present, status, via_group } = row;
     if (!occurrence_id || !observed_at || !status) continue;
     if (is_present === false || status === 'rejected') continue;
     const existing = byOccurrence.get(occurrence_id);
@@ -59,6 +68,9 @@ export function dedupeOccurrenceLinks(rows: IndividualOccurrence[]): OccurrenceL
     byOccurrence.set(occurrence_id, {
       occurrence_id,
       observed_at,
+      location: location?.lon != null && location.lat != null
+        ? { lon: location.lon, lat: location.lat }
+        : null,
       is_present: is_present ?? true,
       status,
       via_group: via_group ?? null,
@@ -180,20 +192,6 @@ export async function fetchOccurrenceLinks(individualId: number): Promise<Occurr
     .eq('individual_id', individualId)
     .throwOnError();
   return dedupeOccurrenceLinks(data);
-}
-
-export async function fetchOccurrencesByIds(ids: string[]): Promise<Occurrence[]> {
-  if (ids.length === 0) return [];
-  const { data } = await supabase()
-    .from('occurrences')
-    .select()
-    .in('id', ids)
-    .order('observed_at', { ascending: false })
-    .throwOnError();
-  return data.map(record => ({
-    observed_at_ms: Date.parse(record.observed_at),
-    ...record,
-  })) as Occurrence[];
 }
 
 // The official nickname if there is one, else the first non-deprecated one.

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -1,0 +1,205 @@
+import { supabase } from './supabase.ts';
+import { Temporal } from 'temporal-polyfill';
+import type { Database } from '../database.types.ts';
+import type { Occurrence } from './types.ts';
+
+type PublicSchema = Database['public'];
+export type Individual = PublicSchema['Tables']['individuals']['Row'];
+export type SocialGroup = PublicSchema['Tables']['social_groups']['Row'];
+export type IndividualOccurrence = PublicSchema['Views']['individual_occurrences']['Row'];
+
+// One (occurrence, individual) link from the individual_occurrences view, with
+// the fields the profile page needs guaranteed present.
+export interface OccurrenceLink {
+  occurrence_id: string;
+  observed_at: string;
+  is_present: boolean;
+  status: PublicSchema['Enums']['identification_status'];
+  via_group: string | null;
+}
+
+export function individualPath(designation: string): string {
+  return `/individuals/${encodeURIComponent(designation)}`;
+}
+
+// Extract the designation from an /individuals/<designation> path.
+export function parseIndividualPath(pathname: string): string | null {
+  const match = pathname.match(/^\/individuals\/([^/]+)\/?$/);
+  if (!match) return null;
+  try {
+    return decodeURIComponent(match[1]!);
+  } catch {
+    return null;
+  }
+}
+
+// TS port of public.normalize_designation (20260707220211_identifications.sql):
+// map an un-padded sighting code ('T65A5') to the padded catalog key ('T065A5').
+// Pad only the first numeric block of T-codes; uppercase; pass others through.
+// .slice(0, 3) mirrors SQL lpad()'s truncation for hypothetical 4+-digit blocks.
+export function normalizeDesignation(code: string): string {
+  const u = code.trim().toUpperCase();
+  const m = u.match(/^T(\d+)(.*)$/);
+  if (!m) return u;
+  return 'T' + m[1]!.padStart(3, '0').slice(0, 3) + m[2]!;
+}
+
+// Collapse view rows to at most one link per occurrence, preferring a direct
+// claim over a via-group inference, and dropping absence claims and rejected
+// identifications — the page lists where the animal was reported, not where a
+// curator ruled it out.
+export function dedupeOccurrenceLinks(rows: IndividualOccurrence[]): OccurrenceLink[] {
+  const byOccurrence = new Map<string, OccurrenceLink>();
+  for (const row of rows) {
+    const { occurrence_id, observed_at, is_present, status, via_group } = row;
+    if (!occurrence_id || !observed_at || !status) continue;
+    if (is_present === false || status === 'rejected') continue;
+    const existing = byOccurrence.get(occurrence_id);
+    if (existing && !(existing.via_group && !via_group)) continue;
+    byOccurrence.set(occurrence_id, {
+      occurrence_id,
+      observed_at,
+      is_present: is_present ?? true,
+      status,
+      via_group: via_group ?? null,
+    });
+  }
+  return [...byOccurrence.values()]
+    .sort((a, b) => b.observed_at.localeCompare(a.observed_at));
+}
+
+export interface PresenceYear {
+  year: number;
+  months: number[]; // 12 counts, January first
+}
+
+// Distinct-occurrence counts per calendar month (PST8PDT, like the rest of the
+// app) for the trailing `years` years ending at `currentYear`, newest first.
+export function monthlyPresence(links: OccurrenceLink[], years: number, currentYear: number): PresenceYear[] {
+  const grid = new Map<number, number[]>();
+  for (let y = currentYear; y > currentYear - years; y--)
+    grid.set(y, new Array<number>(12).fill(0));
+  for (const link of links) {
+    const zoned = Temporal.Instant.from(link.observed_at).toZonedDateTimeISO('PST8PDT');
+    const months = grid.get(zoned.year);
+    if (months)
+      months[zoned.month - 1]! += 1;
+  }
+  return [...grid.entries()].map(([year, months]) => ({ year, months }));
+}
+
+// Walk a group's ancestry (matriline -> parent matriline -> ... -> ecotype).
+// Returns the chain starting at the group itself; guards against cycles.
+export function groupChain(groupId: number, groupsById: Map<number, SocialGroup>): SocialGroup[] {
+  const chain: SocialGroup[] = [];
+  const seen = new Set<number>();
+  for (let id: number | null = groupId; id !== null && !seen.has(id);) {
+    seen.add(id);
+    const group = groupsById.get(id);
+    if (!group) break;
+    chain.push(group);
+    id = group.parent_group_id;
+  }
+  return chain;
+}
+
+// mother/father are fetched separately (fetchParents): the self-referencing FK
+// makes PostgREST embed direction ambiguous, and supabase-js's type parser and
+// the server disagree on the disambiguation syntax.
+const INDIVIDUAL_SELECT = `
+  *,
+  designations (code, scheme, is_primary, status, in_catalog, authority:parties (name, url)),
+  nicknames (name, story, theme, status, named_year, namer:parties (name, url)),
+  memberships:group_memberships!individual_id (
+    is_current, joined_year, left_year, basis,
+    group:social_groups (id, kind, designation, parent_group_id, anchor_individual_id, notes)
+  )
+` as const;
+
+export async function fetchIndividual(designation: string) {
+  const { data } = await supabase()
+    .from('individuals')
+    .select(INDIVIDUAL_SELECT)
+    .eq('primary_designation', designation)
+    .maybeSingle()
+    .throwOnError();
+  return data;
+}
+export type IndividualProfile = NonNullable<Awaited<ReturnType<typeof fetchIndividual>>>;
+
+export async function fetchParents({ mother_id, father_id }: Pick<Individual, 'mother_id' | 'father_id'>) {
+  const ids = [mother_id, father_id].filter((id): id is number => id !== null);
+  if (!ids.length) return { mother: null, father: null };
+  const { data } = await supabase()
+    .from('individuals')
+    .select('id, primary_designation, life_status, nicknames (name, status)')
+    .in('id', ids)
+    .throwOnError();
+  return {
+    mother: data.find(i => i.id === mother_id) ?? null,
+    father: data.find(i => i.id === father_id) ?? null,
+  };
+}
+export type Parent = NonNullable<Awaited<ReturnType<typeof fetchParents>>['mother']>;
+
+export async function fetchOffspring(individualId: number) {
+  const { data } = await supabase()
+    .from('individuals')
+    .select('id, primary_designation, sex, born_earliest, born_latest, life_status, nicknames (name, status)')
+    .or(`mother_id.eq.${individualId},father_id.eq.${individualId}`)
+    .order('born_earliest', { ascending: true, nullsFirst: true })
+    .throwOnError();
+  return data;
+}
+export type Offspring = Awaited<ReturnType<typeof fetchOffspring>>[number];
+
+// The whole catalog's group graph is a few hundred small rows — fetch it once
+// and resolve pod/ecotype chains client-side instead of walking FKs per hop.
+export async function fetchAllGroups(): Promise<Map<number, SocialGroup>> {
+  const { data } = await supabase()
+    .from('social_groups')
+    .select()
+    .throwOnError();
+  return new Map(data.map(group => [group.id, group]));
+}
+
+export async function fetchGroupMembers(groupId: number) {
+  const { data } = await supabase()
+    .from('group_memberships')
+    .select('is_current, joined_year, left_year, individual:individuals (id, primary_designation, sex, born_earliest, life_status, nicknames (name, status))')
+    .eq('group_id', groupId)
+    .throwOnError();
+  return data;
+}
+export type GroupMember = Awaited<ReturnType<typeof fetchGroupMembers>>[number];
+
+export async function fetchOccurrenceLinks(individualId: number): Promise<OccurrenceLink[]> {
+  const { data } = await supabase()
+    .from('individual_occurrences')
+    .select()
+    .eq('individual_id', individualId)
+    .throwOnError();
+  return dedupeOccurrenceLinks(data);
+}
+
+export async function fetchOccurrencesByIds(ids: string[]): Promise<Occurrence[]> {
+  if (ids.length === 0) return [];
+  const { data } = await supabase()
+    .from('occurrences')
+    .select()
+    .in('id', ids)
+    .order('observed_at', { ascending: false })
+    .throwOnError();
+  return data.map(record => ({
+    observed_at_ms: Date.parse(record.observed_at),
+    ...record,
+  })) as Occurrence[];
+}
+
+// The official nickname if there is one, else the first non-deprecated one.
+export function displayName(nicknames: { name: string; status: string | null }[]): string | null {
+  const official = nicknames.find(n => n.status === 'official');
+  if (official) return official.name;
+  const usable = nicknames.find(n => n.status !== 'deprecated');
+  return usable?.name ?? null;
+}

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -109,7 +109,7 @@ export function groupChain(groupId: number, groupsById: Map<number, SocialGroup>
 const INDIVIDUAL_SELECT = `
   *,
   designations (code, scheme, is_primary, status, in_catalog, authority:parties (name, url)),
-  nicknames (name, story, theme, status, named_year, namer:parties (name, url)),
+  nicknames (name, theme, status, named_year, namer:parties (name, url)),
   memberships:group_memberships!individual_id (
     is_current, joined_year, left_year, basis,
     group:social_groups (id, kind, designation, parent_group_id, anchor_individual_id, notes)

--- a/src/individual-links.test.ts
+++ b/src/individual-links.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from 'vitest';
+import { injectIndividualLinks } from './individual-links.ts';
+
+const codes = new Map([
+  ['T065A5', 'T065A5'],
+  ['T065A', 'T065A'],
+  ['T122', 'T122'],   // renamed from T46A; both codes resolve to T122
+  ['T046A', 'T122'],
+]);
+
+test('links resolvable codes to individual pages', () => {
+  expect(injectIndividualLinks('Likely T65A5 slowly northbound', codes))
+    .toBe('Likely [T65A5](/individuals/T065A5) slowly northbound');
+});
+
+test('links superseded codes to the current designation', () => {
+  expect(injectIndividualLinks('T46A heading south', codes))
+    .toBe('[T46A](/individuals/T122) heading south');
+});
+
+test('leaves matriline, unresolvable, and already-linked codes alone', () => {
+  // Matriline codes name a group, not an individual — no page for them yet
+  expect(injectIndividualLinks('the T65As northbound', codes))
+    .toBe('the T65As northbound');
+  // SRKW / CRC codes aren't in the catalog
+  expect(injectIndividualLinks('J26 and CRC56 nearby', codes))
+    .toBe('J26 and CRC56 nearby');
+  // Codes inside existing markdown links are untouched
+  const linked = 'see [T65A5](https://example.com/t65a5) for details';
+  expect(injectIndividualLinks(linked, codes)).toBe(linked);
+});
+
+test('normalizes case and separators', () => {
+  expect(injectIndividualLinks('t-65a5 with T 65A', codes))
+    .toBe('[t-65a5](/individuals/T065A5) with [T 65A](/individuals/T065A)');
+});

--- a/src/individual-links.ts
+++ b/src/individual-links.ts
@@ -1,0 +1,57 @@
+import { supabase } from './supabase.ts';
+import { individualPath, normalizeDesignation } from './catalog.ts';
+
+// Same shape as public.extract_identifiers (20250924160210_detect_individuals.sql):
+// pod/catalog prefix, optional separator, leading zeros, digit + hex block, and a
+// trailing 's' marking a matriline ("T65As"). Group codes are matched so they are
+// recognized (and left alone), not half-linked as the embedded individual code.
+const CODE_RE = /\b(j|k|l|t|crc)[- ]?0*(\d[\da-f]+)(s?)\b/gi;
+
+// Splits body into alternating segments: [plain text, existing-link, plain text, ...]
+// Odd-indexed segments are existing markdown links — leave them untouched.
+const EXISTING_LINK_RE = /(\[.*?\]\(.*?\))/g;
+
+// Turn catalog-resolvable identifier codes in a markdown body into links to the
+// individual's profile page. `codes` maps a normalized designation (e.g.
+// 'T065A5') to the individual's primary designation. Matriline codes and codes
+// that resolve to nothing (SRKW, CRC, uncataloged) pass through as plain text —
+// linking is a navigation aid, never an identification claim.
+export function injectIndividualLinks(body: string, codes: Map<string, string>): string {
+  return body
+    .split(EXISTING_LINK_RE)
+    .map((segment, i) => {
+      if (i % 2 === 1) return segment;
+      return segment.replace(CODE_RE, (match, prefix: string, block: string, matriline: string) => {
+        if (matriline) return match;
+        const designation = codes.get(normalizeDesignation(`${prefix}${block}`.toUpperCase()));
+        return designation ? `[${match}](${individualPath(designation)})` : match;
+      });
+    })
+    .join('');
+}
+
+let codeMap: Map<string, string> | null = null;
+let loading: Promise<Map<string, string>> | null = null;
+
+// Fetch the designation -> primary_designation lookup once per session. The
+// whole catalog is ~1k tiny rows; callers re-render when the promise settles.
+export function loadCatalogCodes(): Promise<Map<string, string>> {
+  loading ??= (async () => {
+    try {
+      const { data } = await supabase()
+        .from('designations')
+        .select('code, individual:individuals (primary_designation)')
+        .throwOnError();
+      codeMap = new Map(data.map(({ code, individual }) => [code, individual.primary_designation]));
+      return codeMap;
+    } catch (error) {
+      loading = null; // allow a later retry rather than caching the failure
+      throw error;
+    }
+  })();
+  return loading;
+}
+
+export function catalogCodes(): Map<string, string> | null {
+  return codeMap;
+}

--- a/src/individual-map.ts
+++ b/src/individual-map.ts
@@ -1,0 +1,127 @@
+import { css, html, LitElement, type PropertyValues } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { createRef, ref } from 'lit/directives/ref.js';
+import OpenLayersMap from 'ol/Map.js';
+import View from 'ol/View.js';
+import TileLayer from 'ol/layer/Tile.js';
+import XYZ from 'ol/source/XYZ.js';
+import VectorLayer from 'ol/layer/Vector.js';
+import VectorSource from 'ol/source/Vector.js';
+import Feature from 'ol/Feature.js';
+import Point from 'ol/geom/Point.js';
+import { fromLonLat } from 'ol/proj.js';
+import { defaults as defaultControls } from 'ol/control/defaults.js';
+import CircleStyle from 'ol/style/Circle.js';
+import Fill from 'ol/style/Fill.js';
+import Stroke from 'ol/style/Stroke.js';
+import Style from 'ol/style/Style.js';
+import olCSS from 'ol/ol.css?url';
+import { mapUrl, type OccurrenceLink } from './catalog.ts';
+
+const dotStyle = new Style({
+  image: new CircleStyle({
+    radius: 5,
+    fill: new Fill({ color: 'rgba(25, 118, 210, 0.55)' }),
+    stroke: new Stroke({ color: '#ffffff', width: 1 }),
+  }),
+});
+
+const latestStyle = new Style({
+  image: new CircleStyle({
+    radius: 7,
+    fill: new Fill({ color: '#1565c0' }),
+    stroke: new Stroke({ color: '#ffffff', width: 2 }),
+  }),
+  zIndex: 1,
+});
+
+// A non-panning, non-zooming map of everywhere an individual has been
+// reported; the most recent report is emphasized. Clicking a dot opens the
+// main map on that day, focused on the occurrence.
+@customElement('individual-map')
+export class IndividualMap extends LitElement {
+  // Newest first, as returned by fetchOccurrenceLinks
+  @property({ attribute: false })
+  links: OccurrenceLink[] = [];
+
+  #mapRef = createRef<HTMLDivElement>();
+  #map: OpenLayersMap | null = null;
+  #source = new VectorSource<Feature<Point>>();
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+    #map {
+      border: 1px solid #e2e8f0;
+      height: 24rem;
+      width: 100%;
+    }
+  `;
+
+  render() {
+    return html`
+      <link rel="stylesheet" href="${olCSS}" type="text/css" />
+      <div id="map" ${ref(this.#mapRef)}></div>
+    `;
+  }
+
+  protected firstUpdated(): void {
+    this.#map = new OpenLayersMap({
+      target: this.#mapRef.value!,
+      interactions: [],
+      controls: defaultControls({ zoom: false, rotate: false }),
+      layers: [
+        new TileLayer({
+          source: new XYZ({
+            attributions: 'Base map by Esri and its data providers',
+            urls: [
+              'https://services.arcgisonline.com/arcgis/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}',
+              'https://server.arcgisonline.com/arcgis/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}',
+            ],
+          }),
+        }),
+        new VectorLayer({ source: this.#source }),
+      ],
+      view: new View({ center: fromLonLat([-123.2, 48.5]), zoom: 7 }),
+    });
+    this.#map.on('singleclick', evt => {
+      const feature = this.#map!.forEachFeatureAtPixel(evt.pixel, f => f, { hitTolerance: 4 });
+      const href = feature?.get('href') as string | undefined;
+      if (href) window.location.href = href;
+    });
+    this.#map.on('pointermove', evt => {
+      const hit = this.#map!.hasFeatureAtPixel(evt.pixel, { hitTolerance: 4 });
+      this.#mapRef.value!.style.cursor = hit ? 'pointer' : '';
+    });
+    this.#renderLinks();
+  }
+
+  protected updated(changed: PropertyValues): void {
+    if (changed.has('links') && this.#map)
+      this.#renderLinks();
+  }
+
+  #renderLinks(): void {
+    this.#source.clear();
+    const located = this.links.filter(link => link.location);
+    this.#source.addFeatures(located.map((link, i) => {
+      const feature = new Feature(new Point(fromLonLat([link.location!.lon, link.location!.lat])));
+      feature.set('href', mapUrl(link));
+      feature.setStyle(i === 0 ? latestStyle : dotStyle);
+      return feature;
+    }));
+    const extent = this.#source.getExtent();
+    if (!located.length || !extent) return;
+    this.#map!.getView().fit(extent, {
+      padding: [32, 32, 32, 32],
+      maxZoom: 10,
+    });
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'individual-map': IndividualMap;
+  }
+}

--- a/src/individual-page.ts
+++ b/src/individual-page.ts
@@ -6,18 +6,15 @@ import { repeat } from 'lit/directives/repeat.js';
 import { Temporal } from 'temporal-polyfill';
 import {
   displayName, fetchAllGroups, fetchGroupMembers, fetchIndividual, fetchOccurrenceLinks,
-  fetchOccurrencesByIds, fetchOffspring, fetchParents, groupChain, individualPath, monthlyPresence,
-  parseIndividualPath,
+  fetchOffspring, fetchParents, groupChain, individualPath, mapUrl, monthlyPresence,
+  observedDate, parseIndividualPath,
   type GroupMember, type IndividualProfile, type OccurrenceLink, type Offspring, type Parent, type SocialGroup,
 } from './catalog.ts';
-import { loadCatalogCodes } from './individual-links.ts';
-import type { Occurrence } from './types.ts';
 import { sentryClient } from './sentry.ts';
-import './obs-summary.ts';
+import './individual-map.ts';
 
 sentryClient.init();
 
-const RECENT_LIMIT = 10;
 const PRESENCE_YEARS = 4;
 const MONTH_INITIALS = ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'];
 
@@ -32,18 +29,6 @@ const SCHEME_LABELS: Record<string, string> = {
   california: 'California',
   other: '',
 };
-
-const STATUS_LABELS: Record<OccurrenceLink['status'], string> = {
-  candidate: 'unverified mention',
-  validated: 'verified',
-  rejected: 'rejected', // filtered out upstream; label kept for exhaustiveness
-};
-
-interface Sightings {
-  links: OccurrenceLink[];
-  linksByOccurrence: Map<string, OccurrenceLink>;
-  recent: Occurrence[];
-}
 
 interface Profile {
   profile: IndividualProfile;
@@ -74,14 +59,6 @@ function lifeStatusPhrase(status: IndividualProfile['life_status']): string | nu
   }
 }
 
-function observedDate(observedAt: string): Temporal.PlainDate {
-  return Temporal.Instant.from(observedAt).toZonedDateTimeISO('PST8PDT').toPlainDate();
-}
-
-function mapUrl(link: OccurrenceLink): string {
-  return `/?d=${observedDate(link.observed_at).toString()}&o=${encodeURIComponent(link.occurrence_id)}`;
-}
-
 @customElement('individual-page')
 export class IndividualPage extends LitElement {
   @state() private designation = parseIndividualPath(window.location.pathname);
@@ -110,27 +87,9 @@ export class IndividualPage extends LitElement {
   // server-side (~2s). Runs after the profile so the masthead paints first.
   #sightings = new Task(this, {
     args: () => [this.#profile.value?.profile.id] as const,
-    task: async ([individualId]): Promise<Sightings | null> => {
-      if (!individualId) return null;
-      const links = await fetchOccurrenceLinks(individualId);
-      const recent = await fetchOccurrencesByIds(links.slice(0, RECENT_LIMIT).map(l => l.occurrence_id));
-      return {
-        links,
-        linksByOccurrence: new Map(links.map(l => [l.occurrence_id, l])),
-        recent,
-      };
-    },
+    task: async ([individualId]): Promise<OccurrenceLink[] | null> =>
+      individualId ? fetchOccurrenceLinks(individualId) : null,
   });
-
-  connectedCallback(): void {
-    super.connectedCallback();
-    void loadCatalogCodes().catch(() => { /* links in sighting text just stay plain */ });
-    this.addEventListener('focus-occurrence', evt => {
-      const occurrence = (evt as CustomEvent<Occurrence>).detail;
-      const link = this.#sightings.value?.linksByOccurrence.get(occurrence.id);
-      if (link) window.location.href = mapUrl(link);
-    });
-  }
 
   static styles = css`
     :host {
@@ -270,22 +229,9 @@ export class IndividualPage extends LitElement {
       font-size: 0.875rem;
       margin: 0.75rem 0 0;
     }
-    article.sighting {
+    individual-map {
+      display: block;
       margin-top: 1.5rem;
-    }
-    .sighting-context {
-      color: #64748b;
-      font-size: 0.8125rem;
-      margin-bottom: 0.125rem;
-    }
-    .status {
-      background: #f1f5f9;
-      border-radius: 3px;
-      padding: 0.0625rem 0.375rem;
-    }
-    .status.validated {
-      background: #e8f5e9;
-      color: #2e7d32;
     }
     .placeholder {
       color: #64748b;
@@ -447,15 +393,18 @@ export class IndividualPage extends LitElement {
         ${this.#sightings.render({
           pending: () => html`<p class="placeholder">Searching sighting reports&hellip; this takes a few seconds.</p>`,
           error: () => html`<p class="error">Couldn't load sightings just now.</p>`,
-          complete: sightings => {
-            if (!sightings || !sightings.links.length)
+          complete: links => {
+            if (!links?.length)
               return html`<p class="placeholder">No sighting reports mention ${designation} yet.</p>`;
+            const latest = links[0]!;
+            const located = links.filter(l => l.location).length;
             return html`
-              ${this.renderPresence(sightings.links)}
-              ${repeat(sightings.recent, occ => occ.id, occ => this.renderSighting(occ, sightings.linksByOccurrence.get(occ.id)))}
-              ${when(sightings.links.length > sightings.recent.length, () => html`
-                <p class="sightings-note">Showing the ${sightings.recent.length} most recent of ${sightings.links.length} reports.</p>
-              `)}
+              ${this.renderPresence(links)}
+              ${when(located, () => html`<individual-map .links=${links}></individual-map>`)}
+              <p class="sightings-note">
+                Last reported <a href=${mapUrl(latest)}>${observedDate(latest.observed_at).toLocaleString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}</a>${latest.via_group ? html` (as ${latest.via_group})` : nothing}
+                · ${links.length} report${links.length === 1 ? '' : 's'} in all${when(located, () => html` — ${located === links.length ? 'each' : `${located} of them`} a dot above; the most recent is solid. Click one to see that day on the map.`)}
+              </p>
             `;
           },
         })}
@@ -491,19 +440,6 @@ export class IndividualPage extends LitElement {
     `;
   }
 
-  private renderSighting(occurrence: Occurrence, link: OccurrenceLink | undefined) {
-    const date = observedDate(occurrence.observed_at).toLocaleString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
-    return html`
-      <article class="sighting">
-        <div class="sighting-context">
-          ${link ? html`<a href=${mapUrl(link)}>${date}</a>` : date}
-          ${link?.via_group ? html` · mentioned as ${link.via_group}` : nothing}
-          ${link ? html` · <span class="status ${link.status}">${STATUS_LABELS[link.status]}</span>` : nothing}
-        </div>
-        <obs-summary .sighting=${occurrence}></obs-summary>
-      </article>
-    `;
-  }
 }
 
 declare global {

--- a/src/individual-page.ts
+++ b/src/individual-page.ts
@@ -237,14 +237,6 @@ export class IndividualPage extends LitElement {
     .nickname-line b {
       font-weight: 600;
     }
-    .story {
-      color: #475569;
-      margin: 0.25rem 0 0;
-    }
-    .notes {
-      color: #475569;
-      white-space: pre-line;
-    }
     table.presence {
       border-collapse: collapse;
       font-variant-numeric: tabular-nums;
@@ -345,12 +337,6 @@ export class IndividualPage extends LitElement {
         ${chain.length ? html`<p class="lineage">${this.renderChain(chain, profile.primary_designation)}</p>` : nothing}
       </header>
       ${this.renderNaming(profile)}
-      ${when(profile.notes, () => html`
-        <section>
-          <h2>Notes</h2>
-          <p class="notes">${profile.notes}</p>
-        </section>
-      `)}
       ${this.renderFamily(profile, mother, father, offspring)}
       ${when(matriline && members.length > 1, () => this.renderMatriline(matriline!, members, profile.id))}
       ${this.renderSightings(profile.primary_designation)}
@@ -385,7 +371,6 @@ export class IndividualPage extends LitElement {
               ${n.status !== 'official' ? html`<span class="muted">(${n.status.replace('_', ' ')})</span>` : nothing}
               ${n.named_year || n.namer ? html`<span class="muted"> — named${n.named_year ? ` in ${n.named_year}` : ''}${n.namer ? html` by ${n.namer.url ? html`<a target="_blank" rel="noopener noreferrer" href=${n.namer.url}>${n.namer.name}</a>` : n.namer.name}` : ''}</span>` : nothing}
             </p>
-            ${when(n.story, () => html`<p class="story">${n.story}</p>`)}
           </article>
         `)}
         ${when(aliases.length, () => html`

--- a/src/individual-page.ts
+++ b/src/individual-page.ts
@@ -21,6 +21,11 @@ const RECENT_LIMIT = 10;
 const PRESENCE_YEARS = 4;
 const MONTH_INITIALS = ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'];
 
+// iNaturalist taxon ids the catalog actually uses (all rows are 41521 today).
+const TAXON_LABELS: Record<number, string> = {
+  41521: 'Killer whale',
+};
+
 const SCHEME_LABELS: Record<string, string> = {
   bc_wa: 'BC/WA',
   alaska: 'Alaska',
@@ -327,13 +332,16 @@ export class IndividualPage extends LitElement {
       lifeStatusPhrase(profile.life_status),
     ].filter(Boolean).join(' · ');
     const chain = matriline ? groupChain(matriline.id, groups) : [];
-    const isBiggs = chain.some(g => g.kind === 'ecotype' && g.designation === 'Biggs');
+    // Prefer the ecotype proven by the group chain; fall back to the taxon.
+    const species = chain.some(g => g.kind === 'ecotype' && g.designation === 'Biggs')
+      ? "Bigg's killer whale"
+      : TAXON_LABELS[profile.taxon_id] ?? null;
 
     return html`
       <header class="masthead">
-        <div class="designation-kicker">${name ? profile.primary_designation : (isBiggs ? "Bigg's killer whale" : nothing)}</div>
+        <div class="designation-kicker">${name ? profile.primary_designation : species ?? nothing}</div>
         <h1>${name ?? profile.primary_designation}</h1>
-        ${vitals ? html`<p class="vitals">${when(name && isBiggs, () => html`Bigg&#8217;s killer whale · `)}${vitals}</p>` : nothing}
+        ${vitals || (name && species) ? html`<p class="vitals">${when(name && species, () => html`${species} · `)}${vitals}</p>` : nothing}
         ${chain.length ? html`<p class="lineage">${this.renderChain(chain, profile.primary_designation)}</p>` : nothing}
       </header>
       ${this.renderNaming(profile)}

--- a/src/individual-page.ts
+++ b/src/individual-page.ts
@@ -403,7 +403,7 @@ export class IndividualPage extends LitElement {
               ${when(located, () => html`<individual-map .links=${links}></individual-map>`)}
               <p class="sightings-note">
                 Last reported <a href=${mapUrl(latest)}>${observedDate(latest.observed_at).toLocaleString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}</a>${latest.via_group ? html` (as ${latest.via_group})` : nothing}
-                · ${links.length} report${links.length === 1 ? '' : 's'} in all${when(located, () => html` — ${located === links.length ? 'each' : `${located} of them`} a dot above; the most recent is solid. Click one to see that day on the map.`)}
+                · ${links.length} report${links.length === 1 ? '' : 's'} in all${when(located, () => html` — ${located === links.length ? 'each' : `${located} of them`} a dot above; the newest located report is solid. Click one to see that day on the map.`)}
               </p>
             `;
           },

--- a/src/individual-page.ts
+++ b/src/individual-page.ts
@@ -1,0 +1,520 @@
+import { css, html, LitElement, nothing, type TemplateResult } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { Task } from '@lit/task';
+import { when } from 'lit/directives/when.js';
+import { repeat } from 'lit/directives/repeat.js';
+import { Temporal } from 'temporal-polyfill';
+import {
+  displayName, fetchAllGroups, fetchGroupMembers, fetchIndividual, fetchOccurrenceLinks,
+  fetchOccurrencesByIds, fetchOffspring, fetchParents, groupChain, individualPath, monthlyPresence,
+  parseIndividualPath,
+  type GroupMember, type IndividualProfile, type OccurrenceLink, type Offspring, type Parent, type SocialGroup,
+} from './catalog.ts';
+import { loadCatalogCodes } from './individual-links.ts';
+import type { Occurrence } from './types.ts';
+import { sentryClient } from './sentry.ts';
+import './obs-summary.ts';
+
+sentryClient.init();
+
+const RECENT_LIMIT = 10;
+const PRESENCE_YEARS = 4;
+const MONTH_INITIALS = ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'];
+
+const SCHEME_LABELS: Record<string, string> = {
+  bc_wa: 'BC/WA',
+  alaska: 'Alaska',
+  california: 'California',
+  other: '',
+};
+
+const STATUS_LABELS: Record<OccurrenceLink['status'], string> = {
+  candidate: 'unverified mention',
+  validated: 'verified',
+  rejected: 'rejected', // filtered out upstream; label kept for exhaustiveness
+};
+
+interface Sightings {
+  links: OccurrenceLink[];
+  linksByOccurrence: Map<string, OccurrenceLink>;
+  recent: Occurrence[];
+}
+
+interface Profile {
+  profile: IndividualProfile;
+  mother: Parent | null;
+  father: Parent | null;
+  offspring: Offspring[];
+  groups: Map<number, SocialGroup>;
+  matriline: SocialGroup | null;
+  members: GroupMember[];
+  name: string | null;
+}
+
+function bornPhrase(earliest: number | null, latest: number | null): string | null {
+  if (earliest !== null && latest !== null)
+    return earliest === latest ? `born ${earliest}` : `born ${earliest}–${latest}`;
+  if (latest !== null)
+    return `born by ${latest}`;
+  if (earliest !== null)
+    return `born after ${earliest}`;
+  return null;
+}
+
+function lifeStatusPhrase(status: IndividualProfile['life_status']): string | null {
+  switch (status) {
+    case 'deceased': return 'deceased';
+    case 'presumed_deceased': return 'presumed deceased';
+    default: return null; // 'alive' is the unremarkable case; 'unknown' says nothing
+  }
+}
+
+function observedDate(observedAt: string): Temporal.PlainDate {
+  return Temporal.Instant.from(observedAt).toZonedDateTimeISO('PST8PDT').toPlainDate();
+}
+
+function mapUrl(link: OccurrenceLink): string {
+  return `/?d=${observedDate(link.observed_at).toString()}&o=${encodeURIComponent(link.occurrence_id)}`;
+}
+
+@customElement('individual-page')
+export class IndividualPage extends LitElement {
+  @state() private designation = parseIndividualPath(window.location.pathname);
+
+  #profile = new Task(this, {
+    args: () => [this.designation] as const,
+    task: async ([designation]): Promise<Profile | null> => {
+      if (!designation) return null;
+      const profile = await fetchIndividual(designation);
+      if (!profile) return null;
+      const [{ mother, father }, offspring, groups] = await Promise.all([
+        fetchParents(profile),
+        fetchOffspring(profile.id),
+        fetchAllGroups(),
+      ]);
+      const matrilineMembership = profile.memberships.find(m => m.is_current && m.group?.kind === 'matriline');
+      const matriline = matrilineMembership?.group ?? null;
+      const members = matriline ? await fetchGroupMembers(matriline.id) : [];
+      const name = displayName(profile.nicknames);
+      document.title = `${name ? `${name} (${profile.primary_designation})` : profile.primary_designation} · SalishSea.io`;
+      return { profile, mother, father, offspring, groups, matriline, members, name };
+    },
+  });
+
+  // The slow half: identification links resolve live against sighting text
+  // server-side (~2s). Runs after the profile so the masthead paints first.
+  #sightings = new Task(this, {
+    args: () => [this.#profile.value?.profile.id] as const,
+    task: async ([individualId]): Promise<Sightings | null> => {
+      if (!individualId) return null;
+      const links = await fetchOccurrenceLinks(individualId);
+      const recent = await fetchOccurrencesByIds(links.slice(0, RECENT_LIMIT).map(l => l.occurrence_id));
+      return {
+        links,
+        linksByOccurrence: new Map(links.map(l => [l.occurrence_id, l])),
+        recent,
+      };
+    },
+  });
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    void loadCatalogCodes().catch(() => { /* links in sighting text just stay plain */ });
+    this.addEventListener('focus-occurrence', evt => {
+      const occurrence = (evt as CustomEvent<Occurrence>).detail;
+      const link = this.#sightings.value?.linksByOccurrence.get(occurrence.id);
+      if (link) window.location.href = mapUrl(link);
+    });
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+    main {
+      margin: 0 auto;
+      max-width: 44rem;
+      padding: 1rem 1rem 4rem;
+    }
+    a {
+      color: #1976d2;
+      font-weight: 500;
+      text-decoration: none;
+    }
+    a:hover {
+      color: #1565c0;
+    }
+    .back {
+      display: inline-block;
+      margin-bottom: 2.5rem;
+    }
+    header.masthead {
+      margin-bottom: 2.5rem;
+    }
+    .designation-kicker {
+      color: #64748b;
+      font-size: 0.9375rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    h1 {
+      font-size: clamp(2.25rem, 6vw, 3.25rem);
+      font-weight: 600;
+      line-height: 1.1;
+      margin: 0.25rem 0 0.5rem;
+    }
+    .vitals {
+      color: #475569;
+      font-size: 1.0625rem;
+      margin: 0;
+    }
+    .lineage {
+      color: #64748b;
+      font-size: 0.9375rem;
+      margin: 0.5rem 0 0;
+    }
+    .lineage b {
+      color: #475569;
+      font-weight: 600;
+    }
+    section {
+      margin-top: 2.5rem;
+    }
+    h2 {
+      border-bottom: 1px solid #e2e8f0;
+      font-size: 0.9375rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      margin: 0 0 1rem;
+      padding-bottom: 0.375rem;
+      text-transform: uppercase;
+    }
+    dl.family {
+      display: grid;
+      gap: 0.375rem 1.5rem;
+      grid-template-columns: max-content 1fr;
+      margin: 0;
+    }
+    dl.family dt {
+      color: #64748b;
+    }
+    dl.family dd {
+      margin: 0;
+    }
+    ul.people {
+      display: inline;
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    ul.people li {
+      display: inline;
+    }
+    ul.people li:not(:last-child)::after {
+      content: " · ";
+      color: #94a3b8;
+    }
+    .muted {
+      color: #64748b;
+    }
+    .self {
+      font-weight: 600;
+    }
+    article.nickname {
+      margin-bottom: 1.25rem;
+    }
+    article.nickname:last-child {
+      margin-bottom: 0;
+    }
+    .nickname-line {
+      margin: 0;
+    }
+    .nickname-line b {
+      font-weight: 600;
+    }
+    .story {
+      color: #475569;
+      margin: 0.25rem 0 0;
+    }
+    .notes {
+      color: #475569;
+      white-space: pre-line;
+    }
+    table.presence {
+      border-collapse: collapse;
+      font-variant-numeric: tabular-nums;
+    }
+    table.presence th {
+      color: #94a3b8;
+      font-size: 0.75rem;
+      font-weight: 500;
+      padding: 0.125rem;
+      text-align: center;
+    }
+    table.presence th[scope="row"] {
+      color: #64748b;
+      padding-right: 0.625rem;
+      text-align: right;
+    }
+    table.presence td {
+      border: 1px solid #f1f5f9;
+      color: #1e3a5f;
+      font-size: 0.8125rem;
+      height: 1.75rem;
+      min-width: 1.75rem;
+      padding: 0;
+      text-align: center;
+    }
+    table.presence td.p1 { background: #e3f2fd; }
+    table.presence td.p2 { background: #bbdefb; }
+    table.presence td.p3 { background: #90caf9; }
+    .presence-note, .sightings-note {
+      color: #64748b;
+      font-size: 0.875rem;
+      margin: 0.75rem 0 0;
+    }
+    article.sighting {
+      margin-top: 1.5rem;
+    }
+    .sighting-context {
+      color: #64748b;
+      font-size: 0.8125rem;
+      margin-bottom: 0.125rem;
+    }
+    .status {
+      background: #f1f5f9;
+      border-radius: 3px;
+      padding: 0.0625rem 0.375rem;
+    }
+    .status.validated {
+      background: #e8f5e9;
+      color: #2e7d32;
+    }
+    .placeholder {
+      color: #64748b;
+    }
+    .error {
+      color: #b71c1c;
+    }
+  `;
+
+  render() {
+    return html`
+      <main>
+        <a class="back" href="/">&#8592; Back to the map</a>
+        ${this.#profile.render({
+          pending: () => html`<p class="placeholder">Looking up ${this.designation}&hellip;</p>`,
+          error: () => html`<p class="error">Something went wrong loading this page. Please try again.</p>`,
+          complete: value => value ? this.renderProfile(value) : this.renderNotFound(),
+        })}
+      </main>
+    `;
+  }
+
+  private renderNotFound() {
+    return html`
+      <h1>${this.designation ?? 'Not found'}</h1>
+      <p>We don't have ${this.designation ? html`<b>${this.designation}</b>` : 'that individual'} in our catalog.
+      So far it covers Bigg's (transient) killer whales of the Salish Sea; other populations are on the way.</p>
+      <p><a href="/">Explore the sightings map</a> or <a href="/about.html">read about this site</a>.</p>
+    `;
+  }
+
+  private renderProfile({ profile, mother, father, offspring, groups, matriline, members, name }: Profile) {
+    const vitals = [
+      profile.sex === 'female' ? 'Female' : profile.sex === 'male' ? 'Male' : null,
+      bornPhrase(profile.born_earliest, profile.born_latest),
+      lifeStatusPhrase(profile.life_status),
+    ].filter(Boolean).join(' · ');
+    const chain = matriline ? groupChain(matriline.id, groups) : [];
+    const isBiggs = chain.some(g => g.kind === 'ecotype' && g.designation === 'Biggs');
+
+    return html`
+      <header class="masthead">
+        <div class="designation-kicker">${name ? profile.primary_designation : (isBiggs ? "Bigg's killer whale" : nothing)}</div>
+        <h1>${name ?? profile.primary_designation}</h1>
+        ${vitals ? html`<p class="vitals">${when(name && isBiggs, () => html`Bigg&#8217;s killer whale · `)}${vitals}</p>` : nothing}
+        ${chain.length ? html`<p class="lineage">${this.renderChain(chain, profile.primary_designation)}</p>` : nothing}
+      </header>
+      ${this.renderNaming(profile)}
+      ${when(profile.notes, () => html`
+        <section>
+          <h2>Notes</h2>
+          <p class="notes">${profile.notes}</p>
+        </section>
+      `)}
+      ${this.renderFamily(profile, mother, father, offspring)}
+      ${when(matriline && members.length > 1, () => this.renderMatriline(matriline!, members, profile.id))}
+      ${this.renderSightings(profile.primary_designation)}
+    `;
+  }
+
+  // "T065A matriline — within T065 · Bigg's killer whales"
+  private renderChain(chain: SocialGroup[], selfDesignation: string): TemplateResult {
+    const [first, ...rest] = chain;
+    const parents = rest.filter(g => g.kind !== 'ecotype');
+    const ecotype = rest.find(g => g.kind === 'ecotype');
+    return html`
+      <b>${first!.designation} ${first!.kind === 'matriline' ? 'matriline' : first!.kind}</b>${
+        parents.map(g => html` · within ${g.anchor_individual_id && g.designation !== selfDesignation
+          ? html`<a href=${individualPath(g.designation)}>${g.designation}</a>`
+          : g.designation}${g.kind === 'matriline' ? "'s matriline" : ` ${g.kind}`}`)
+      }${ecotype ? html` · ${ecotype.designation === 'Biggs' ? "Bigg's (transient) killer whales" : ecotype.designation}` : nothing}
+    `;
+  }
+
+  private renderNaming(profile: IndividualProfile) {
+    const aliases = profile.designations.filter(d => d.code !== profile.primary_designation);
+    const nicknames = profile.nicknames.filter(n => n.status !== 'deprecated');
+    if (!aliases.length && !nicknames.length) return nothing;
+    return html`
+      <section>
+        <h2>Names</h2>
+        ${repeat(nicknames, n => n.name, n => html`
+          <article class="nickname">
+            <p class="nickname-line">
+              <b>${n.name}</b>
+              ${n.status !== 'official' ? html`<span class="muted">(${n.status.replace('_', ' ')})</span>` : nothing}
+              ${n.named_year || n.namer ? html`<span class="muted"> — named${n.named_year ? ` in ${n.named_year}` : ''}${n.namer ? html` by ${n.namer.url ? html`<a target="_blank" rel="noopener noreferrer" href=${n.namer.url}>${n.namer.name}</a>` : n.namer.name}` : ''}</span>` : nothing}
+            </p>
+            ${when(n.story, () => html`<p class="story">${n.story}</p>`)}
+          </article>
+        `)}
+        ${when(aliases.length, () => html`
+          <p class="muted">Also cataloged as ${aliases.map((d, i) => html`${i ? ', ' : ''}<b>${d.code}</b>${SCHEME_LABELS[d.scheme] ? ` (${SCHEME_LABELS[d.scheme]})` : ''}${d.status === 'superseded' ? ' — superseded' : ''}`)}.</p>
+        `)}
+      </section>
+    `;
+  }
+
+  private renderFamily(profile: IndividualProfile, mother: Parent | null, father: Parent | null, offspring: Offspring[]) {
+    if (!mother && !father && !offspring.length) return nothing;
+    const certainty = profile.maternity_certainty;
+    return html`
+      <section>
+        <h2>Family</h2>
+        <dl class="family">
+          ${when(mother, () => html`
+            <dt>Mother</dt>
+            <dd>${this.renderRelative(mother!)}${certainty !== 'confirmed' ? html` <span class="muted">(${certainty})</span>` : nothing}</dd>
+          `)}
+          ${when(father, () => html`
+            <dt>Father</dt>
+            <dd>${this.renderRelative(father!)}${profile.paternity_certainty && profile.paternity_certainty !== 'confirmed' ? html` <span class="muted">(${profile.paternity_certainty})</span>` : nothing}</dd>
+          `)}
+          ${when(offspring.length, () => html`
+            <dt>Offspring</dt>
+            <dd>
+              <ul class="people">
+                ${repeat(offspring, calf => calf.id, calf => html`
+                  <li>${this.renderRelative(calf)}${calf.born_earliest ? html` <span class="muted">b.&thinsp;${calf.born_earliest}</span>` : nothing}${this.renderDagger(calf.life_status)}</li>
+                `)}
+              </ul>
+            </dd>
+          `)}
+        </dl>
+      </section>
+    `;
+  }
+
+  private renderRelative(relative: { primary_designation: string; nicknames?: { name: string; status: string | null }[] }) {
+    const name = relative.nicknames ? displayName(relative.nicknames) : null;
+    return html`<a href=${individualPath(relative.primary_designation)}>${relative.primary_designation}${name ? ` ${name}` : ''}</a>`;
+  }
+
+  private renderDagger(lifeStatus: string) {
+    return lifeStatus === 'deceased' || lifeStatus === 'presumed_deceased'
+      ? html`<span class="muted" title=${lifeStatus === 'deceased' ? 'deceased' : 'presumed deceased'}>&dagger;</span>`
+      : nothing;
+  }
+
+  private renderMatriline(matriline: SocialGroup, members: GroupMember[], selfId: number) {
+    const sorted = [...members].sort((a, b) =>
+      (a.individual?.born_earliest ?? -Infinity) - (b.individual?.born_earliest ?? -Infinity));
+    return html`
+      <section>
+        <h2>${matriline.designation} matriline</h2>
+        <ul class="people">
+          ${repeat(sorted, m => m.individual!.id, m => html`
+            <li class=${m.individual!.id === selfId ? 'self' : ''}>
+              ${m.individual!.id === selfId
+                ? html`${m.individual!.primary_designation}`
+                : this.renderRelative(m.individual!)}${m.individual!.born_earliest ? html` <span class="muted">b.&thinsp;${m.individual!.born_earliest}</span>` : nothing}${this.renderDagger(m.individual!.life_status)}${!m.is_current ? html` <span class="muted">(former)</span>` : nothing}
+            </li>
+          `)}
+        </ul>
+      </section>
+    `;
+  }
+
+  private renderSightings(designation: string) {
+    return html`
+      <section>
+        <h2>Sightings</h2>
+        ${this.#sightings.render({
+          pending: () => html`<p class="placeholder">Searching sighting reports&hellip; this takes a few seconds.</p>`,
+          error: () => html`<p class="error">Couldn't load sightings just now.</p>`,
+          complete: sightings => {
+            if (!sightings || !sightings.links.length)
+              return html`<p class="placeholder">No sighting reports mention ${designation} yet.</p>`;
+            return html`
+              ${this.renderPresence(sightings.links)}
+              ${repeat(sightings.recent, occ => occ.id, occ => this.renderSighting(occ, sightings.linksByOccurrence.get(occ.id)))}
+              ${when(sightings.links.length > sightings.recent.length, () => html`
+                <p class="sightings-note">Showing the ${sightings.recent.length} most recent of ${sightings.links.length} reports.</p>
+              `)}
+            `;
+          },
+        })}
+      </section>
+    `;
+  }
+
+  private renderPresence(links: OccurrenceLink[]) {
+    const currentYear = Temporal.Now.zonedDateTimeISO('PST8PDT').year;
+    const grid = monthlyPresence(links, PRESENCE_YEARS, currentYear);
+    if (grid.every(row => row.months.every(count => count === 0))) return nothing;
+    return html`
+      <table class="presence">
+        <thead>
+          <tr>
+            <td></td>
+            ${MONTH_INITIALS.map((initial, i) => html`<th scope="col" title=${Temporal.PlainDate.from({year: 2000, month: i + 1, day: 1}).toLocaleString('en-US', {month: 'long'})}>${initial}</th>`)}
+          </tr>
+        </thead>
+        <tbody>
+          ${grid.map(({ year, months }) => html`
+            <tr>
+              <th scope="row">${year}</th>
+              ${months.map((count, i) => html`
+                <td class=${count >= 4 ? 'p3' : count >= 2 ? 'p2' : count === 1 ? 'p1' : ''}
+                    title="${count} report${count === 1 ? '' : 's'} in ${Temporal.PlainDate.from({year, month: i + 1, day: 1}).toLocaleString('en-US', {month: 'long', year: 'numeric'})}">${count || nothing}</td>
+              `)}
+            </tr>
+          `)}
+        </tbody>
+      </table>
+      <p class="presence-note">Reports per month. Most are unverified mentions in sighting text, not confirmed identifications.</p>
+    `;
+  }
+
+  private renderSighting(occurrence: Occurrence, link: OccurrenceLink | undefined) {
+    const date = observedDate(occurrence.observed_at).toLocaleString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+    return html`
+      <article class="sighting">
+        <div class="sighting-context">
+          ${link ? html`<a href=${mapUrl(link)}>${date}</a>` : date}
+          ${link?.via_group ? html` · mentioned as ${link.via_group}` : nothing}
+          ${link ? html` · <span class="status ${link.status}">${STATUS_LABELS[link.status]}</span>` : nothing}
+        </div>
+        <obs-summary .sighting=${occurrence}></obs-summary>
+      </article>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'individual-page': IndividualPage;
+  }
+}

--- a/src/obs-summary.test.ts
+++ b/src/obs-summary.test.ts
@@ -31,9 +31,9 @@ describe('buildShareUrl', () => {
     });
   });
 
-  it('Test 1: builds a URL from origin + pathname + ?o=id', () => {
+  it('Test 1: builds a URL from origin + map root + ?o=id, whatever page hosts the summary', () => {
     const result = buildShareUrl('abc123');
-    expect(result).toBe('https://example.com/app?o=abc123');
+    expect(result).toBe('https://example.com/?o=abc123');
   });
 
   it('Test 2: never includes other query params regardless of window.location.search', () => {
@@ -53,13 +53,13 @@ describe('buildShareUrl', () => {
     expect(result).not.toContain('?x=');
     expect(result).not.toContain('?y=');
     expect(result).not.toContain('?z=');
-    expect(result).toBe('https://example.com/app?o=xyz');
+    expect(result).toBe('https://example.com/?o=xyz');
   });
 
   it('Test 3: UUID-style id round-trips cleanly', () => {
     const uuid = '550e8400-e29b-41d4-a716-446655440000';
     const result = buildShareUrl(uuid);
-    expect(result).toBe(`https://example.com/app?o=${uuid}`);
+    expect(result).toBe(`https://example.com/?o=${uuid}`);
     // Verify no double-encoding occurs for standard UUID characters
     expect(result).toContain(uuid);
   });

--- a/src/obs-summary.ts
+++ b/src/obs-summary.ts
@@ -15,12 +15,17 @@ import { supabase } from "./supabase.ts";
 import type { Contributor, Occurrence } from "./types.ts";
 import { canEdit } from "./occurrence.ts";
 import { injectPartnerLinks } from './partner-links.ts';
+import { catalogCodes, injectIndividualLinks, loadCatalogCodes } from './individual-links.ts';
 
 const domPurify = createDOMPurify(window as any);
 
 const markedRenderer = new Renderer();
+// Site-internal links (injected individual-profile links) stay in this tab;
+// everything else — external partner/source links — opens in a new one.
 markedRenderer.link = ({ href, text }: { href: string; text: string }) =>
-  `<a href="${href}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+  href.startsWith('/')
+    ? `<a href="${href}">${text}</a>`
+    : `<a href="${href}" target="_blank" rel="noopener noreferrer">${text}</a>`;
 
 @customElement('obs-summary')
 export class ObsSummary extends LitElement {
@@ -34,6 +39,10 @@ export class ObsSummary extends LitElement {
   protected ownObservation = false
 
   @state() private copied = false;
+
+  // Flips once the catalog code lookup arrives so guarded bodies re-render
+  // with individual-profile links; until then codes show as plain text.
+  @state() private catalogLoaded = catalogCodes() !== null;
 
   static styles = css`
     :host {
@@ -165,6 +174,12 @@ export class ObsSummary extends LitElement {
   @consume({context: contributorContext, subscribe: true})
   private contributor: Contributor | undefined;
 
+  connectedCallback(): void {
+    super.connectedCallback();
+    if (!this.catalogLoaded)
+      loadCatalogCodes().then(() => { this.catalogLoaded = true; }, () => { /* codes stay plain text */ });
+  }
+
   protected willUpdate(changedProperties: PropertyValues): void {
     if (changedProperties.has('contributor') || changedProperties.has('sighting')) {
       this.ownObservation = !!(this.contributor && this.sighting.contributor_id === this.contributor.id);
@@ -191,10 +206,13 @@ export class ObsSummary extends LitElement {
         }`)}</time>
       </header>
       ${this.renderProvenance()}
-      ${guard([body], () => html`${
+      ${guard([body, this.catalogLoaded], () => html`${
         unsafeHTML(domPurify.sanitize(
           marked.parse(
-            injectPartnerLinks(stripResolvedProvenance((body || '').replace(/(<br\s*\/?\s*>\s*)+/gi, '\n\n'), provider_slug)),
+            injectIndividualLinks(
+              injectPartnerLinks(stripResolvedProvenance((body || '').replace(/(<br\s*\/?\s*>\s*)+/gi, '\n\n'), provider_slug)),
+              catalogCodes() ?? new Map()
+            ),
             { async: false, renderer: markedRenderer }
           ),
           { ADD_ATTR: ['target', 'rel'] }
@@ -330,8 +348,10 @@ function safeExternalHref(raw: string | null | undefined): string | null {
   }
 }
 
+// Share links always point at the map, regardless of which page (map or
+// individual profile) hosts the summary.
 export function buildShareUrl(occurrenceId: string): string {
-  return `${window.location.origin}${window.location.pathname}?o=${occurrenceId}`;
+  return `${window.location.origin}/?o=${occurrenceId}`;
 }
 
 export type CloneSightingEvent = CustomEvent<Occurrence>;

--- a/src/obs-summary.ts
+++ b/src/obs-summary.ts
@@ -22,8 +22,10 @@ const domPurify = createDOMPurify(window as any);
 const markedRenderer = new Renderer();
 // Site-internal links (injected individual-profile links) stay in this tab;
 // everything else — external partner/source links — opens in a new one.
+// `//host/...` is protocol-relative, i.e. external: bodies are third-party
+// text, and such a link must not masquerade as internal.
 markedRenderer.link = ({ href, text }: { href: string; text: string }) =>
-  href.startsWith('/')
+  href.startsWith('/') && !href.startsWith('//')
     ? `<a href="${href}">${text}</a>`
     : `<a href="${href}" target="_blank" rel="noopener noreferrer">${text}</a>`;
 

--- a/supabase/migrations/20260707224748_individual_occurrences.sql
+++ b/supabase/migrations/20260707224748_individual_occurrences.sql
@@ -1,0 +1,42 @@
+-- individual_occurrences — the per-individual read path for profile pages
+-- (GitHub #49). Flattens occurrence_identifications to one row per
+-- (individual, occurrence) link so a page can answer "when has this animal
+-- been reported?" with a single PostgREST filter on individual_id — powering
+-- both the recent-observations list and the presence-by-month grid from the
+-- same result set.
+--
+-- A group claim (e.g. a "T65As" text mention) reaches every CURRENT member of
+-- that group; via_group carries the group designation so the UI can label the
+-- weaker inference ("via T065As"), NULL for a direct claim. An occurrence
+-- mentioning both the individual and its group therefore yields two rows —
+-- readers dedupe by occurrence_id, preferring the direct row.
+--
+-- Honesty invariant (decision 014 / rights-policy §2.4) flows through
+-- unchanged: status/evidence come straight from occurrence_identifications,
+-- and regex candidates stay labeled 'candidate'. Resolution remains live
+-- (regex over occurrences at read time, ~2s/query on prod today); indexing
+-- ahead of time is deliberately deferred.
+CREATE VIEW public.individual_occurrences AS
+SELECT
+  COALESCE(oi.individual_id, gm.individual_id) AS individual_id,
+  oi.occurrence_id,
+  o.observed_at,
+  oi.is_present,
+  oi.status,
+  oi.evidence,
+  oi.code,
+  CASE WHEN oi.individual_id IS NULL THEN g.designation END AS via_group
+FROM public.occurrence_identifications oi
+LEFT JOIN public.group_memberships gm
+  ON oi.individual_id IS NULL AND gm.group_id = oi.social_group_id AND gm.is_current
+LEFT JOIN public.social_groups g
+  ON g.id = oi.social_group_id
+JOIN public.occurrences o
+  ON o.id = oi.occurrence_id
+WHERE COALESCE(oi.individual_id, gm.individual_id) IS NOT NULL;
+
+-- Redundant with Supabase's default privileges when applied via `db push`, but
+-- explicit per repo convention — and load-bearing when a migration is applied
+-- by other means (default privileges only attach for the roles they were
+-- configured for).
+GRANT SELECT ON public.individual_occurrences TO anon, authenticated;

--- a/supabase/migrations/20260707224748_individual_occurrences.sql
+++ b/supabase/migrations/20260707224748_individual_occurrences.sql
@@ -21,6 +21,7 @@ SELECT
   COALESCE(oi.individual_id, gm.individual_id) AS individual_id,
   oi.occurrence_id,
   o.observed_at,
+  o.location,
   oi.is_present,
   oi.status,
   oi.evidence,

--- a/supabase/migrations/20260707232335_restrict_nickname_story.sql
+++ b/supabase/migrations/20260707232335_restrict_nickname_story.sql
@@ -1,0 +1,13 @@
+-- Rights-policy D-21 (docs/rights-policy.md §7.1): a minority of the Bigg's
+-- sheet's story cells are creative prose carrying a thin copyright. The mirror
+-- is an internal baseline — the prose may not be republished verbatim, in the
+-- UI or via the anon API. Facts about a naming (name, namer, year, theme,
+-- status) remain public; the story column becomes readable only by privileged
+-- roles until entries are restated as facts or permission is secured.
+--
+-- Column-level SELECT means PostgREST requests naming `story` (or `select=*`
+-- expansion including it) fail for anon/authenticated; app code selects
+-- explicit nickname columns.
+REVOKE SELECT ON public.nicknames FROM anon, authenticated;
+GRANT SELECT (id, individual_id, social_group_id, name, namer_id, theme, status, named_year)
+  ON public.nicknames TO anon, authenticated;

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,13 @@ import { defineConfig } from 'vite';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+// Exactly one path segment after /individuals/ — the page's own module/asset
+// requests resolve elsewhere and must not be swallowed by the rewrite.
+function individualsRewrite(req, _res, next) {
+  if (/^\/individuals\/[^/]+\/?(\?.*)?$/.test(req.url ?? '')) req.url = '/individual.html';
+  next();
+}
+
 export default defineConfig({
   assetsInclude: ['**/*.geojson'],
 
@@ -13,6 +20,7 @@ export default defineConfig({
       input: {
         main: resolve(__dirname, 'index.html'),
         about: resolve(__dirname, 'about.html'),
+        individual: resolve(__dirname, 'individual.html'),
       }
     },
 
@@ -20,6 +28,18 @@ export default defineConfig({
   },
 
   plugins: [
+    {
+      // In production this rewrite lives in the CloudFront viewer-request
+      // Lambda@Edge (infra/lib/edge-handler): /individuals/<designation> is a
+      // client-rendered page served from the individual.html shell.
+      name: 'individuals-rewrite',
+      configureServer(server) {
+        server.middlewares.use(individualsRewrite);
+      },
+      configurePreviewServer(server) {
+        server.middlewares.use(individualsRewrite);
+      },
+    },
     {
       name: 'strip-csp-upgrade-insecure-requests-in-dev',
       apply: 'serve',


### PR DESCRIPTION
Closes #49.

Every catalog individual now has a full profile page — e.g. `/individuals/T065A` — built on the catalog + identification foundation (#317, #318, decision 014). Recorded as [decision 015](docs/decisions/015-individual-profile-pages.md).

## What's on the page

- **Masthead**: nickname + designation, species (ecotype chain, falling back to taxon), sex, birth-year range, life status, and matriline → pod → ecotype lineage.
- **Names**: nicknames with namer and year, plus other catalog designations (Alaska/California schemes, superseded codes). Naming *stories* and `individuals.notes` are deliberately **not** rendered — they're verbatim Bigg's-sheet cells, a minority of which are creative prose we may not republish (rights-policy **D-21** §7.1). The `nicknames.story` column is also revoked from the anon/authenticated API roles (column-level GRANT); naming facts stay public.
- **Family**: mother (with parentage certainty), father, offspring — all linked to their own pages.
- **Matriline**: current and former members, birth years, † for deceased.
- **Sightings**: presence-by-month grid (last 4 years) plus a **static map** of every located report — most recent emphasized, dots click through to the main map on that day. A one-line caption carries the honesty framing (counts are mostly unverified text mentions; "as T046B" when the latest link is a via-group inference).

## How it works

- **`public.individual_occurrences` view** (new migration): flattens `occurrence_identifications` to one row per (individual, occurrence, location); group claims reach current group members with `via_group` carrying the label. One PostgREST filter powers the grid and the map. Resolution stays live (~2s/query on prod, loaded async after the masthead paints); indexing ahead of time is filed as `salishsea-io-be4`.
- **Routing**: third Vite HTML entry (`individual.html`, `about.html` precedent). The existing viewer-request Lambda@Edge rewrites `/individuals/*` → `/individual.html` for humans and synthesizes catalog-driven OG meta for crawlers (fail-open, generic card for unknown designations). Dev/preview servers mirror the rewrite via middleware.
- **Discovery**: identifier codes in sighting text site-wide now link to profile pages (`injectIndividualLinks`, `partner-links` pattern) — navigation aid only, never an identification claim; matriline (`…s`) and non-catalog codes stay plain text. `buildShareUrl` now always targets the map root so copy-link works from profile pages.
- **Bundle**: the profile page is its own entry chunk (~5 kB gzip); shared vendor (Lit, OpenLayers, Supabase, Sentry) moved into chunks shared by both pages, so the map page's payload grew only ~3 kB gzip. The size-limit delta (+3.7%) is dominated by the new page's own code, which map visitors never download.

## Tests

- 17 new unit tests (path parsing, `normalize_designation` TS-port parity, dedupe/presence aggregation, link injection) — 294 pass.
- 9 new Lambda@Edge tests (rewrite, OG tags incl. born-after vitals, fail-open, HTML escaping) — 42 pass.
- 2 new post-deploy smoke tests in `e2e/og-previews.spec.ts`.
- `npm run build` (tsc + html-validate + CSP hash) green; driven end-to-end locally (map → linked code → profile → dot click → map focused on that day).

## Notes for review

- CodeRabbit findings triaged in-thread: born-after OG vitals fixed (+test), protocol-relative href classification fixed; `security_invoker` suggestion declined with reasoning (owner-rights projection views are the repo's established pattern).
- Only Bigg's individuals are seeded; SRKW J/K/L pages await `salishsea-io-lzi`. Unknown designations get a friendly not-found state.
- Group/matriline pages deferred (`salishsea-io-w2d`); individual pages not in the static sitemap (noted in decision 015).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated individual profile pages at `/individuals/<designation>` with crawler/bot social preview metadata.
  * Profiles include vitals, lineage/family, and sightings with “last reported” plus a monthly presence grid and map.
  * Catalog codes in text are auto-linked to the correct individual profile when resolvable; restricted nickname story visibility to prevent unintended exposure.
* **Bug Fixes**
  * Improved fail-open routing so bots and humans still receive the appropriate page shell on errors; share links now consistently use the site root.
* **Tests**
  * Added e2e and unit tests for individual routing, OG previews, catalog utilities, and link injection.
* **Documentation**
  * Updated architecture overview, conventions, and added decision 015 for individual profile pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->