### PR TITLE
Cache identification candidates in a materialized view

### DIFF
--- a/database.types.ts
+++ b/database.types.ts
@@ -210,6 +210,13 @@ export type Database = {
             foreignKeyName: "group_memberships_group_id_fkey"
             columns: ["group_id"]
             isOneToOne: false
+            referencedRelation: "occurrence_identifier_candidates"
+            referencedColumns: ["social_group_id"]
+          },
+          {
+            foreignKeyName: "group_memberships_group_id_fkey"
+            columns: ["group_id"]
+            isOneToOne: false
             referencedRelation: "social_groups"
             referencedColumns: ["id"]
           },
@@ -285,6 +292,13 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "individuals"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "identifications_social_group_id_fkey"
+            columns: ["social_group_id"]
+            isOneToOne: false
+            referencedRelation: "occurrence_identifier_candidates"
+            referencedColumns: ["social_group_id"]
           },
           {
             foreignKeyName: "identifications_social_group_id_fkey"
@@ -409,6 +423,13 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "parties"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "nicknames_social_group_id_fkey"
+            columns: ["social_group_id"]
+            isOneToOne: false
+            referencedRelation: "occurrence_identifier_candidates"
+            referencedColumns: ["social_group_id"]
           },
           {
             foreignKeyName: "nicknames_social_group_id_fkey"
@@ -633,6 +654,13 @@ export type Database = {
             foreignKeyName: "social_groups_parent_group_id_fkey"
             columns: ["parent_group_id"]
             isOneToOne: false
+            referencedRelation: "occurrence_identifier_candidates"
+            referencedColumns: ["social_group_id"]
+          },
+          {
+            foreignKeyName: "social_groups_parent_group_id_fkey"
+            columns: ["parent_group_id"]
+            isOneToOne: false
             referencedRelation: "social_groups"
             referencedColumns: ["id"]
           },
@@ -697,6 +725,25 @@ export type Database = {
           status: Database["public"]["Enums"]["identification_status"] | null
         }
         Relationships: []
+      }
+      occurrence_identifier_candidates: {
+        Row: {
+          code: string | null
+          individual_id: number | null
+          location: Database["public"]["CompositeTypes"]["lon_lat"] | null
+          observed_at: string | null
+          occurrence_id: string | null
+          social_group_id: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "designations_individual_id_fkey"
+            columns: ["individual_id"]
+            isOneToOne: false
+            referencedRelation: "individuals"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       occurrence_unresolved_codes: {
         Row: {

--- a/docs/decisions/015-individual-profile-pages.md
+++ b/docs/decisions/015-individual-profile-pages.md
@@ -32,10 +32,13 @@ section: a presence-by-month grid plus a **static map** of everywhere the
 animal has been reported (most recent emphasized; dots click through to the
 main map on that day). Re-rendering `<obs-summary>` rows was tried and
 rejected — a wall of borrowed sighting cards read poorly on a profile.
-Resolution stays **live** (regex over sighting text at read time, ~2s/query on
-prod) — acceptable for an async page section today; indexing candidates ahead
-of time is deliberately deferred until the live path actually hurts (bd
-`salishsea-io-be4`).
+Resolution was initially **live** (regex over sighting text at read time,
+~2s/query on prod). Migration `20260708000104` (bd `salishsea-io-be4`) moved
+extraction + resolution into the `occurrence_identifier_candidates`
+materialized view, refreshed by pg_cron a minute after each 5-minute ingest
+tick and by the catalog seed script; per-individual reads dropped to
+milliseconds. Stored claims (curation) still read live so a curator's edit
+takes effect immediately; candidates lag ingest by ≤6 minutes.
 
 ### Honesty invariant carried to the UI
 

--- a/scripts/seed/seed-biggs.ts
+++ b/scripts/seed/seed-biggs.ts
@@ -168,6 +168,16 @@ async function main(): Promise<void> {
         });
 
         console.log('Bigg\'s catalog seeded:', counts);
+
+        // A reseed changes what sighting codes resolve to; the candidate cache
+        // (20260708000104) otherwise only refreshes on the ingest cadence.
+        const [cache] = await sql`
+            SELECT to_regclass('public.occurrence_identifier_candidates') IS NOT NULL AS exists`;
+        if (cache?.['exists']) {
+            await sql`REFRESH MATERIALIZED VIEW public.occurrence_identifier_candidates`;
+            console.log('Refreshed occurrence_identifier_candidates');
+        }
+
         if (unresolvedMothers.length) {
             console.warn(
                 `${unresolvedMothers.length} mother designation(s) not present as their own row (mother_id left NULL): ` +

--- a/supabase/migrations/20260708000104_identifier_candidate_cache.sql
+++ b/supabase/migrations/20260708000104_identifier_candidate_cache.sql
@@ -1,0 +1,146 @@
+-- Index identification candidates ahead of read time (bd salishsea-io-be4,
+-- deferred in decision 015).
+--
+-- The live resolver regexed every sighting body on every read; worse, any join
+-- to public.occurrences pays ~1.6s for the view scan alone (photo aggregation
+-- etc.), so a per-individual page query cost ~2s on prod. This caches the
+-- expensive part — code extraction + catalog resolution, plus the occurrence
+-- attributes profile pages need (observed_at, location) — in a materialized
+-- view refreshed by pg_cron a minute after each 5-minute ingest tick.
+--
+-- What stays LIVE, deliberately:
+--   * stored claims in public.identifications (curation, decision 014): a
+--     curator's validated/rejected/absence row must take effect immediately,
+--     so the reader views keep that branch uncached. While curation volume is
+--     ~zero the planner never scans occurrences for it (nested loop over an
+--     empty outer); revisit alongside the curation UI (bd salishsea-io-ek3).
+--   * the shadow rule: a stored claim still suppresses the cached candidate
+--     for the same (occurrence, subject).
+--
+-- Freshness contract: text-extraction candidates lag ingest by up to ~6
+-- minutes; catalog reseeds must REFRESH explicitly (scripts/seed/seed-biggs.ts
+-- does). Unresolved codes are cached too so occurrence_unresolved_codes stops
+-- regexing as well.
+
+-- One row per (occurrence, extracted code) — resolved to an individual, a
+-- matriline, or (both NULL) unresolved. DISTINCT ON because
+-- extract_identifiers keeps duplicate mentions within one body.
+CREATE MATERIALIZED VIEW public.occurrence_identifier_candidates AS
+SELECT DISTINCT ON (o.id, ident.code)
+  o.id AS occurrence_id,
+  ident.code AS code,
+  d.individual_id AS individual_id,
+  grp.id AS social_group_id,
+  o.observed_at,
+  o.location
+FROM public.occurrences o
+CROSS JOIN LATERAL unnest(o.identifiers) AS ident(code)
+LEFT JOIN public.social_groups grp
+  ON ident.code ~ 's$'
+  AND grp.kind = 'matriline'
+  AND grp.designation = public.normalize_designation(regexp_replace(ident.code, 's$', ''))
+LEFT JOIN public.designations d
+  ON ident.code !~ 's$'
+  AND d.code = public.normalize_designation(ident.code);
+
+-- Required by REFRESH ... CONCURRENTLY (and the natural key).
+CREATE UNIQUE INDEX occurrence_identifier_candidates_key
+  ON public.occurrence_identifier_candidates (occurrence_id, code);
+CREATE INDEX ON public.occurrence_identifier_candidates (individual_id);
+CREATE INDEX ON public.occurrence_identifier_candidates (social_group_id);
+
+-- Internal read path: clients read through the views below. (Supabase default
+-- privileges would otherwise expose the matview via PostgREST.)
+REVOKE ALL ON public.occurrence_identifier_candidates FROM anon, authenticated;
+
+-- ============================================================================
+-- Repoint the reader views at the cache. Output columns and semantics are
+-- unchanged from 20260707220211 / 20260707224748.
+-- ============================================================================
+
+CREATE OR REPLACE VIEW public.occurrence_identifications AS
+SELECT
+  id, occurrence_id, individual_id, social_group_id, is_present,
+  evidence, method, status, asserted_by_party_id, confidence, code, created_at
+FROM public.identifications
+UNION ALL
+SELECT
+  NULL::integer AS id,
+  c.occurrence_id,
+  c.individual_id,
+  c.social_group_id,
+  true AS is_present,
+  'text_mention'::public.identification_evidence AS evidence,
+  'text_extraction'::public.identification_method AS method,
+  'candidate'::public.identification_status AS status,
+  NULL::integer AS asserted_by_party_id,
+  NULL::real AS confidence,
+  c.code,
+  NULL::timestamptz AS created_at
+FROM public.occurrence_identifier_candidates c
+WHERE (c.individual_id IS NOT NULL OR c.social_group_id IS NOT NULL)
+  AND NOT EXISTS (
+    SELECT 1 FROM public.identifications s
+    WHERE s.occurrence_id = c.occurrence_id
+      AND s.individual_id IS NOT DISTINCT FROM c.individual_id
+      AND s.social_group_id IS NOT DISTINCT FROM c.social_group_id
+  );
+
+CREATE OR REPLACE VIEW public.occurrence_unresolved_codes AS
+SELECT c.occurrence_id, c.code
+FROM public.occurrence_identifier_candidates c
+WHERE c.individual_id IS NULL AND c.social_group_id IS NULL;
+
+-- Two branches so the common case (no stored claims yet) never touches the
+-- expensive occurrences view: candidates carry their own observed_at/location.
+CREATE OR REPLACE VIEW public.individual_occurrences AS
+SELECT
+  COALESCE(s.individual_id, gm.individual_id) AS individual_id,
+  s.occurrence_id,
+  o.observed_at,
+  o.location,
+  s.is_present,
+  s.status,
+  s.evidence,
+  s.code,
+  CASE WHEN s.individual_id IS NULL THEN g.designation END AS via_group
+FROM public.identifications s
+LEFT JOIN public.group_memberships gm
+  ON s.individual_id IS NULL AND gm.group_id = s.social_group_id AND gm.is_current
+LEFT JOIN public.social_groups g
+  ON g.id = s.social_group_id
+JOIN public.occurrences o
+  ON o.id = s.occurrence_id
+WHERE COALESCE(s.individual_id, gm.individual_id) IS NOT NULL
+UNION ALL
+SELECT
+  COALESCE(c.individual_id, gm.individual_id) AS individual_id,
+  c.occurrence_id,
+  c.observed_at,
+  c.location,
+  true AS is_present,
+  'candidate'::public.identification_status AS status,
+  'text_mention'::public.identification_evidence AS evidence,
+  c.code,
+  CASE WHEN c.individual_id IS NULL THEN g.designation END AS via_group
+FROM public.occurrence_identifier_candidates c
+LEFT JOIN public.group_memberships gm
+  ON c.individual_id IS NULL AND gm.group_id = c.social_group_id AND gm.is_current
+LEFT JOIN public.social_groups g
+  ON g.id = c.social_group_id
+WHERE (c.individual_id IS NOT NULL OR c.social_group_id IS NOT NULL)
+  AND COALESCE(c.individual_id, gm.individual_id) IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM public.identifications s
+    WHERE s.occurrence_id = c.occurrence_id
+      AND s.individual_id IS NOT DISTINCT FROM c.individual_id
+      AND s.social_group_id IS NOT DISTINCT FROM c.social_group_id
+  );
+
+-- Refresh one minute after each */5 ingest tick. CONCURRENTLY keeps readers
+-- unblocked; cron.schedule upserts by name.
+SELECT cron.schedule(
+  'refresh-identifier-candidates',
+  '1-59/5 * * * *',
+  $$REFRESH MATERIALIZED VIEW CONCURRENTLY public.occurrence_identifier_candidates$$
+);


### PR DESCRIPTION
Closes bd `salishsea-io-be4` (deferred in [decision 015](docs/decisions/015-individual-profile-pages.md); anticipated in #49's "extract and index ahead of time" comment).

## Problem

Profile pages resolved identification candidates live: regex over every sighting body (~0.5s) plus a scan of the `occurrences` view (~1.6s for the view's expensive columns) — ~2s per individual, and a blocker for group pages, per-individual map counts, and sitemap generation.

## Change

- New **`occurrence_identifier_candidates` materialized view**: one row per (occurrence, extracted code) with its catalog resolution (individual / matriline / unresolved) **plus `observed_at` and `location`**, so reads never touch the `occurrences` view. Unique index on `(occurrence_id, code)` for `REFRESH … CONCURRENTLY`; not API-exposed (explicit REVOKE) — clients read through the existing views.
- `occurrence_identifications`, `occurrence_unresolved_codes`, and `individual_occurrences` are repointed at the cache with **identical output** — verified row-for-row against pre-migration snapshots locally (`EXCEPT ALL` both ways = 0 rows for all three).
- **Stored claims stay live**: the curation branch (decision 014) reads `public.identifications` directly, so a curator's validated/rejected row takes effect immediately and still shadows the cached candidate. While that table is empty the planner never executes the `occurrences` join (nested loop over an empty outer); revisit with the curation UI (`salishsea-io-ek3`).
- **Freshness**: pg_cron refreshes at `1-59/5 * * * *` — one minute after each ingest tick — so candidates lag ingest by ≤6 minutes. `seed-biggs.ts` refreshes explicitly after a reseed (guarded by `to_regclass`, so it still works on a pre-migration database).

Measured locally: per-individual query ~20ms (was seconds); refresh itself costs the old one-time scan (~2s) every 5 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added faster, precomputed identifier candidate resolution for profile and occurrence views.
  * Introduced refreshed candidate data that stays up to date shortly after ingest runs.

* **Performance Improvements**
  * Improved read speed for individual profile pages and related lookups, reducing delays from seconds to milliseconds.

* **Bug Fixes**
  * Updated relationship handling so linked group, nickname, and identification data resolve correctly with the new cached source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->