### PR TITLE
Matriline profile pages at /matrilines/<designation>

### DIFF
--- a/database.types.ts
+++ b/database.types.ts
@@ -691,6 +691,21 @@ export type Database = {
       }
     }
     Views: {
+      group_occurrences: {
+        Row: {
+          code: string | null
+          evidence:
+            | Database["public"]["Enums"]["identification_evidence"]
+            | null
+          is_present: boolean | null
+          location: Database["public"]["CompositeTypes"]["lon_lat"] | null
+          observed_at: string | null
+          occurrence_id: string | null
+          social_group_id: number | null
+          status: Database["public"]["Enums"]["identification_status"] | null
+        }
+        Relationships: []
+      }
       individual_occurrences: {
         Row: {
           code: string | null

--- a/docs/decisions/016-matriline-profile-pages.md
+++ b/docs/decisions/016-matriline-profile-pages.md
@@ -1,0 +1,72 @@
+# 016 — Matriline profile pages
+
+**Status:** accepted (2026-07-07)
+**Context:** bd `salishsea-io-w2d`; builds on individual profile pages
+(decision 015). Most Bigg's sighting reports name the matriline ("T65As"),
+not individuals — the richest identification signal we have — but those codes
+were deliberately left unlinked because there was nowhere to send them.
+
+## Decision
+
+Give every cataloged matriline a page at **`/matrilines/<designation>`**
+(e.g. `/matrilines/T065A`, the anchor matriarch's designation), rendered
+client-side from a fourth Vite HTML entry (`matriline.html` +
+`<matriline-page>`), mirroring decision 015's shell/edge pattern.
+
+*Rejected:* `/groups/<designation>` as a single route for every
+`social_group` kind. It would have served pods/clans/named groups with no new
+infra, but "matrilines" is the meaningful word for the pages that exist today;
+each later kind costs one entry in the edge route table and one shell.
+
+### URL scheme: path-based, resolved at the edge route table
+
+The viewer-request Lambda@Edge's individual-page branch became a small route
+table (`PROFILE_ROUTES` in `infra/lib/edge-handler/index.ts`): per route, a
+path regex, a shell to rewrite humans to, and an OG-preview builder for
+crawler user-agents (same fail-open contract; unknown designations get the
+generic site card). The Vite dev/preview middleware mirrors both rewrites.
+
+### Read path: `group_occurrences`, direct group claims only — no member fan-out
+
+A new `public.group_occurrences` view (migration `20260708021011`) is the
+group analogue of `individual_occurrences`: the same live-stored-claims +
+cached-candidates two-branch shape, filtered to rows where `social_group_id`
+is set. A matriline's sightings are reports that name the group **as a unit**.
+
+*Rejected:* the union of members' individual sightings. It double-counts
+(every member row for one report), blurs whose sighting it was, and is
+already presented subject-by-subject on the members' own pages —
+`individual_occurrences` fans group claims out to members, so the two views
+are complements, not duplicates.
+
+### Group codes now link site-wide
+
+`injectIndividualLinks` previously matched matriline codes ("T65As") only to
+leave them untouched. It now resolves them against the matriline catalog and
+links to `/matrilines/<designation>`; unresolved codes still pass through as
+plain text (linking is a navigation aid, never an identification claim).
+Individual pages' matriline section headers link to the matriline page.
+
+### Invariants carried over from 015
+
+- **Honesty:** the sightings section says its counts are mostly unverified
+  mentions, and states the no-fan-out semantics (reports naming the group,
+  not members' sightings). Absence claims and rejected identifications are
+  excluded.
+- **D-21:** only naming and genealogy facts are rendered — group nicknames'
+  facts via `nicknames.social_group_id`; `social_groups.notes` and nickname
+  stories are never rendered.
+- Matriline pages are not in `sitemap.xml`.
+- Shared rendering (member list, presence grid, common styles) lives in
+  `src/profile-shared.ts`; the `<individual-map>` component was already
+  subject-agnostic.
+
+## Consequences / follow-ups
+
+- Pod, clan, and named-group pages are follow-ups: one `PROFILE_ROUTES` entry
+  + one shell each, reusing the same page structure with a different `kind`
+  filter.
+- The matriline lookup filters `kind = 'matriline'`, so ecotype/pod
+  designations 404 on `/matrilines/*` until those pages exist.
+- Only Bigg's matrilines are seeded (they mirror the individuals catalog,
+  decision 014).

--- a/e2e/og-previews.spec.ts
+++ b/e2e/og-previews.spec.ts
@@ -51,3 +51,28 @@ test('regular browser UA on an individual page receives the page shell', async (
   // shell (there is no S3 object at the path itself).
   expect(body).toContain('<individual-page>');
 });
+
+test('bot UA on a matriline page receives profile OG meta tags', async ({ request }) => {
+  const response = await request.get('/matrilines/T065A', {
+    headers: { 'User-Agent': 'facebookexternalhit/1.1' },
+  });
+
+  expect(response.status()).toBe(200);
+  const body = await response.text();
+  expect(body).toContain('T065A');
+  expect(body).toContain('og:title');
+  expect(body).toContain('content="profile"');
+  expect(body).toContain('https://salishsea.io/matrilines/T065A');
+});
+
+test('regular browser UA on a matriline page receives the page shell', async ({ request }) => {
+  const response = await request.get('/matrilines/T065A', {
+    headers: { 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36' },
+  });
+
+  expect(response.status()).toBe(200);
+  const body = await response.text();
+  // The viewer-request function rewrites /matrilines/* to the matriline.html
+  // shell (there is no S3 object at the path itself).
+  expect(body).toContain('<matriline-page>');
+});

--- a/infra/lib/edge-handler/index.test.ts
+++ b/infra/lib/edge-handler/index.test.ts
@@ -499,3 +499,86 @@ describe('/individuals/<designation> profile pages', () => {
     expect(result.body).toContain('&lt;script&gt;');
   });
 });
+
+describe('/matrilines/<designation> profile pages', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    _clearCredentialCache();
+    jest.spyOn(global, 'fetch').mockReset();
+  });
+
+  const sampleGroup = {
+    designation: 'T065A',
+    nicknames: [{ name: 'Artemis family', status: 'official' }],
+  };
+
+  it('rewrites the URI to /matriline.html for a human user-agent', async () => {
+    const event = makeEvent('Mozilla/5.0 (Macintosh)', '', '/matrilines/T065A');
+    const result = await handler(event);
+    expect(result).toBe(event.Records[0].cf.request);
+    expect(result.uri).toBe('/matriline.html');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not rewrite deeper paths under /matrilines/', async () => {
+    const event = makeEvent('Mozilla/5.0 (Macintosh)', '', '/matrilines/T065A/photos');
+    const result = await handler(event);
+    expect(result.uri).toBe('/matrilines/T065A/photos');
+  });
+
+  it('returns matriline-specific OG tags for a bot', async () => {
+    mockSsmCredentials();
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => [sampleGroup],
+    } as Response);
+
+    const event = makeEvent('facebookexternalhit/1.1', '', '/matrilines/T065A');
+    const result = await handler(event) as { status: string; body: string };
+    expect(result.status).toBe('200');
+    expect(result.body).toContain('content="Artemis family (T065A matriline)"');
+    expect(result.body).toContain('content="https://salishsea.io/matrilines/T065A"');
+    expect(result.body).toContain('content="profile"');
+
+    const apiUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+    expect(apiUrl).toContain('/rest/v1/social_groups?designation=eq.T065A');
+    expect(apiUrl).toContain('kind=eq.matriline');
+  });
+
+  it('falls back to a designation-only title when there is no usable nickname', async () => {
+    mockSsmCredentials();
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => [{ ...sampleGroup, nicknames: [] }],
+    } as Response);
+
+    const event = makeEvent('facebookexternalhit/1.1', '', '/matrilines/T065A');
+    const result = await handler(event) as { body: string };
+    expect(result.body).toContain('<title>The T065A matriline</title>');
+    expect(result.body).not.toContain('Artemis');
+  });
+
+  it('returns the generic preview for an unknown designation', async () => {
+    mockSsmCredentials();
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    } as Response);
+
+    const event = makeEvent('facebookexternalhit/1.1', '', '/matrilines/NOPE');
+    const result = await handler(event) as { status: string; body: string };
+    expect(result.status).toBe('200');
+    expect(result.body).toContain('Salish Sea');
+    expect(result.body).not.toContain('NOPE');
+  });
+
+  it('fail-open for a bot still rewrites to the page shell when fetch throws', async () => {
+    mockSsmCredentials();
+    jest.spyOn(global, 'fetch').mockRejectedValue(new Error('network down'));
+
+    const event = makeEvent('facebookexternalhit/1.1', '', '/matrilines/T065A');
+    const result = await handler(event);
+    expect(result).toBe(event.Records[0].cf.request);
+    expect(result.uri).toBe('/matriline.html');
+  });
+});

--- a/infra/lib/edge-handler/index.ts
+++ b/infra/lib/edge-handler/index.ts
@@ -115,9 +115,10 @@ interface Individual {
   nicknames: { name: string; status: string }[];
 }
 
-// /individuals/<designation> — an individual-animal profile page, rendered
-// client-side from the individual.html shell (see src/individual-page.ts).
-const INDIVIDUAL_PATH_RE = /^\/individuals\/([^/]+)\/?$/;
+interface SocialGroup {
+  designation: string;
+  nicknames: { name: string; status: string }[];
+}
 
 function individualPreviewTags(individual: Individual): OgTags {
   const name = individual.nicknames.find(n => n.status === 'official')?.name
@@ -153,15 +154,15 @@ const FALLBACK_IMAGE = 'https://salishsea.io/preview.jpg';
 // Not a secret; it appears in page meta by design.
 const FB_APP_ID = '678644427974059';
 
+const htmlResponse = (tags: OgTags) => ({
+  status: '200',
+  headers: { 'content-type': [{ key: 'Content-Type', value: 'text/html; charset=utf-8' }] },
+  body: buildOgHtml(tags),
+});
+
 // OG-meta response for a bot fetching an individual's profile page. Unknown
 // designations fall back to the generic site card — same contract as ?o=.
 async function individualPreview(designation: string): Promise<any> {
-  const htmlResponse = (tags: OgTags) => ({
-    status: '200',
-    headers: { 'content-type': [{ key: 'Content-Type', value: 'text/html; charset=utf-8' }] },
-    body: buildOgHtml(tags),
-  });
-
   const { url, key } = await getCredentials();
   const apiUrl = `${url}/rest/v1/individuals?primary_designation=eq.${encodeURIComponent(designation)}`
     + '&select=primary_designation,sex,born_earliest,born_latest,life_status,nicknames(name,status)&limit=1';
@@ -173,6 +174,56 @@ async function individualPreview(designation: string): Promise<any> {
   const individual = individuals[0];
   if (!individual) return htmlResponse(genericPreviewTags());
   return htmlResponse(individualPreviewTags(individual));
+}
+
+function matrilinePreviewTags(group: SocialGroup): OgTags {
+  const name = group.nicknames.find(n => n.status === 'official')?.name
+    ?? group.nicknames.find(n => n.status !== 'deprecated')?.name;
+  const designation = group.designation;
+  const title = name ? `${name} (${designation} matriline)` : `The ${designation} matriline`;
+  const description =
+    `Members, naming, and sighting history of the ${designation} matriline of Bigg's killer whales in the Salish Sea.`;
+  return {
+    'og:site_name': 'SalishSea.io',
+    'og:type': 'profile',
+    'og:url': `https://salishsea.io/matrilines/${encodeURIComponent(designation)}`,
+    'og:title': title,
+    'og:description': description,
+    'og:image': FALLBACK_IMAGE,
+    'twitter:card': 'summary_large_image',
+    'fb:app_id': FB_APP_ID,
+  };
+}
+
+// OG-meta response for a bot fetching a matriline's profile page.
+async function matrilinePreview(designation: string): Promise<any> {
+  const { url, key } = await getCredentials();
+  const apiUrl = `${url}/rest/v1/social_groups?designation=eq.${encodeURIComponent(designation)}`
+    + '&kind=eq.matriline&select=designation,nicknames(name,status)&limit=1';
+  const res = await fetch(apiUrl, {
+    headers: { 'apikey': key, 'Authorization': `Bearer ${key}` },
+  });
+  if (!res.ok) return htmlResponse(genericPreviewTags());
+  const groups = await res.json() as SocialGroup[];
+  const group = groups[0];
+  if (!group) return htmlResponse(genericPreviewTags());
+  return htmlResponse(matrilinePreviewTags(group));
+}
+
+// Profile pages rendered client-side from a static shell (decision 015/016):
+// humans get the shell rewrite, bots get synthesized OG meta. S3 has no object
+// at these paths, so even the fail-open branch must rewrite to the shell.
+const PROFILE_ROUTES = [
+  { re: /^\/individuals\/([^/]+)\/?$/, shell: '/individual.html', preview: individualPreview },
+  { re: /^\/matrilines\/([^/]+)\/?$/, shell: '/matriline.html', preview: matrilinePreview },
+];
+
+function matchProfileRoute(uri: string): { shell: string; preview: (designation: string) => Promise<any>; designation: string } | null {
+  for (const { re, shell, preview } of PROFILE_ROUTES) {
+    const match = uri.match(re);
+    if (match) return { shell, preview, designation: match[1]! };
+  }
+  return null;
 }
 
 export const handler = async (event: any): Promise<any> => {
@@ -202,20 +253,21 @@ export const handler = async (event: any): Promise<any> => {
   }
 
   const ua = request.headers['user-agent']?.[0]?.value ?? '';
-  const individualMatch = request.uri.match(INDIVIDUAL_PATH_RE);
+  const profileRoute = matchProfileRoute(request.uri);
 
   if (!isBot(ua)) {
-    // Humans get the SPA shell; the page reads the designation from the path.
-    // S3 has no object at /individuals/*, so without this rewrite the path 404s.
-    if (individualMatch) {
-      request.uri = '/individual.html';
+    // Humans get the page shell; the page reads the designation from the path.
+    // S3 has no object at /individuals/* or /matrilines/*, so without this
+    // rewrite the path 404s.
+    if (profileRoute) {
+      request.uri = profileRoute.shell;
     }
     return request;
   }
 
   try {
-    if (individualMatch) {
-      return await individualPreview(decodeURIComponent(individualMatch[1]!));
+    if (profileRoute) {
+      return await profileRoute.preview(decodeURIComponent(profileRoute.designation));
     }
 
     const qs = new URLSearchParams(request.querystring ?? '');
@@ -291,10 +343,10 @@ export const handler = async (event: any): Promise<any> => {
     };
   } catch {
     // Fail-open: return the original request so CloudFront serves index.html
-    // normally — except individual paths, which have no S3 object and must
-    // still be rewritten to the page shell.
-    if (individualMatch) {
-      request.uri = '/individual.html';
+    // normally — except profile paths, which have no S3 object and must
+    // still be rewritten to their page shell.
+    if (profileRoute) {
+      request.uri = profileRoute.shell;
     }
     return request;
   }

--- a/matriline.html
+++ b/matriline.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self';
+      script-src 'self';
+      style-src 'self' 'unsafe-inline';
+      img-src 'self' https: data:;
+      font-src 'self';
+      connect-src 'self' %VITE_SUPABASE_URL% %VITE_SUPABASE_WS_URL% https://o4509634382331904.ingest.us.sentry.io;
+      object-src 'none';
+      media-src 'self';
+      worker-src 'self';
+      base-uri 'self';
+      form-action 'none';
+      upgrade-insecure-requests;
+    ">
+    <title>Matriline — SalishSea.io</title>
+    <meta name="description" content="Profile of a killer whale matriline in the Salish Sea: the matriarch, members, naming, and recent sighting reports.">
+    <meta property="og:site_name" content="SalishSea.io">
+    <meta property="og:type" content="profile">
+    <meta property="og:title" content="Matriline — SalishSea.io">
+    <meta property="og:description" content="Profile of a killer whale matriline in the Salish Sea: the matriarch, members, naming, and recent sighting reports.">
+    <meta property="og:image" content="https://salishsea.io/preview.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <!-- Root-absolute URLs: this shell is served at /matrilines/<designation>,
+         so relative paths would resolve under /matrilines/. -->
+    <link href="/src/assets/favicon.ico" rel="icon" type="image/x-icon">
+    <style>
+      :root {
+        font-family: Mukta,Helvetica,Arial,sans-serif;
+        line-height: 1.5;
+        font-weight: 400;
+        color: #213547;
+        background-color: #ffffff;
+        font-synthesis: none;
+        text-rendering: optimizeLegibility;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+      body {
+        margin: 0;
+      }
+    </style>
+    <script type="module" src="/src/matriline-page.ts"></script>
+  </head>
+  <body>
+    <matriline-page></matriline-page>
+  </body>
+</html>

--- a/src/catalog.test.ts
+++ b/src/catalog.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import {
-  dedupeOccurrenceLinks, displayName, groupChain, individualPath, monthlyPresence,
-  normalizeDesignation, parseIndividualPath,
+  dedupeOccurrenceLinks, displayName, groupChain, individualPath, matrilinePath, monthlyPresence,
+  normalizeDesignation, parseIndividualPath, parseMatrilinePath,
   type IndividualOccurrence, type OccurrenceLink, type SocialGroup,
 } from './catalog.ts';
 
@@ -18,6 +18,21 @@ test('parses /individuals/<designation> paths', () => {
 test('individualPath round-trips through parseIndividualPath', () => {
   for (const designation of ['T065A', 'CA20', 'AM25 X']) {
     expect(parseIndividualPath(individualPath(designation))).toBe(designation);
+  }
+});
+
+test('parses /matrilines/<designation> paths', () => {
+  expect(parseMatrilinePath('/matrilines/T065A')).toBe('T065A');
+  expect(parseMatrilinePath('/matrilines/T065A/')).toBe('T065A');
+  expect(parseMatrilinePath('/matrilines/')).toBeNull();
+  expect(parseMatrilinePath('/matrilines/T065A/photos')).toBeNull();
+  expect(parseMatrilinePath('/individuals/T065A')).toBeNull();
+  expect(parseIndividualPath('/matrilines/T065A')).toBeNull();
+});
+
+test('matrilinePath round-trips through parseMatrilinePath', () => {
+  for (const designation of ['T065A', 'T046B', 'AM25 X']) {
+    expect(parseMatrilinePath(matrilinePath(designation))).toBe(designation);
   }
 });
 
@@ -66,6 +81,13 @@ test('drops absence claims and rejected identifications', () => {
     link({ occurrence_id: 'c' }),
   ];
   expect(dedupeOccurrenceLinks(rows).map(l => l.occurrence_id)).toEqual(['c']);
+});
+
+test('dedupes group_occurrences-shaped rows, which carry no via_group', () => {
+  const { via_group: _elide, ...groupRow } = link({ occurrence_id: 'a' });
+  const deduped = dedupeOccurrenceLinks([groupRow, { ...groupRow, occurrence_id: 'b' }]);
+  expect(deduped).toHaveLength(2);
+  expect(deduped.every(l => l.via_group === null)).toBe(true);
 });
 
 test('sorts deduped links newest first', () => {

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -31,15 +31,28 @@ export function individualPath(designation: string): string {
   return `/individuals/${encodeURIComponent(designation)}`;
 }
 
-// Extract the designation from an /individuals/<designation> path.
-export function parseIndividualPath(pathname: string): string | null {
-  const match = pathname.match(/^\/individuals\/([^/]+)\/?$/);
+export function matrilinePath(designation: string): string {
+  return `/matrilines/${encodeURIComponent(designation)}`;
+}
+
+function parseProfilePath(pathname: string, re: RegExp): string | null {
+  const match = pathname.match(re);
   if (!match) return null;
   try {
     return decodeURIComponent(match[1]!);
   } catch {
     return null;
   }
+}
+
+// Extract the designation from an /individuals/<designation> path.
+export function parseIndividualPath(pathname: string): string | null {
+  return parseProfilePath(pathname, /^\/individuals\/([^/]+)\/?$/);
+}
+
+// Extract the designation from a /matrilines/<designation> path.
+export function parseMatrilinePath(pathname: string): string | null {
+  return parseProfilePath(pathname, /^\/matrilines\/([^/]+)\/?$/);
 }
 
 // TS port of public.normalize_designation (20260707220211_identifications.sql):
@@ -53,11 +66,17 @@ export function normalizeDesignation(code: string): string {
   return 'T' + m[1]!.padStart(3, '0').slice(0, 3) + m[2]!;
 }
 
+// The shared shape of individual_occurrences and group_occurrences rows;
+// group rows carry no via_group (a group claim is always direct).
+type OccurrenceRow =
+  Pick<IndividualOccurrence, 'occurrence_id' | 'observed_at' | 'location' | 'is_present' | 'status'>
+  & { via_group?: string | null };
+
 // Collapse view rows to at most one link per occurrence, preferring a direct
 // claim over a via-group inference, and dropping absence claims and rejected
 // identifications — the page lists where the animal was reported, not where a
 // curator ruled it out.
-export function dedupeOccurrenceLinks(rows: IndividualOccurrence[]): OccurrenceLink[] {
+export function dedupeOccurrenceLinks(rows: OccurrenceRow[]): OccurrenceLink[] {
   const byOccurrence = new Map<string, OccurrenceLink>();
   for (const row of rows) {
     const { occurrence_id, observed_at, location, is_present, status, via_group } = row;
@@ -190,6 +209,36 @@ export async function fetchOccurrenceLinks(individualId: number): Promise<Occurr
     .from('individual_occurrences')
     .select()
     .eq('individual_id', individualId)
+    .throwOnError();
+  return dedupeOccurrenceLinks(data);
+}
+
+// The !anchor_individual_id hint disambiguates the embed: social_groups
+// reaches individuals both through the anchor FK and through
+// group_memberships. Nickname facts only — story is access-restricted (D-21).
+const MATRILINE_SELECT = `
+  *,
+  nicknames (name, theme, status, named_year, namer:parties (name, url)),
+  anchor:individuals!anchor_individual_id (id, primary_designation, life_status, nicknames (name, status))
+` as const;
+
+export async function fetchMatriline(designation: string) {
+  const { data } = await supabase()
+    .from('social_groups')
+    .select(MATRILINE_SELECT)
+    .eq('designation', designation)
+    .eq('kind', 'matriline')
+    .maybeSingle()
+    .throwOnError();
+  return data;
+}
+export type MatrilineProfile = NonNullable<Awaited<ReturnType<typeof fetchMatriline>>>;
+
+export async function fetchGroupOccurrenceLinks(groupId: number): Promise<OccurrenceLink[]> {
+  const { data } = await supabase()
+    .from('group_occurrences')
+    .select()
+    .eq('social_group_id', groupId)
     .throwOnError();
   return dedupeOccurrenceLinks(data);
 }

--- a/src/individual-links.test.ts
+++ b/src/individual-links.test.ts
@@ -8,6 +8,11 @@ const codes = new Map([
   ['T046A', 'T122'],
 ]);
 
+const matrilines = new Map([
+  ['T065A', 'T065A'],
+  ['T046B', 'T046B'],
+]);
+
 test('links resolvable codes to individual pages', () => {
   expect(injectIndividualLinks('Likely T65A5 slowly northbound', codes))
     .toBe('Likely [T65A5](/individuals/T065A5) slowly northbound');
@@ -18,16 +23,27 @@ test('links superseded codes to the current designation', () => {
     .toBe('[T46A](/individuals/T122) heading south');
 });
 
-test('leaves matriline, unresolvable, and already-linked codes alone', () => {
-  // Matriline codes name a group, not an individual — no page for them yet
+test('links matriline codes to matriline pages', () => {
+  expect(injectIndividualLinks('the T65As northbound', codes, matrilines))
+    .toBe('the [T65As](/matrilines/T065A) northbound');
+  // Case and separators normalize the same way as individual codes
+  expect(injectIndividualLinks('t-46bs milling', codes, matrilines))
+    .toBe('[t-46bs](/matrilines/T046B) milling');
+});
+
+test('leaves unresolvable and already-linked codes alone', () => {
+  // Matriline codes with no cataloged group stay plain text
+  expect(injectIndividualLinks('the T99s northbound', codes, matrilines))
+    .toBe('the T99s northbound');
+  // Without a matriline map (older call sites), matriline codes stay plain text
   expect(injectIndividualLinks('the T65As northbound', codes))
     .toBe('the T65As northbound');
   // SRKW / CRC codes aren't in the catalog
-  expect(injectIndividualLinks('J26 and CRC56 nearby', codes))
+  expect(injectIndividualLinks('J26 and CRC56 nearby', codes, matrilines))
     .toBe('J26 and CRC56 nearby');
   // Codes inside existing markdown links are untouched
-  const linked = 'see [T65A5](https://example.com/t65a5) for details';
-  expect(injectIndividualLinks(linked, codes)).toBe(linked);
+  const linked = 'see [T65A5](https://example.com/t65a5) and [T65As](https://example.com/t65as) for details';
+  expect(injectIndividualLinks(linked, codes, matrilines)).toBe(linked);
 });
 
 test('normalizes case and separators', () => {

--- a/src/individual-links.ts
+++ b/src/individual-links.ts
@@ -1,10 +1,11 @@
 import { supabase } from './supabase.ts';
-import { individualPath, normalizeDesignation } from './catalog.ts';
+import { individualPath, matrilinePath, normalizeDesignation } from './catalog.ts';
 
 // Same shape as public.extract_identifiers (20250924160210_detect_individuals.sql):
 // pod/catalog prefix, optional separator, leading zeros, digit + hex block, and a
 // trailing 's' marking a matriline ("T65As"). Group codes are matched so they are
-// recognized (and left alone), not half-linked as the embedded individual code.
+// linked to the matriline's page (or left alone when unresolved), not half-linked
+// as the embedded individual code.
 const CODE_RE = /\b(j|k|l|t|crc)[- ]?0*(\d[\da-f]+)(s?)\b/gi;
 
 // Splits body into alternating segments: [plain text, existing-link, plain text, ...]
@@ -12,18 +13,28 @@ const CODE_RE = /\b(j|k|l|t|crc)[- ]?0*(\d[\da-f]+)(s?)\b/gi;
 const EXISTING_LINK_RE = /(\[.*?\]\(.*?\))/g;
 
 // Turn catalog-resolvable identifier codes in a markdown body into links to the
-// individual's profile page. `codes` maps a normalized designation (e.g.
-// 'T065A5') to the individual's primary designation. Matriline codes and codes
+// individual's profile page, and matriline codes ("T65As") into links to the
+// matriline's page. `codes` maps a normalized designation (e.g. 'T065A5') to
+// the individual's primary designation; `matrilines` maps a normalized
+// matriarch designation (e.g. 'T065A') to the matriline's designation. Codes
 // that resolve to nothing (SRKW, CRC, uncataloged) pass through as plain text —
 // linking is a navigation aid, never an identification claim.
-export function injectIndividualLinks(body: string, codes: Map<string, string>): string {
+export function injectIndividualLinks(
+  body: string,
+  codes: Map<string, string>,
+  matrilines: Map<string, string> = new Map(),
+): string {
   return body
     .split(EXISTING_LINK_RE)
     .map((segment, i) => {
       if (i % 2 === 1) return segment;
       return segment.replace(CODE_RE, (match, prefix: string, block: string, matriline: string) => {
-        if (matriline) return match;
-        const designation = codes.get(normalizeDesignation(`${prefix}${block}`.toUpperCase()));
+        const normalized = normalizeDesignation(`${prefix}${block}`.toUpperCase());
+        if (matriline) {
+          const designation = matrilines.get(normalized);
+          return designation ? `[${match}](${matrilinePath(designation)})` : match;
+        }
+        const designation = codes.get(normalized);
         return designation ? `[${match}](${individualPath(designation)})` : match;
       });
     })
@@ -31,18 +42,28 @@ export function injectIndividualLinks(body: string, codes: Map<string, string>):
 }
 
 let codeMap: Map<string, string> | null = null;
+let matrilineMap: Map<string, string> | null = null;
 let loading: Promise<Map<string, string>> | null = null;
 
-// Fetch the designation -> primary_designation lookup once per session. The
-// whole catalog is ~1k tiny rows; callers re-render when the promise settles.
+// Fetch the designation -> primary_designation lookup (plus the matriline
+// designations) once per session. The whole catalog is ~1k tiny rows; callers
+// re-render when the promise settles.
 export function loadCatalogCodes(): Promise<Map<string, string>> {
   loading ??= (async () => {
     try {
-      const { data } = await supabase()
-        .from('designations')
-        .select('code, individual:individuals (primary_designation)')
-        .throwOnError();
-      codeMap = new Map(data.map(({ code, individual }) => [code, individual.primary_designation]));
+      const [{ data: designations }, { data: groups }] = await Promise.all([
+        supabase()
+          .from('designations')
+          .select('code, individual:individuals (primary_designation)')
+          .throwOnError(),
+        supabase()
+          .from('social_groups')
+          .select('designation')
+          .eq('kind', 'matriline')
+          .throwOnError(),
+      ]);
+      codeMap = new Map(designations.map(({ code, individual }) => [code, individual.primary_designation]));
+      matrilineMap = new Map(groups.map(({ designation }) => [designation, designation]));
       return codeMap;
     } catch (error) {
       loading = null; // allow a later retry rather than caching the failure
@@ -54,4 +75,8 @@ export function loadCatalogCodes(): Promise<Map<string, string>> {
 
 export function catalogCodes(): Map<string, string> | null {
   return codeMap;
+}
+
+export function matrilineCodes(): Map<string, string> | null {
+  return matrilineMap;
 }

--- a/src/individual-page.ts
+++ b/src/individual-page.ts
@@ -3,20 +3,17 @@ import { customElement, state } from 'lit/decorators.js';
 import { Task } from '@lit/task';
 import { when } from 'lit/directives/when.js';
 import { repeat } from 'lit/directives/repeat.js';
-import { Temporal } from 'temporal-polyfill';
 import {
   displayName, fetchAllGroups, fetchGroupMembers, fetchIndividual, fetchOccurrenceLinks,
-  fetchOffspring, fetchParents, groupChain, individualPath, mapUrl, monthlyPresence,
+  fetchOffspring, fetchParents, groupChain, individualPath, mapUrl, matrilinePath,
   observedDate, parseIndividualPath,
   type GroupMember, type IndividualProfile, type OccurrenceLink, type Offspring, type Parent, type SocialGroup,
 } from './catalog.ts';
+import { profileStyles, renderDagger, renderMemberList, renderPresenceTable, renderRelative } from './profile-shared.ts';
 import { sentryClient } from './sentry.ts';
 import './individual-map.ts';
 
 sentryClient.init();
-
-const PRESENCE_YEARS = 4;
-const MONTH_INITIALS = ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'];
 
 // iNaturalist taxon ids the catalog actually uses (all rows are 41521 today).
 const TAXON_LABELS: Record<number, string> = {
@@ -91,68 +88,7 @@ export class IndividualPage extends LitElement {
       individualId ? fetchOccurrenceLinks(individualId) : null,
   });
 
-  static styles = css`
-    :host {
-      display: block;
-    }
-    main {
-      margin: 0 auto;
-      max-width: 44rem;
-      padding: 1rem 1rem 4rem;
-    }
-    a {
-      color: #1976d2;
-      font-weight: 500;
-      text-decoration: none;
-    }
-    a:hover {
-      color: #1565c0;
-    }
-    .back {
-      display: inline-block;
-      margin-bottom: 2.5rem;
-    }
-    header.masthead {
-      margin-bottom: 2.5rem;
-    }
-    .designation-kicker {
-      color: #64748b;
-      font-size: 0.9375rem;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-    }
-    h1 {
-      font-size: clamp(2.25rem, 6vw, 3.25rem);
-      font-weight: 600;
-      line-height: 1.1;
-      margin: 0.25rem 0 0.5rem;
-    }
-    .vitals {
-      color: #475569;
-      font-size: 1.0625rem;
-      margin: 0;
-    }
-    .lineage {
-      color: #64748b;
-      font-size: 0.9375rem;
-      margin: 0.5rem 0 0;
-    }
-    .lineage b {
-      color: #475569;
-      font-weight: 600;
-    }
-    section {
-      margin-top: 2.5rem;
-    }
-    h2 {
-      border-bottom: 1px solid #e2e8f0;
-      font-size: 0.9375rem;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      margin: 0 0 1rem;
-      padding-bottom: 0.375rem;
-      text-transform: uppercase;
-    }
+  static styles = [profileStyles, css`
     dl.family {
       display: grid;
       gap: 0.375rem 1.5rem;
@@ -165,81 +101,13 @@ export class IndividualPage extends LitElement {
     dl.family dd {
       margin: 0;
     }
-    ul.people {
-      display: inline;
-      list-style: none;
-      margin: 0;
-      padding: 0;
+    h2 a {
+      color: inherit;
     }
-    ul.people li {
-      display: inline;
+    h2 a:hover {
+      color: #1976d2;
     }
-    ul.people li:not(:last-child)::after {
-      content: " · ";
-      color: #94a3b8;
-    }
-    .muted {
-      color: #64748b;
-    }
-    .self {
-      font-weight: 600;
-    }
-    article.nickname {
-      margin-bottom: 1.25rem;
-    }
-    article.nickname:last-child {
-      margin-bottom: 0;
-    }
-    .nickname-line {
-      margin: 0;
-    }
-    .nickname-line b {
-      font-weight: 600;
-    }
-    table.presence {
-      border-collapse: collapse;
-      font-variant-numeric: tabular-nums;
-    }
-    table.presence th {
-      color: #94a3b8;
-      font-size: 0.75rem;
-      font-weight: 500;
-      padding: 0.125rem;
-      text-align: center;
-    }
-    table.presence th[scope="row"] {
-      color: #64748b;
-      padding-right: 0.625rem;
-      text-align: right;
-    }
-    table.presence td {
-      border: 1px solid #f1f5f9;
-      color: #1e3a5f;
-      font-size: 0.8125rem;
-      height: 1.75rem;
-      min-width: 1.75rem;
-      padding: 0;
-      text-align: center;
-    }
-    table.presence td.p1 { background: #e3f2fd; }
-    table.presence td.p2 { background: #bbdefb; }
-    table.presence td.p3 { background: #90caf9; }
-    .presence-note, .sightings-note {
-      color: #64748b;
-      font-size: 0.875rem;
-      margin: 0.75rem 0 0;
-    }
-    individual-map {
-      display: block;
-      margin-top: 1.5rem;
-    }
-    .placeholder {
-      color: #64748b;
-    }
-    .error {
-      color: #b71c1c;
-    }
-  `;
+  `];
 
   render() {
     return html`
@@ -335,18 +203,18 @@ export class IndividualPage extends LitElement {
         <dl class="family">
           ${when(mother, () => html`
             <dt>Mother</dt>
-            <dd>${this.renderRelative(mother!)}${certainty !== 'confirmed' ? html` <span class="muted">(${certainty})</span>` : nothing}</dd>
+            <dd>${renderRelative(mother!)}${certainty !== 'confirmed' ? html` <span class="muted">(${certainty})</span>` : nothing}</dd>
           `)}
           ${when(father, () => html`
             <dt>Father</dt>
-            <dd>${this.renderRelative(father!)}${profile.paternity_certainty && profile.paternity_certainty !== 'confirmed' ? html` <span class="muted">(${profile.paternity_certainty})</span>` : nothing}</dd>
+            <dd>${renderRelative(father!)}${profile.paternity_certainty && profile.paternity_certainty !== 'confirmed' ? html` <span class="muted">(${profile.paternity_certainty})</span>` : nothing}</dd>
           `)}
           ${when(offspring.length, () => html`
             <dt>Offspring</dt>
             <dd>
               <ul class="people">
                 ${repeat(offspring, calf => calf.id, calf => html`
-                  <li>${this.renderRelative(calf)}${calf.born_earliest ? html` <span class="muted">b.&thinsp;${calf.born_earliest}</span>` : nothing}${this.renderDagger(calf.life_status)}</li>
+                  <li>${renderRelative(calf)}${calf.born_earliest ? html` <span class="muted">b.&thinsp;${calf.born_earliest}</span>` : nothing}${renderDagger(calf.life_status)}</li>
                 `)}
               </ul>
             </dd>
@@ -356,32 +224,11 @@ export class IndividualPage extends LitElement {
     `;
   }
 
-  private renderRelative(relative: { primary_designation: string; nicknames?: { name: string; status: string | null }[] }) {
-    const name = relative.nicknames ? displayName(relative.nicknames) : null;
-    return html`<a href=${individualPath(relative.primary_designation)}>${relative.primary_designation}${name ? ` ${name}` : ''}</a>`;
-  }
-
-  private renderDagger(lifeStatus: string) {
-    return lifeStatus === 'deceased' || lifeStatus === 'presumed_deceased'
-      ? html`<span class="muted" title=${lifeStatus === 'deceased' ? 'deceased' : 'presumed deceased'}>&dagger;</span>`
-      : nothing;
-  }
-
   private renderMatriline(matriline: SocialGroup, members: GroupMember[], selfId: number) {
-    const sorted = [...members].sort((a, b) =>
-      (a.individual?.born_earliest ?? -Infinity) - (b.individual?.born_earliest ?? -Infinity));
     return html`
       <section>
-        <h2>${matriline.designation} matriline</h2>
-        <ul class="people">
-          ${repeat(sorted, m => m.individual!.id, m => html`
-            <li class=${m.individual!.id === selfId ? 'self' : ''}>
-              ${m.individual!.id === selfId
-                ? html`${m.individual!.primary_designation}`
-                : this.renderRelative(m.individual!)}${m.individual!.born_earliest ? html` <span class="muted">b.&thinsp;${m.individual!.born_earliest}</span>` : nothing}${this.renderDagger(m.individual!.life_status)}${!m.is_current ? html` <span class="muted">(former)</span>` : nothing}
-            </li>
-          `)}
-        </ul>
+        <h2><a href=${matrilinePath(matriline.designation)}>${matriline.designation} matriline</a></h2>
+        ${renderMemberList(members, selfId)}
       </section>
     `;
   }
@@ -399,7 +246,7 @@ export class IndividualPage extends LitElement {
             const latest = links[0]!;
             const located = links.filter(l => l.location).length;
             return html`
-              ${this.renderPresence(links)}
+              ${renderPresenceTable(links)}
               ${when(located, () => html`<individual-map .links=${links}></individual-map>`)}
               <p class="sightings-note">
                 Last reported <a href=${mapUrl(latest)}>${observedDate(latest.observed_at).toLocaleString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}</a>${latest.via_group ? html` (as ${latest.via_group})` : nothing}
@@ -409,34 +256,6 @@ export class IndividualPage extends LitElement {
           },
         })}
       </section>
-    `;
-  }
-
-  private renderPresence(links: OccurrenceLink[]) {
-    const currentYear = Temporal.Now.zonedDateTimeISO('PST8PDT').year;
-    const grid = monthlyPresence(links, PRESENCE_YEARS, currentYear);
-    if (grid.every(row => row.months.every(count => count === 0))) return nothing;
-    return html`
-      <table class="presence">
-        <thead>
-          <tr>
-            <td></td>
-            ${MONTH_INITIALS.map((initial, i) => html`<th scope="col" title=${Temporal.PlainDate.from({year: 2000, month: i + 1, day: 1}).toLocaleString('en-US', {month: 'long'})}>${initial}</th>`)}
-          </tr>
-        </thead>
-        <tbody>
-          ${grid.map(({ year, months }) => html`
-            <tr>
-              <th scope="row">${year}</th>
-              ${months.map((count, i) => html`
-                <td class=${count >= 4 ? 'p3' : count >= 2 ? 'p2' : count === 1 ? 'p1' : ''}
-                    title="${count} report${count === 1 ? '' : 's'} in ${Temporal.PlainDate.from({year, month: i + 1, day: 1}).toLocaleString('en-US', {month: 'long', year: 'numeric'})}">${count || nothing}</td>
-              `)}
-            </tr>
-          `)}
-        </tbody>
-      </table>
-      <p class="presence-note">Reports per month. Most are unverified mentions in sighting text, not confirmed identifications.</p>
     `;
   }
 

--- a/src/matriline-page.ts
+++ b/src/matriline-page.ts
@@ -1,0 +1,173 @@
+import { html, LitElement, nothing, type TemplateResult } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { Task } from '@lit/task';
+import { when } from 'lit/directives/when.js';
+import { repeat } from 'lit/directives/repeat.js';
+import {
+  displayName, fetchAllGroups, fetchGroupMembers, fetchGroupOccurrenceLinks, fetchMatriline,
+  groupChain, mapUrl, matrilinePath, observedDate, parseMatrilinePath,
+  type GroupMember, type MatrilineProfile, type OccurrenceLink, type SocialGroup,
+} from './catalog.ts';
+import { profileStyles, renderDagger, renderMemberList, renderPresenceTable, renderRelative } from './profile-shared.ts';
+import { sentryClient } from './sentry.ts';
+import './individual-map.ts';
+
+sentryClient.init();
+
+interface Profile {
+  group: MatrilineProfile;
+  groups: Map<number, SocialGroup>;
+  members: GroupMember[];
+  name: string | null;
+}
+
+@customElement('matriline-page')
+export class MatrilinePage extends LitElement {
+  @state() private designation = parseMatrilinePath(window.location.pathname);
+
+  #profile = new Task(this, {
+    args: () => [this.designation] as const,
+    task: async ([designation]): Promise<Profile | null> => {
+      if (!designation) return null;
+      const group = await fetchMatriline(designation);
+      if (!group) return null;
+      const [members, groups] = await Promise.all([
+        fetchGroupMembers(group.id),
+        fetchAllGroups(),
+      ]);
+      const name = displayName(group.nicknames);
+      document.title = `${name ? `${name} (${group.designation} matriline)` : `The ${group.designation} matriline`} · SalishSea.io`;
+      return { group, groups, members, name };
+    },
+  });
+
+  // The slow half runs after the profile so the masthead paints first
+  // (individual-page precedent).
+  #sightings = new Task(this, {
+    args: () => [this.#profile.value?.group.id] as const,
+    task: async ([groupId]): Promise<OccurrenceLink[] | null> =>
+      groupId ? fetchGroupOccurrenceLinks(groupId) : null,
+  });
+
+  static styles = profileStyles;
+
+  render() {
+    return html`
+      <main>
+        <a class="back" href="/">&#8592; Back to the map</a>
+        ${this.#profile.render({
+          pending: () => html`<p class="placeholder">Looking up the ${this.designation} matriline&hellip;</p>`,
+          error: () => html`<p class="error">Something went wrong loading this page. Please try again.</p>`,
+          complete: value => value ? this.renderProfile(value) : this.renderNotFound(),
+        })}
+      </main>
+    `;
+  }
+
+  private renderNotFound() {
+    return html`
+      <h1>${this.designation ?? 'Not found'}</h1>
+      <p>We don't have ${this.designation ? html`a <b>${this.designation}</b> matriline` : 'that matriline'} in our catalog.
+      So far it covers Bigg's (transient) killer whales of the Salish Sea; other populations are on the way.</p>
+      <p><a href="/">Explore the sightings map</a> or <a href="/about.html">read about this site</a>.</p>
+    `;
+  }
+
+  private renderProfile({ group, groups, members, name }: Profile) {
+    const chain = groupChain(group.id, groups);
+    const biggs = chain.some(g => g.kind === 'ecotype' && g.designation === 'Biggs');
+    const anchor = group.anchor;
+    const current = members.filter(m => m.is_current);
+    return html`
+      <header class="masthead">
+        <div class="designation-kicker">${name ? `${group.designation} matriline` : biggs ? "Bigg's killer whale matriline" : 'Matriline'}</div>
+        <h1>${name ?? `The ${group.designation} matriline`}</h1>
+        <p class="vitals">
+          ${anchor ? html`Matriline of ${renderRelative(anchor)}${renderDagger(anchor.life_status)}` : nothing}${anchor && current.length ? ' · ' : nothing}${current.length ? `${current.length} current member${current.length === 1 ? '' : 's'}` : nothing}
+        </p>
+        ${when(this.renderChain(chain) !== nothing, () => html`<p class="lineage">${this.renderChain(chain)}</p>`)}
+      </header>
+      ${this.renderNaming(group)}
+      ${this.renderMembers(members)}
+      ${this.renderSightings(group.designation)}
+    `;
+  }
+
+  // "Within T065's matriline · Bigg's (transient) killer whales" — ancestors
+  // only; the masthead already names the group itself.
+  private renderChain(chain: SocialGroup[]): TemplateResult | typeof nothing {
+    const ancestors = chain.slice(1);
+    const parents = ancestors.filter(g => g.kind !== 'ecotype');
+    const ecotype = ancestors.find(g => g.kind === 'ecotype');
+    if (!parents.length && !ecotype) return nothing;
+    return html`${parents.map((g, i) => html`${i ? ' · ' : ''}Within ${g.kind === 'matriline'
+        ? html`<a href=${matrilinePath(g.designation)}>${g.designation}</a>`
+        : g.designation}${g.kind === 'matriline' ? "'s matriline" : ` ${g.kind}`}`)
+      }${ecotype ? html`${parents.length ? ' · ' : ''}${ecotype.designation === 'Biggs' ? "Bigg's (transient) killer whales" : ecotype.designation}` : nothing}`;
+  }
+
+  // Naming facts only (name, status, year, namer) — no story prose (D-21).
+  private renderNaming(group: MatrilineProfile) {
+    const nicknames = group.nicknames.filter(n => n.status !== 'deprecated');
+    if (!nicknames.length) return nothing;
+    return html`
+      <section>
+        <h2>Names</h2>
+        ${repeat(nicknames, n => n.name, n => html`
+          <article class="nickname">
+            <p class="nickname-line">
+              <b>${n.name}</b>
+              ${n.status !== 'official' ? html`<span class="muted">(${n.status.replace('_', ' ')})</span>` : nothing}
+              ${n.named_year || n.namer ? html`<span class="muted"> — named${n.named_year ? ` in ${n.named_year}` : ''}${n.namer ? html` by ${n.namer.url ? html`<a target="_blank" rel="noopener noreferrer" href=${n.namer.url}>${n.namer.name}</a>` : n.namer.name}` : ''}</span>` : nothing}
+            </p>
+          </article>
+        `)}
+      </section>
+    `;
+  }
+
+  private renderMembers(members: GroupMember[]) {
+    return html`
+      <section>
+        <h2>Members</h2>
+        ${members.length
+          ? renderMemberList(members)
+          : html`<p class="placeholder">No cataloged members yet.</p>`}
+      </section>
+    `;
+  }
+
+  private renderSightings(designation: string) {
+    return html`
+      <section>
+        <h2>Sightings</h2>
+        <p class="sightings-note">Reports that mention the ${designation}s as a group. Sightings reported
+        against individual members appear on their own pages instead.</p>
+        ${this.#sightings.render({
+          pending: () => html`<p class="placeholder">Searching sighting reports&hellip;</p>`,
+          error: () => html`<p class="error">Couldn't load sightings just now.</p>`,
+          complete: links => {
+            if (!links?.length)
+              return html`<p class="placeholder">No sighting reports mention the ${designation}s as a group yet.</p>`;
+            const latest = links[0]!;
+            const located = links.filter(l => l.location).length;
+            return html`
+              ${renderPresenceTable(links)}
+              ${when(located, () => html`<individual-map .links=${links}></individual-map>`)}
+              <p class="sightings-note">
+                Last reported <a href=${mapUrl(latest)}>${observedDate(latest.observed_at).toLocaleString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}</a>
+                · ${links.length} report${links.length === 1 ? '' : 's'} in all${when(located, () => html` — ${located === links.length ? 'each' : `${located} of them`} a dot above; the newest located report is solid. Click one to see that day on the map.`)}
+              </p>
+            `;
+          },
+        })}
+      </section>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'matriline-page': MatrilinePage;
+  }
+}

--- a/src/obs-summary.ts
+++ b/src/obs-summary.ts
@@ -15,7 +15,7 @@ import { supabase } from "./supabase.ts";
 import type { Contributor, Occurrence } from "./types.ts";
 import { canEdit } from "./occurrence.ts";
 import { injectPartnerLinks } from './partner-links.ts';
-import { catalogCodes, injectIndividualLinks, loadCatalogCodes } from './individual-links.ts';
+import { catalogCodes, injectIndividualLinks, loadCatalogCodes, matrilineCodes } from './individual-links.ts';
 
 const domPurify = createDOMPurify(window as any);
 
@@ -213,7 +213,8 @@ export class ObsSummary extends LitElement {
           marked.parse(
             injectIndividualLinks(
               injectPartnerLinks(stripResolvedProvenance((body || '').replace(/(<br\s*\/?\s*>\s*)+/gi, '\n\n'), provider_slug)),
-              catalogCodes() ?? new Map()
+              catalogCodes() ?? new Map(),
+              matrilineCodes() ?? new Map()
             ),
             { async: false, renderer: markedRenderer }
           ),

--- a/src/profile-shared.ts
+++ b/src/profile-shared.ts
@@ -162,11 +162,12 @@ export function renderDagger(lifeStatus: string) {
     : nothing;
 }
 
-// A matriline's member roster, oldest first. `selfId` bolds the page's own
-// individual instead of linking it (individual pages only).
+// A matriline's member roster, oldest first (unknown birth years last).
+// `selfId` bolds the page's own individual instead of linking it (individual
+// pages only).
 export function renderMemberList(members: GroupMember[], selfId?: number) {
   const sorted = [...members].sort((a, b) =>
-    (a.individual?.born_earliest ?? -Infinity) - (b.individual?.born_earliest ?? -Infinity));
+    (a.individual?.born_earliest ?? Infinity) - (b.individual?.born_earliest ?? Infinity));
   return html`
     <ul class="people">
       ${repeat(sorted, m => m.individual!.id, m => html`

--- a/src/profile-shared.ts
+++ b/src/profile-shared.ts
@@ -1,0 +1,210 @@
+import { css, html, nothing } from 'lit';
+import { repeat } from 'lit/directives/repeat.js';
+import { Temporal } from 'temporal-polyfill';
+import {
+  displayName, individualPath, monthlyPresence,
+  type GroupMember, type OccurrenceLink,
+} from './catalog.ts';
+
+// Shared rendering for the profile pages (individual-page, matriline-page).
+// Lit styles are scoped per component, so the common rules live here as a
+// CSSResult both pages put first in their `static styles` arrays.
+
+export const PRESENCE_YEARS = 4;
+const MONTH_INITIALS = ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'];
+
+export const profileStyles = css`
+  :host {
+    display: block;
+  }
+  main {
+    margin: 0 auto;
+    max-width: 44rem;
+    padding: 1rem 1rem 4rem;
+  }
+  a {
+    color: #1976d2;
+    font-weight: 500;
+    text-decoration: none;
+  }
+  a:hover {
+    color: #1565c0;
+  }
+  .back {
+    display: inline-block;
+    margin-bottom: 2.5rem;
+  }
+  header.masthead {
+    margin-bottom: 2.5rem;
+  }
+  .designation-kicker {
+    color: #64748b;
+    font-size: 0.9375rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  h1 {
+    font-size: clamp(2.25rem, 6vw, 3.25rem);
+    font-weight: 600;
+    line-height: 1.1;
+    margin: 0.25rem 0 0.5rem;
+  }
+  .vitals {
+    color: #475569;
+    font-size: 1.0625rem;
+    margin: 0;
+  }
+  .lineage {
+    color: #64748b;
+    font-size: 0.9375rem;
+    margin: 0.5rem 0 0;
+  }
+  .lineage b {
+    color: #475569;
+    font-weight: 600;
+  }
+  section {
+    margin-top: 2.5rem;
+  }
+  h2 {
+    border-bottom: 1px solid #e2e8f0;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    margin: 0 0 1rem;
+    padding-bottom: 0.375rem;
+    text-transform: uppercase;
+  }
+  ul.people {
+    display: inline;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  ul.people li {
+    display: inline;
+  }
+  ul.people li:not(:last-child)::after {
+    content: " · ";
+    color: #94a3b8;
+  }
+  .muted {
+    color: #64748b;
+  }
+  .self {
+    font-weight: 600;
+  }
+  article.nickname {
+    margin-bottom: 1.25rem;
+  }
+  article.nickname:last-child {
+    margin-bottom: 0;
+  }
+  .nickname-line {
+    margin: 0;
+  }
+  .nickname-line b {
+    font-weight: 600;
+  }
+  table.presence {
+    border-collapse: collapse;
+    font-variant-numeric: tabular-nums;
+  }
+  table.presence th {
+    color: #94a3b8;
+    font-size: 0.75rem;
+    font-weight: 500;
+    padding: 0.125rem;
+    text-align: center;
+  }
+  table.presence th[scope="row"] {
+    color: #64748b;
+    padding-right: 0.625rem;
+    text-align: right;
+  }
+  table.presence td {
+    border: 1px solid #f1f5f9;
+    color: #1e3a5f;
+    font-size: 0.8125rem;
+    height: 1.75rem;
+    min-width: 1.75rem;
+    padding: 0;
+    text-align: center;
+  }
+  table.presence td.p1 { background: #e3f2fd; }
+  table.presence td.p2 { background: #bbdefb; }
+  table.presence td.p3 { background: #90caf9; }
+  .presence-note, .sightings-note {
+    color: #64748b;
+    font-size: 0.875rem;
+    margin: 0.75rem 0 0;
+  }
+  individual-map {
+    display: block;
+    margin-top: 1.5rem;
+  }
+  .placeholder {
+    color: #64748b;
+  }
+  .error {
+    color: #b71c1c;
+  }
+`;
+
+export function renderRelative(relative: { primary_designation: string; nicknames?: { name: string; status: string | null }[] }) {
+  const name = relative.nicknames ? displayName(relative.nicknames) : null;
+  return html`<a href=${individualPath(relative.primary_designation)}>${relative.primary_designation}${name ? ` ${name}` : ''}</a>`;
+}
+
+export function renderDagger(lifeStatus: string) {
+  return lifeStatus === 'deceased' || lifeStatus === 'presumed_deceased'
+    ? html`<span class="muted" title=${lifeStatus === 'deceased' ? 'deceased' : 'presumed deceased'}>&dagger;</span>`
+    : nothing;
+}
+
+// A matriline's member roster, oldest first. `selfId` bolds the page's own
+// individual instead of linking it (individual pages only).
+export function renderMemberList(members: GroupMember[], selfId?: number) {
+  const sorted = [...members].sort((a, b) =>
+    (a.individual?.born_earliest ?? -Infinity) - (b.individual?.born_earliest ?? -Infinity));
+  return html`
+    <ul class="people">
+      ${repeat(sorted, m => m.individual!.id, m => html`
+        <li class=${m.individual!.id === selfId ? 'self' : ''}>
+          ${m.individual!.id === selfId
+            ? html`${m.individual!.primary_designation}`
+            : renderRelative(m.individual!)}${m.individual!.born_earliest ? html` <span class="muted">b.&thinsp;${m.individual!.born_earliest}</span>` : nothing}${renderDagger(m.individual!.life_status)}${!m.is_current ? html` <span class="muted">(former)</span>` : nothing}
+        </li>
+      `)}
+    </ul>
+  `;
+}
+
+// The month×year report-count grid with its honesty note.
+export function renderPresenceTable(links: OccurrenceLink[]) {
+  const currentYear = Temporal.Now.zonedDateTimeISO('PST8PDT').year;
+  const grid = monthlyPresence(links, PRESENCE_YEARS, currentYear);
+  if (grid.every(row => row.months.every(count => count === 0))) return nothing;
+  return html`
+    <table class="presence">
+      <thead>
+        <tr>
+          <td></td>
+          ${MONTH_INITIALS.map((initial, i) => html`<th scope="col" title=${Temporal.PlainDate.from({year: 2000, month: i + 1, day: 1}).toLocaleString('en-US', {month: 'long'})}>${initial}</th>`)}
+        </tr>
+      </thead>
+      <tbody>
+        ${grid.map(({ year, months }) => html`
+          <tr>
+            <th scope="row">${year}</th>
+            ${months.map((count, i) => html`
+              <td class=${count >= 4 ? 'p3' : count >= 2 ? 'p2' : count === 1 ? 'p1' : ''}
+                  title="${count} report${count === 1 ? '' : 's'} in ${Temporal.PlainDate.from({year, month: i + 1, day: 1}).toLocaleString('en-US', {month: 'long', year: 'numeric'})}">${count || nothing}</td>
+            `)}
+          </tr>
+        `)}
+      </tbody>
+    </table>
+    <p class="presence-note">Reports per month. Most are unverified mentions in sighting text, not confirmed identifications.</p>
+  `;
+}

--- a/supabase/migrations/20260708021011_group_occurrences.sql
+++ b/supabase/migrations/20260708021011_group_occurrences.sql
@@ -1,0 +1,49 @@
+-- A social group's own sighting record for its profile page (bd
+-- salishsea-io-w2d, decision 016): identifications naming the group as a
+-- unit ("T65As"). Deliberately NO member fan-out — the union of members'
+-- sightings would double-count and blur whose sighting it was; that view of
+-- the data belongs to the members' own pages (individual_occurrences).
+--
+-- Same two-branch shape as individual_occurrences (20260708000104): stored
+-- claims stay live so curation takes effect immediately; candidates come from
+-- the cache with their own observed_at/location, shadowed by any stored claim
+-- for the same (occurrence, group). identifications' XOR CHECK guarantees
+-- social_group_id rows carry no individual_id, so matching on social_group_id
+-- alone is exact — a stored claim about an individual member must not
+-- suppress a group candidate on the same occurrence.
+CREATE VIEW public.group_occurrences AS
+SELECT
+  s.social_group_id,
+  s.occurrence_id,
+  o.observed_at,
+  o.location,
+  s.is_present,
+  s.status,
+  s.evidence,
+  s.code
+FROM public.identifications s
+JOIN public.occurrences o
+  ON o.id = s.occurrence_id
+WHERE s.social_group_id IS NOT NULL
+UNION ALL
+SELECT
+  c.social_group_id,
+  c.occurrence_id,
+  c.observed_at,
+  c.location,
+  true AS is_present,
+  'candidate'::public.identification_status AS status,
+  'text_mention'::public.identification_evidence AS evidence,
+  c.code
+FROM public.occurrence_identifier_candidates c
+WHERE c.social_group_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM public.identifications s
+    WHERE s.occurrence_id = c.occurrence_id
+      AND s.social_group_id = c.social_group_id
+  );
+
+-- Views don't inherit table policies; grant reads explicitly (the view runs
+-- with definer rights, which is what lets clients read through it to the
+-- REVOKEd candidates matview).
+GRANT SELECT ON public.group_occurrences TO anon, authenticated;

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,10 +5,16 @@ import { defineConfig } from 'vite';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-// Exactly one path segment after /individuals/ — the page's own module/asset
+// Exactly one path segment after the prefix — the page's own module/asset
 // requests resolve elsewhere and must not be swallowed by the rewrite.
-function individualsRewrite(req, _res, next) {
-  if (/^\/individuals\/[^/]+\/?(\?.*)?$/.test(req.url ?? '')) req.url = '/individual.html';
+const PROFILE_REWRITES = [
+  [/^\/individuals\/[^/]+\/?(\?.*)?$/, '/individual.html'],
+  [/^\/matrilines\/[^/]+\/?(\?.*)?$/, '/matriline.html'],
+];
+
+function profilePagesRewrite(req, _res, next) {
+  const rewrite = PROFILE_REWRITES.find(([re]) => re.test(req.url ?? ''));
+  if (rewrite) req.url = rewrite[1];
   next();
 }
 
@@ -21,6 +27,7 @@ export default defineConfig({
         main: resolve(__dirname, 'index.html'),
         about: resolve(__dirname, 'about.html'),
         individual: resolve(__dirname, 'individual.html'),
+        matriline: resolve(__dirname, 'matriline.html'),
       }
     },
 
@@ -29,15 +36,16 @@ export default defineConfig({
 
   plugins: [
     {
-      // In production this rewrite lives in the CloudFront viewer-request
-      // Lambda@Edge (infra/lib/edge-handler): /individuals/<designation> is a
-      // client-rendered page served from the individual.html shell.
-      name: 'individuals-rewrite',
+      // In production these rewrites live in the CloudFront viewer-request
+      // Lambda@Edge (infra/lib/edge-handler): /individuals/<designation> and
+      // /matrilines/<designation> are client-rendered pages served from their
+      // HTML shells.
+      name: 'profile-pages-rewrite',
       configureServer(server) {
-        server.middlewares.use(individualsRewrite);
+        server.middlewares.use(profilePagesRewrite);
       },
       configurePreviewServer(server) {
-        server.middlewares.use(individualsRewrite);
+        server.middlewares.use(profilePagesRewrite);
       },
     },
     {


### PR DESCRIPTION
## Summary

First cut of social-group pages (bd `salishsea-io-w2d`), matriline-first: every cataloged matriline gets a profile page at `/matrilines/<designation>` mirroring the individual pages from decision 015. See the new [decision 016](docs/decisions/016-matriline-profile-pages.md).

- **New `group_occurrences` view** (`supabase/migrations/20260708021011`): a matriline's sightings are identifications/candidates naming the group **as a unit** — deliberately no member fan-out (the union of members' sightings double-counts and is already on the members' pages). Same live-stored + cached-candidate two-branch shape as `individual_occurrences`, with the shadow rule.
- **`matriline.html` + `<matriline-page>`**: masthead (matriarch link, lineage chain), naming facts (D-21: no story/notes prose), member roster, presence grid, static sightings map. `/matrilines/Biggs` 404s via the `kind=matriline` filter.
- **Shared rendering** extracted to `src/profile-shared.ts` (member list, presence table, common styles as a shared `CSSResult`); `individual-page.ts` re-verified unchanged.
- **Edge handler**: the `/individuals` branch became a two-entry route table (human shell rewrite, bot OG preview, fail-open) — pods/clans later are one entry each. No CDK changes.
- **Cross-linking**: s-suffixed codes ("T65As") in sighting text now link to matriline pages site-wide (`injectIndividualLinks` third arg); individual pages' matriline section headers link out.

## Testing

- `npm test`: 298 passing (new: matriline path helpers, group-row dedupe, matriline link injection incl. unresolved/backward-compat cases).
- `infra`: tsc + 48 jest tests (new `/matrilines` suite mirrors `/individuals`; existing suite guards the route-table refactor).
- `npm run build` (html-validate + CSP check) passes; dev + preview rewrites verified.
- Local end-to-end: `/matrilines/T065A` renders all sections against seeded data; stored-claim shadowing verified in psql; "T65As" in a live sighting card links to the matriline page.
- e2e `og-previews` gains two `/matrilines/T065A` tests — they run post-deploy in smoke.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added matriline profile pages, including a dedicated page shell and bot-friendly Open Graph/Twitter preview metadata.
  * Matriline codes and names in content now link to the correct matriline pages when resolvable.

* **Bug Fixes**
  * Improved profile routing and fail-safe behavior so both browsers and preview bots load the right page content.
  * Matriline sightings are now sourced from direct group records with clearer, deduped results.

* **Tests / Documentation**
  * Added end-to-end coverage for matriline Open Graph previews and updated related decision documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->