### PR TITLE
Bigg's ecotype profile page at /ecotypes/Biggs

### DIFF
--- a/database.types.ts
+++ b/database.types.ts
@@ -691,6 +691,17 @@ export type Database = {
       }
     }
     Views: {
+      ecotype_occurrences: {
+        Row: {
+          ecotype_id: number | null
+          is_present: boolean | null
+          location: Database["public"]["CompositeTypes"]["lon_lat"] | null
+          observed_at: string | null
+          occurrence_id: string | null
+          status: Database["public"]["Enums"]["identification_status"] | null
+        }
+        Relationships: []
+      }
       group_occurrences: {
         Row: {
           code: string | null

--- a/docs/decisions/017-ecotype-profile-pages.md
+++ b/docs/decisions/017-ecotype-profile-pages.md
@@ -54,8 +54,11 @@ is named).
   not rendered from `social_groups.notes` (notes/story prose are never shown).
 - **Honesty invariant (015):** the sightings copy states the grid pools all
   members' reports, mostly unverified mentions.
-- Not in `sitemap.xml`. The only inbound links are the ecotype labels in the
-  individual and matriline lineage chains, now linked to this page.
+- Not in `sitemap.xml`. Inbound links: the ecotype labels in the individual and
+  matriline lineage chains, plus ecotype names written out in sighting prose
+  ("Biggs", "Bigg's", "transients") — `injectIndividualLinks` links these
+  fixed terms in code (there is no catalog designation for a prose word),
+  alongside the codes it already links.
 
 ## Consequences / follow-ups
 

--- a/docs/decisions/017-ecotype-profile-pages.md
+++ b/docs/decisions/017-ecotype-profile-pages.md
@@ -1,0 +1,66 @@
+# 017 — Ecotype profile pages
+
+**Status:** accepted (2026-07-07)
+**Context:** bd `salishsea-io-zw6`; builds on matriline pages (decision 016).
+The ecotype is the root of the social-group hierarchy — one `social_groups`
+row (`kind='ecotype'`, `designation='Biggs'`, no anchor, no parent), parent of
+all 65 top-level → 132 total matrilines, and every cataloged Bigg's
+individual descends from it.
+
+## Decision
+
+Give the ecotype a page at **`/ecotypes/Biggs`**, mirroring decision 016's
+shell/edge/read-view pattern (third entry in the edge `PROFILE_ROUTES` table
+and the Vite rewrite list). The page is the root of the hierarchy: no anchor
+matriarch, no lineage chain above it.
+
+### Content: a directory and a pooled sighting record
+
+The page's core is a **flat A–Z directory** of all descendant matrilines, each
+linking to its matriline page. Below it, a sightings section with the same
+presence grid + static map as the other profile pages.
+
+### Read path: `ecotype_occurrences`, a deliberate fan-out
+
+An ecotype's sightings are the **union of every descendant's reports** — member
+individuals (resolved through their current maternal matriline up the tree) and
+descendant matrilines named directly. This **deliberately fans out**, which is
+the opposite of the matriline page's rule (decision 016):
+
+- A **matriline** page shows reports naming the group *as a unit* ("T65As") —
+  no fan-out, because a text mention of the matriline is a distinct claim from a
+  mention of one member.
+- An **ecotype**'s membership is instead *structural and complete*: every T-whale
+  is a Bigg's whether or not the word "Bigg's" appears in the report. So pooling
+  all members' reports isn't double-counting — it is the honest, fullest
+  presence record the catalog can produce. (Locally, 17 distinct occurrences
+  resolve to Bigg's, a real subset of the 56 raw orca occurrences.)
+
+The new `public.ecotype_occurrences` view (migration `20260708031133`) computes
+this with a recursive CTE that walks `social_groups.parent_group_id` to each
+subject's `kind='ecotype'` root, unioning `group_occurrences` (branch A) and
+`individual_occurrences` joined through maternal `group_memberships` (branch B).
+It is **tree-scoped, not "all individuals"**, so when SRKW lands as a second
+ecotype each subject partitions cleanly by `ecotype_id`. One PostgREST filter
+(`ecotype_id`) powers the page; the client (`dedupeOccurrenceLinks`) collapses
+the two branches to one row per occurrence. Individuals with no maternal
+membership row are excluded from branch B (a no-op today — all cataloged
+individuals have one — and they still surface via branch A if their matriline
+is named).
+
+### Invariants carried over
+
+- **D-21:** the "Bigg's (transient) killer whales" descriptor is set in code,
+  not rendered from `social_groups.notes` (notes/story prose are never shown).
+- **Honesty invariant (015):** the sightings copy states the grid pools all
+  members' reports, mostly unverified mentions.
+- Not in `sitemap.xml`. The only inbound links are the ecotype labels in the
+  individual and matriline lineage chains, now linked to this page.
+
+## Consequences / follow-ups
+
+- Pod, clan, and named-group pages remain follow-ups: one `PROFILE_ROUTES`
+  entry + one shell each, as before.
+- `ecotype_occurrences` is the first read view that fans out through the group
+  tree; a future pod page (an intermediate node) would reuse the same recursive
+  descendants shape scoped to the pod rather than the ecotype root.

--- a/e2e/og-previews.spec.ts
+++ b/e2e/og-previews.spec.ts
@@ -76,3 +76,27 @@ test('regular browser UA on a matriline page receives the page shell', async ({ 
   // shell (there is no S3 object at the path itself).
   expect(body).toContain('<matriline-page>');
 });
+
+test('bot UA on an ecotype page receives profile OG meta tags', async ({ request }) => {
+  const response = await request.get('/ecotypes/Biggs', {
+    headers: { 'User-Agent': 'facebookexternalhit/1.1' },
+  });
+
+  expect(response.status()).toBe(200);
+  const body = await response.text();
+  expect(body).toContain('og:title');
+  expect(body).toContain('content="profile"');
+  expect(body).toContain('https://salishsea.io/ecotypes/Biggs');
+});
+
+test('regular browser UA on an ecotype page receives the page shell', async ({ request }) => {
+  const response = await request.get('/ecotypes/Biggs', {
+    headers: { 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36' },
+  });
+
+  expect(response.status()).toBe(200);
+  const body = await response.text();
+  // The viewer-request function rewrites /ecotypes/* to the ecotype.html
+  // shell (there is no S3 object at the path itself).
+  expect(body).toContain('<ecotype-page>');
+});

--- a/ecotype.html
+++ b/ecotype.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self';
+      script-src 'self';
+      style-src 'self' 'unsafe-inline';
+      img-src 'self' https: data:;
+      font-src 'self';
+      connect-src 'self' %VITE_SUPABASE_URL% %VITE_SUPABASE_WS_URL% https://o4509634382331904.ingest.us.sentry.io;
+      object-src 'none';
+      media-src 'self';
+      worker-src 'self';
+      base-uri 'self';
+      form-action 'none';
+      upgrade-insecure-requests;
+    ">
+    <title>Ecotype — SalishSea.io</title>
+    <meta name="description" content="Profile of a killer whale ecotype in the Salish Sea: its matrilines and aggregated sighting history.">
+    <meta property="og:site_name" content="SalishSea.io">
+    <meta property="og:type" content="profile">
+    <meta property="og:title" content="Ecotype — SalishSea.io">
+    <meta property="og:description" content="Profile of a killer whale ecotype in the Salish Sea: its matrilines and aggregated sighting history.">
+    <meta property="og:image" content="https://salishsea.io/preview.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <!-- Root-absolute URLs: this shell is served at /ecotypes/<designation>,
+         so relative paths would resolve under /ecotypes/. -->
+    <link href="/src/assets/favicon.ico" rel="icon" type="image/x-icon">
+    <style>
+      :root {
+        font-family: Mukta,Helvetica,Arial,sans-serif;
+        line-height: 1.5;
+        font-weight: 400;
+        color: #213547;
+        background-color: #ffffff;
+        font-synthesis: none;
+        text-rendering: optimizeLegibility;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+      body {
+        margin: 0;
+      }
+    </style>
+    <script type="module" src="/src/ecotype-page.ts"></script>
+  </head>
+  <body>
+    <ecotype-page></ecotype-page>
+  </body>
+</html>

--- a/infra/lib/edge-handler/index.test.ts
+++ b/infra/lib/edge-handler/index.test.ts
@@ -582,3 +582,70 @@ describe('/matrilines/<designation> profile pages', () => {
     expect(result.uri).toBe('/matriline.html');
   });
 });
+
+describe('/ecotypes/<designation> profile pages', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    _clearCredentialCache();
+    jest.spyOn(global, 'fetch').mockReset();
+  });
+
+  const sampleEcotype = { designation: 'Biggs', nicknames: [] };
+
+  it('rewrites the URI to /ecotype.html for a human user-agent', async () => {
+    const event = makeEvent('Mozilla/5.0 (Macintosh)', '', '/ecotypes/Biggs');
+    const result = await handler(event);
+    expect(result).toBe(event.Records[0].cf.request);
+    expect(result.uri).toBe('/ecotype.html');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not rewrite deeper paths under /ecotypes/', async () => {
+    const event = makeEvent('Mozilla/5.0 (Macintosh)', '', '/ecotypes/Biggs/members');
+    const result = await handler(event);
+    expect(result.uri).toBe('/ecotypes/Biggs/members');
+  });
+
+  it('returns ecotype-specific OG tags for a bot', async () => {
+    mockSsmCredentials();
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => [sampleEcotype],
+    } as Response);
+
+    const event = makeEvent('facebookexternalhit/1.1', '', '/ecotypes/Biggs');
+    const result = await handler(event) as { status: string; body: string };
+    expect(result.status).toBe('200');
+    expect(result.body).toContain(`content="Bigg's (transient) killer whales"`);
+    expect(result.body).toContain('content="https://salishsea.io/ecotypes/Biggs"');
+    expect(result.body).toContain('content="profile"');
+
+    const apiUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+    expect(apiUrl).toContain('/rest/v1/social_groups?designation=eq.Biggs');
+    expect(apiUrl).toContain('kind=eq.ecotype');
+  });
+
+  it('returns the generic preview for an unknown designation', async () => {
+    mockSsmCredentials();
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    } as Response);
+
+    const event = makeEvent('facebookexternalhit/1.1', '', '/ecotypes/NOPE');
+    const result = await handler(event) as { status: string; body: string };
+    expect(result.status).toBe('200');
+    expect(result.body).toContain('Salish Sea');
+    expect(result.body).not.toContain('NOPE');
+  });
+
+  it('fail-open for a bot still rewrites to the page shell when fetch throws', async () => {
+    mockSsmCredentials();
+    jest.spyOn(global, 'fetch').mockRejectedValue(new Error('network down'));
+
+    const event = makeEvent('facebookexternalhit/1.1', '', '/ecotypes/Biggs');
+    const result = await handler(event);
+    expect(result).toBe(event.Records[0].cf.request);
+    expect(result.uri).toBe('/ecotype.html');
+  });
+});

--- a/infra/lib/edge-handler/index.ts
+++ b/infra/lib/edge-handler/index.ts
@@ -210,12 +210,50 @@ async function matrilinePreview(designation: string): Promise<any> {
   return htmlResponse(matrilinePreviewTags(group));
 }
 
-// Profile pages rendered client-side from a static shell (decision 015/016):
+// Well-known killer whale ecotype descriptors. notes on the social_groups row
+// carries this too, but notes are never rendered (D-21), so it lives in code.
+const ECOTYPE_LABELS: Record<string, string> = {
+  Biggs: "Bigg's (transient) killer whales",
+};
+
+function ecotypePreviewTags(group: SocialGroup): OgTags {
+  const designation = group.designation;
+  const label = ECOTYPE_LABELS[designation] ?? `The ${designation} ecotype`;
+  const description = `The matrilines and aggregated sighting history of ${label} in the Salish Sea.`;
+  return {
+    'og:site_name': 'SalishSea.io',
+    'og:type': 'profile',
+    'og:url': `https://salishsea.io/ecotypes/${encodeURIComponent(designation)}`,
+    'og:title': label,
+    'og:description': description,
+    'og:image': FALLBACK_IMAGE,
+    'twitter:card': 'summary_large_image',
+    'fb:app_id': FB_APP_ID,
+  };
+}
+
+// OG-meta response for a bot fetching an ecotype's profile page.
+async function ecotypePreview(designation: string): Promise<any> {
+  const { url, key } = await getCredentials();
+  const apiUrl = `${url}/rest/v1/social_groups?designation=eq.${encodeURIComponent(designation)}`
+    + '&kind=eq.ecotype&select=designation,nicknames(name,status)&limit=1';
+  const res = await fetch(apiUrl, {
+    headers: { 'apikey': key, 'Authorization': `Bearer ${key}` },
+  });
+  if (!res.ok) return htmlResponse(genericPreviewTags());
+  const groups = await res.json() as SocialGroup[];
+  const group = groups[0];
+  if (!group) return htmlResponse(genericPreviewTags());
+  return htmlResponse(ecotypePreviewTags(group));
+}
+
+// Profile pages rendered client-side from a static shell (decision 015/016/017):
 // humans get the shell rewrite, bots get synthesized OG meta. S3 has no object
 // at these paths, so even the fail-open branch must rewrite to the shell.
 const PROFILE_ROUTES = [
   { re: /^\/individuals\/([^/]+)\/?$/, shell: '/individual.html', preview: individualPreview },
   { re: /^\/matrilines\/([^/]+)\/?$/, shell: '/matriline.html', preview: matrilinePreview },
+  { re: /^\/ecotypes\/([^/]+)\/?$/, shell: '/ecotype.html', preview: ecotypePreview },
 ];
 
 function matchProfileRoute(uri: string): { shell: string; preview: (designation: string) => Promise<any>; designation: string } | null {

--- a/src/catalog.test.ts
+++ b/src/catalog.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import {
-  dedupeOccurrenceLinks, displayName, groupChain, individualPath, matrilinePath, monthlyPresence,
-  normalizeDesignation, parseIndividualPath, parseMatrilinePath,
+  dedupeOccurrenceLinks, displayName, ecotypePath, groupChain, individualPath, matrilinePath, monthlyPresence,
+  normalizeDesignation, parseEcotypePath, parseIndividualPath, parseMatrilinePath,
   type IndividualOccurrence, type OccurrenceLink, type SocialGroup,
 } from './catalog.ts';
 
@@ -33,6 +33,21 @@ test('parses /matrilines/<designation> paths', () => {
 test('matrilinePath round-trips through parseMatrilinePath', () => {
   for (const designation of ['T065A', 'T046B', 'AM25 X']) {
     expect(parseMatrilinePath(matrilinePath(designation))).toBe(designation);
+  }
+});
+
+test('parses /ecotypes/<designation> paths', () => {
+  expect(parseEcotypePath('/ecotypes/Biggs')).toBe('Biggs');
+  expect(parseEcotypePath('/ecotypes/Biggs/')).toBe('Biggs');
+  expect(parseEcotypePath('/ecotypes/')).toBeNull();
+  expect(parseEcotypePath('/ecotypes/Biggs/members')).toBeNull();
+  expect(parseEcotypePath('/matrilines/Biggs')).toBeNull();
+  expect(parseMatrilinePath('/ecotypes/Biggs')).toBeNull();
+});
+
+test('ecotypePath round-trips through parseEcotypePath', () => {
+  for (const designation of ['Biggs', 'Southern Residents']) {
+    expect(parseEcotypePath(ecotypePath(designation))).toBe(designation);
   }
 });
 

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -35,6 +35,10 @@ export function matrilinePath(designation: string): string {
   return `/matrilines/${encodeURIComponent(designation)}`;
 }
 
+export function ecotypePath(designation: string): string {
+  return `/ecotypes/${encodeURIComponent(designation)}`;
+}
+
 function parseProfilePath(pathname: string, re: RegExp): string | null {
   const match = pathname.match(re);
   if (!match) return null;
@@ -53,6 +57,11 @@ export function parseIndividualPath(pathname: string): string | null {
 // Extract the designation from a /matrilines/<designation> path.
 export function parseMatrilinePath(pathname: string): string | null {
   return parseProfilePath(pathname, /^\/matrilines\/([^/]+)\/?$/);
+}
+
+// Extract the designation from an /ecotypes/<designation> path.
+export function parseEcotypePath(pathname: string): string | null {
+  return parseProfilePath(pathname, /^\/ecotypes\/([^/]+)\/?$/);
 }
 
 // TS port of public.normalize_designation (20260707220211_identifications.sql):
@@ -241,6 +250,45 @@ export async function fetchGroupOccurrenceLinks(groupId: number): Promise<Occurr
     .eq('social_group_id', groupId)
     .throwOnError();
   return dedupeOccurrenceLinks(data);
+}
+
+// An ecotype has no anchor individual and no group nicknames today, but the
+// select mirrors the matriline shape so the masthead can grow. Facts only (D-21).
+const ECOTYPE_SELECT = `
+  *,
+  nicknames (name, theme, status, named_year, namer:parties (name, url))
+` as const;
+
+export async function fetchEcotype(designation: string) {
+  const { data } = await supabase()
+    .from('social_groups')
+    .select(ECOTYPE_SELECT)
+    .eq('designation', designation)
+    .eq('kind', 'ecotype')
+    .maybeSingle()
+    .throwOnError();
+  return data;
+}
+export type EcotypeProfile = NonNullable<Awaited<ReturnType<typeof fetchEcotype>>>;
+
+// The ecotype's sighting record is the union of every descendant's reports
+// (see docs/decisions/017); one filter on ecotype_id, deduped per occurrence.
+export async function fetchEcotypeOccurrenceLinks(ecotypeId: number): Promise<OccurrenceLink[]> {
+  const { data } = await supabase()
+    .from('ecotype_occurrences')
+    .select()
+    .eq('ecotype_id', ecotypeId)
+    .throwOnError();
+  return dedupeOccurrenceLinks(data);
+}
+
+// The matrilines that descend from an ecotype, sorted A–Z — for the ecotype
+// page's directory. Tree-scoped (via groupChain), so a future second ecotype
+// only lists its own matrilines.
+export function descendantMatrilines(ecotypeId: number, groupsById: Map<number, SocialGroup>): SocialGroup[] {
+  return [...groupsById.values()]
+    .filter(g => g.kind === 'matriline' && groupChain(g.id, groupsById).some(a => a.id === ecotypeId))
+    .sort((a, b) => a.designation.localeCompare(b.designation));
 }
 
 // The official nickname if there is one, else the first non-deprecated one.

--- a/src/ecotype-page.ts
+++ b/src/ecotype-page.ts
@@ -1,0 +1,140 @@
+import { html, LitElement, nothing } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { Task } from '@lit/task';
+import { when } from 'lit/directives/when.js';
+import { repeat } from 'lit/directives/repeat.js';
+import {
+  descendantMatrilines, fetchAllGroups, fetchEcotype, fetchEcotypeOccurrenceLinks,
+  mapUrl, matrilinePath, observedDate, parseEcotypePath,
+  type EcotypeProfile, type OccurrenceLink, type SocialGroup,
+} from './catalog.ts';
+import { profileStyles, renderPresenceTable } from './profile-shared.ts';
+import { sentryClient } from './sentry.ts';
+import './individual-map.ts';
+
+sentryClient.init();
+
+// The catalog's one ecotype today; its notes column carries this descriptor but
+// notes are never rendered (D-21), so the display label is set in code.
+const ECOTYPE_LABELS: Record<string, string> = {
+  Biggs: "Bigg's (transient) killer whales",
+};
+
+interface Profile {
+  group: EcotypeProfile;
+  matrilines: SocialGroup[];
+}
+
+@customElement('ecotype-page')
+export class EcotypePage extends LitElement {
+  @state() private designation = parseEcotypePath(window.location.pathname);
+
+  #profile = new Task(this, {
+    args: () => [this.designation] as const,
+    task: async ([designation]): Promise<Profile | null> => {
+      if (!designation) return null;
+      const [group, groups] = await Promise.all([
+        fetchEcotype(designation),
+        fetchAllGroups(),
+      ]);
+      if (!group) return null;
+      const matrilines = descendantMatrilines(group.id, groups);
+      document.title = `${ECOTYPE_LABELS[group.designation] ?? group.designation} · SalishSea.io`;
+      return { group, matrilines };
+    },
+  });
+
+  // The slow half runs after the profile so the masthead paints first.
+  #sightings = new Task(this, {
+    args: () => [this.#profile.value?.group.id] as const,
+    task: async ([ecotypeId]): Promise<OccurrenceLink[] | null> =>
+      ecotypeId ? fetchEcotypeOccurrenceLinks(ecotypeId) : null,
+  });
+
+  static styles = profileStyles;
+
+  render() {
+    return html`
+      <main>
+        <a class="back" href="/">&#8592; Back to the map</a>
+        ${this.#profile.render({
+          pending: () => html`<p class="placeholder">Looking up ${this.designation}&hellip;</p>`,
+          error: () => html`<p class="error">Something went wrong loading this page. Please try again.</p>`,
+          complete: value => value ? this.renderProfile(value) : this.renderNotFound(),
+        })}
+      </main>
+    `;
+  }
+
+  private renderNotFound() {
+    return html`
+      <h1>${this.designation ?? 'Not found'}</h1>
+      <p>We don't have ${this.designation ? html`a <b>${this.designation}</b> ecotype` : 'that ecotype'} in our catalog.
+      So far it covers Bigg's (transient) killer whales of the Salish Sea; other populations are on the way.</p>
+      <p><a href="/">Explore the sightings map</a> or <a href="/about.html">read about this site</a>.</p>
+    `;
+  }
+
+  private renderProfile({ group, matrilines }: Profile) {
+    const label = ECOTYPE_LABELS[group.designation] ?? group.designation;
+    return html`
+      <header class="masthead">
+        <div class="designation-kicker">Ecotype</div>
+        <h1>${label}</h1>
+        ${matrilines.length
+          ? html`<p class="vitals">${matrilines.length} matrilines cataloged in the Salish Sea</p>`
+          : nothing}
+      </header>
+      ${this.renderDirectory(matrilines)}
+      ${this.renderSightings(label)}
+    `;
+  }
+
+  private renderDirectory(matrilines: SocialGroup[]) {
+    return html`
+      <section>
+        <h2>Matrilines</h2>
+        ${matrilines.length
+          ? html`<ul class="people">
+              ${repeat(matrilines, g => g.id, g =>
+                html`<li><a href=${matrilinePath(g.designation)}>${g.designation}</a></li>`)}
+            </ul>`
+          : html`<p class="placeholder">No matrilines cataloged yet.</p>`}
+      </section>
+    `;
+  }
+
+  private renderSightings(label: string) {
+    return html`
+      <section>
+        <h2>Sightings</h2>
+        <p class="sightings-note">Every report of any ${label.replace(/ killer whales$/, '')} member —
+        each matriline and individual pooled together. Individual and matriline pages break this down by subject.</p>
+        ${this.#sightings.render({
+          pending: () => html`<p class="placeholder">Searching sighting reports&hellip;</p>`,
+          error: () => html`<p class="error">Couldn't load sightings just now.</p>`,
+          complete: links => {
+            if (!links?.length)
+              return html`<p class="placeholder">No sighting reports resolve to this ecotype yet.</p>`;
+            const latest = links[0]!;
+            const located = links.filter(l => l.location).length;
+            return html`
+              ${renderPresenceTable(links)}
+              ${when(located, () => html`<individual-map .links=${links}></individual-map>`)}
+              <p class="sightings-note">
+                Last reported <a href=${mapUrl(latest)}>${observedDate(latest.observed_at).toLocaleString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}</a>
+                · ${links.length} report${links.length === 1 ? '' : 's'} in all${when(located, () => html` — ${located === links.length ? 'each' : `${located} of them`} a dot above; the newest located report is solid. Click one to see that day on the map.`)}
+              </p>
+            `;
+          },
+        })}
+      </section>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'ecotype-page': EcotypePage;
+  }
+}

--- a/src/individual-links.test.ts
+++ b/src/individual-links.test.ts
@@ -50,3 +50,19 @@ test('normalizes case and separators', () => {
   expect(injectIndividualLinks('t-65a5 with T 65A', codes))
     .toBe('[t-65a5](/individuals/T065A5) with [T 65A](/individuals/T065A)');
 });
+
+test('links ecotype names in prose to the ecotype page', () => {
+  expect(injectIndividualLinks('Biggs T46Bs southbound', codes, matrilines))
+    .toBe('[Biggs](/ecotypes/Biggs) [T46Bs](/matrilines/T046B) southbound');
+  // apostrophe variants and "transient(s)" all resolve to the same ecotype
+  expect(injectIndividualLinks("Bigg's transients milling", codes))
+    .toBe("[Bigg's](/ecotypes/Biggs) [transients](/ecotypes/Biggs) milling");
+  // curly apostrophe
+  expect(injectIndividualLinks('Bigg’s northbound', codes))
+    .toBe('[Bigg’s](/ecotypes/Biggs) northbound');
+});
+
+test('does not link ecotype names inside existing markdown links', () => {
+  const linked = 'see [Biggs report](https://example.com/biggs) for details';
+  expect(injectIndividualLinks(linked, codes)).toBe(linked);
+});

--- a/src/individual-links.ts
+++ b/src/individual-links.ts
@@ -1,5 +1,5 @@
 import { supabase } from './supabase.ts';
-import { individualPath, matrilinePath, normalizeDesignation } from './catalog.ts';
+import { ecotypePath, individualPath, matrilinePath, normalizeDesignation } from './catalog.ts';
 
 // Same shape as public.extract_identifiers (20250924160210_detect_individuals.sql):
 // pod/catalog prefix, optional separator, leading zeros, digit + hex block, and a
@@ -8,17 +8,31 @@ import { individualPath, matrilinePath, normalizeDesignation } from './catalog.t
 // as the embedded individual code.
 const CODE_RE = /\b(j|k|l|t|crc)[- ]?0*(\d[\da-f]+)(s?)\b/gi;
 
+// Ecotype names written out in sighting prose ("Biggs T46Bs southbound"). Unlike
+// codes these aren't in the catalog as designations, so the small set of known
+// terms maps to an ecotype designation in code (mirrors ECOTYPE_LABELS in
+// ecotype-page.ts / the edge handler). Straight and curly apostrophes both.
+const ECOTYPE_TERM_RE = /\b(bigg['’]?s|transients?)\b/gi;
+
+function ecotypeForTerm(term: string): string | null {
+  const t = term.toLowerCase().replace(/[’]/g, "'");
+  if (t === 'biggs' || t === "bigg's" || t === 'transient' || t === 'transients') return 'Biggs';
+  return null;
+}
+
 // Splits body into alternating segments: [plain text, existing-link, plain text, ...]
 // Odd-indexed segments are existing markdown links — leave them untouched.
 const EXISTING_LINK_RE = /(\[.*?\]\(.*?\))/g;
 
 // Turn catalog-resolvable identifier codes in a markdown body into links to the
-// individual's profile page, and matriline codes ("T65As") into links to the
-// matriline's page. `codes` maps a normalized designation (e.g. 'T065A5') to
-// the individual's primary designation; `matrilines` maps a normalized
-// matriarch designation (e.g. 'T065A') to the matriline's designation. Codes
-// that resolve to nothing (SRKW, CRC, uncataloged) pass through as plain text —
-// linking is a navigation aid, never an identification claim.
+// individual's profile page, matriline codes ("T65As") into links to the
+// matriline's page, and ecotype names in prose ("Biggs", "transients") into
+// links to the ecotype page. `codes` maps a normalized designation (e.g.
+// 'T065A5') to the individual's primary designation; `matrilines` maps a
+// normalized matriarch designation (e.g. 'T065A') to the matriline's
+// designation. Codes that resolve to nothing (SRKW, CRC, uncataloged) pass
+// through as plain text — linking is a navigation aid, never an identification
+// claim.
 export function injectIndividualLinks(
   body: string,
   codes: Map<string, string>,
@@ -28,7 +42,7 @@ export function injectIndividualLinks(
     .split(EXISTING_LINK_RE)
     .map((segment, i) => {
       if (i % 2 === 1) return segment;
-      return segment.replace(CODE_RE, (match, prefix: string, block: string, matriline: string) => {
+      const linked = segment.replace(CODE_RE, (match, prefix: string, block: string, matriline: string) => {
         const normalized = normalizeDesignation(`${prefix}${block}`.toUpperCase());
         if (matriline) {
           const designation = matrilines.get(normalized);
@@ -36,6 +50,12 @@ export function injectIndividualLinks(
         }
         const designation = codes.get(normalized);
         return designation ? `[${match}](${individualPath(designation)})` : match;
+      });
+      // Codes never contain an ecotype word and ecotype links never contain a
+      // code, so this second pass can't collide with the one above.
+      return linked.replace(ECOTYPE_TERM_RE, match => {
+        const designation = ecotypeForTerm(match);
+        return designation ? `[${match}](${ecotypePath(designation)})` : match;
       });
     })
     .join('');

--- a/src/individual-page.ts
+++ b/src/individual-page.ts
@@ -5,7 +5,7 @@ import { when } from 'lit/directives/when.js';
 import { repeat } from 'lit/directives/repeat.js';
 import {
   displayName, fetchAllGroups, fetchGroupMembers, fetchIndividual, fetchOccurrenceLinks,
-  fetchOffspring, fetchParents, groupChain, individualPath, mapUrl, matrilinePath,
+  ecotypePath, fetchOffspring, fetchParents, groupChain, individualPath, mapUrl, matrilinePath,
   observedDate, parseIndividualPath,
   type GroupMember, type IndividualProfile, type OccurrenceLink, type Offspring, type Parent, type SocialGroup,
 } from './catalog.ts';
@@ -167,7 +167,7 @@ export class IndividualPage extends LitElement {
         parents.map(g => html` · within ${g.anchor_individual_id && g.designation !== selfDesignation
           ? html`<a href=${individualPath(g.designation)}>${g.designation}</a>`
           : g.designation}${g.kind === 'matriline' ? "'s matriline" : ` ${g.kind}`}`)
-      }${ecotype ? html` · ${ecotype.designation === 'Biggs' ? "Bigg's (transient) killer whales" : ecotype.designation}` : nothing}
+      }${ecotype ? html` · <a href=${ecotypePath(ecotype.designation)}>${ecotype.designation === 'Biggs' ? "Bigg's (transient) killer whales" : ecotype.designation}</a>` : nothing}
     `;
   }
 

--- a/src/matriline-page.ts
+++ b/src/matriline-page.ts
@@ -5,7 +5,7 @@ import { when } from 'lit/directives/when.js';
 import { repeat } from 'lit/directives/repeat.js';
 import {
   displayName, fetchAllGroups, fetchGroupMembers, fetchGroupOccurrenceLinks, fetchMatriline,
-  groupChain, mapUrl, matrilinePath, observedDate, parseMatrilinePath,
+  ecotypePath, groupChain, mapUrl, matrilinePath, observedDate, parseMatrilinePath,
   type GroupMember, type MatrilineProfile, type OccurrenceLink, type SocialGroup,
 } from './catalog.ts';
 import { profileStyles, renderDagger, renderMemberList, renderPresenceTable, renderRelative } from './profile-shared.ts';
@@ -103,7 +103,7 @@ export class MatrilinePage extends LitElement {
     return html`${parents.map((g, i) => html`${i ? ' · ' : ''}Within ${g.kind === 'matriline'
         ? html`<a href=${matrilinePath(g.designation)}>${g.designation}</a>`
         : g.designation}${g.kind === 'matriline' ? "'s matriline" : ` ${g.kind}`}`)
-      }${ecotype ? html`${parents.length ? ' · ' : ''}${ecotype.designation === 'Biggs' ? "Bigg's (transient) killer whales" : ecotype.designation}` : nothing}`;
+      }${ecotype ? html`${parents.length ? ' · ' : ''}<a href=${ecotypePath(ecotype.designation)}>${ecotype.designation === 'Biggs' ? "Bigg's (transient) killer whales" : ecotype.designation}</a>` : nothing}`;
   }
 
   // Naming facts only (name, status, year, namer) — no story prose (D-21).

--- a/supabase/migrations/20260708031133_ecotype_occurrences.sql
+++ b/supabase/migrations/20260708031133_ecotype_occurrences.sql
@@ -16,13 +16,17 @@
 CREATE VIEW public.ecotype_occurrences AS
 WITH RECURSIVE group_ecotype AS (
   -- Seed: every group, carrying itself as the current walk node.
-  SELECT id AS group_id, id AS node_id, parent_group_id, kind
+  SELECT id AS group_id, id AS node_id, parent_group_id, kind, ARRAY[id] AS visited
   FROM public.social_groups
   UNION ALL
-  -- Walk one hop up parent_group_id.
-  SELECT ge.group_id, p.id, p.parent_group_id, p.kind
+  -- Walk one hop up parent_group_id. parent_group_id is a plain self-FK with no
+  -- schema-level cycle prevention, so track visited ids and stop on a repeat —
+  -- otherwise a bad loop would hang every read (Postgres has no built-in cycle
+  -- detection). Mirrors the guard in groupChain() (src/catalog.ts).
+  SELECT ge.group_id, p.id, p.parent_group_id, p.kind, ge.visited || p.id
   FROM group_ecotype ge
   JOIN public.social_groups p ON p.id = ge.parent_group_id
+  WHERE NOT p.id = ANY(ge.visited)
 ),
 group_to_ecotype AS (
   -- Each group mapped to the ecotype root at the top of its chain.

--- a/supabase/migrations/20260708031133_ecotype_occurrences.sql
+++ b/supabase/migrations/20260708031133_ecotype_occurrences.sql
@@ -1,0 +1,64 @@
+-- An ecotype's sighting record for its profile page (bd salishsea-io-zw6,
+-- decision 017): the UNION of every descendant's reports — member individuals
+-- (resolved via their current maternal matriline up the parent chain) AND
+-- descendant matrilines named directly.
+--
+-- This DELIBERATELY fans out, unlike group_occurrences (decision 016). A
+-- matriline page shows reports naming the group as a unit ("T65As"); an
+-- ecotype's membership is instead structural and complete, so aggregating all
+-- members' reports is exactly the record the page wants. Scoped through the
+-- social_groups tree (not "every individual"), so it stays correct when a
+-- second ecotype (SRKW) lands: each subject's chain terminates at its own
+-- kind='ecotype' root, partitioning cleanly by ecotype_id.
+--
+-- No via_group/individual_id columns: ecotype rows are structural. The client
+-- (dedupeOccurrenceLinks) collapses the two branches to one row per occurrence.
+CREATE VIEW public.ecotype_occurrences AS
+WITH RECURSIVE group_ecotype AS (
+  -- Seed: every group, carrying itself as the current walk node.
+  SELECT id AS group_id, id AS node_id, parent_group_id, kind
+  FROM public.social_groups
+  UNION ALL
+  -- Walk one hop up parent_group_id.
+  SELECT ge.group_id, p.id, p.parent_group_id, p.kind
+  FROM group_ecotype ge
+  JOIN public.social_groups p ON p.id = ge.parent_group_id
+),
+group_to_ecotype AS (
+  -- Each group mapped to the ecotype root at the top of its chain.
+  SELECT group_id, node_id AS ecotype_id
+  FROM group_ecotype
+  WHERE kind = 'ecotype'
+)
+-- Branch A: a descendant matriline named as a unit.
+SELECT
+  gte.ecotype_id,
+  go.occurrence_id,
+  go.observed_at,
+  go.location,
+  go.is_present,
+  go.status
+FROM public.group_occurrences go
+JOIN group_to_ecotype gte ON gte.group_id = go.social_group_id
+UNION ALL
+-- Branch B: an individual member, resolved through its current maternal
+-- matriline to the ecotype. Individuals with no maternal membership row drop
+-- here (a no-op today — all cataloged individuals have one — and they would
+-- still surface via branch A if their matriline is named).
+SELECT
+  gte.ecotype_id,
+  io.occurrence_id,
+  io.observed_at,
+  io.location,
+  io.is_present,
+  io.status
+FROM public.individual_occurrences io
+JOIN public.group_memberships gm
+  ON gm.individual_id = io.individual_id
+  AND gm.is_current
+  AND gm.basis = 'maternal'
+JOIN group_to_ecotype gte ON gte.group_id = gm.group_id;
+
+-- Views don't inherit table policies; grant reads explicitly (same convention
+-- as group_occurrences / individual_occurrences).
+GRANT SELECT ON public.ecotype_occurrences TO anon, authenticated;

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,6 +10,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROFILE_REWRITES = [
   [/^\/individuals\/[^/]+\/?(\?.*)?$/, '/individual.html'],
   [/^\/matrilines\/[^/]+\/?(\?.*)?$/, '/matriline.html'],
+  [/^\/ecotypes\/[^/]+\/?(\?.*)?$/, '/ecotype.html'],
 ];
 
 function profilePagesRewrite(req, _res, next) {
@@ -28,6 +29,7 @@ export default defineConfig({
         about: resolve(__dirname, 'about.html'),
         individual: resolve(__dirname, 'individual.html'),
         matriline: resolve(__dirname, 'matriline.html'),
+        ecotype: resolve(__dirname, 'ecotype.html'),
       }
     },
 


### PR DESCRIPTION
## Summary

The ecotype page (bd `salishsea-io-zw6`), top of the social-group hierarchy — see [decision 017](docs/decisions/017-ecotype-profile-pages.md). Third page kind after individuals (015) and matrilines (016), reusing the same shell/edge/read-view pattern.

- **`/ecotypes/Biggs`**: masthead ("Bigg's (transient) killer whales", descriptor hardcoded per D-21 — `notes` never rendered), a **flat A–Z directory of all 132 descendant matrilines**, and a pooled sightings section (presence grid + static map).
- **New `ecotype_occurrences` view** (`20260708031133`): the ecotype's sightings are the **union of every descendant's reports** — member individuals (via current maternal matriline up the tree) + descendant matrilines named directly. A **deliberate fan-out**, the opposite of the matriline page's group-as-unit rule (016): ecotype membership is structural and complete, not a text mention. Recursive CTE walks `parent_group_id` to each subject's `kind='ecotype'` root, so it's **tree-scoped** and stays correct when SRKW lands as a second ecotype. Locally resolves 17 distinct occurrences.
- **Edge handler**: third `PROFILE_ROUTES` entry + `ecotypePreview` (no CDK change). **Cross-links**: ecotype labels in the individual and matriline lineage chains now link to the page.

## Testing

- `npm test`: 300 passing (new: `parseEcotypePath`/`ecotypePath` round-trips).
- `infra`: tsc + 53 jest (new `/ecotypes/Biggs` suite; existing suites guard the route table).
- `npm run build` (html-validate + CSP) passes.
- Local end-to-end: `/ecotypes/Biggs` renders the masthead, 132-link directory, and pooled grid/map (17 reports); `/ecotypes/NOPE` shows not-found; matriline and individual pages now link the ecotype label. `ecotype_occurrences` verified as anon (17 distinct occurrences, all mapped to the Biggs `ecotype_id`).
- e2e `og-previews` gains two `/ecotypes/Biggs` tests (run post-deploy in smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ecotype profile pages with a dedicated route and standalone page shell, including bot/preview OG metadata.
  * Added ecotype sightings aggregation via `public.ecotype_occurrences` and updated the ecotype UI to show descendant matrilines plus a sightings presence grid (with optional map).
  * Linked ecotype names mentioned in prose to the matching ecotype page.
* **Bug Fixes**
  * Improved browser vs bot routing so canonical URLs and `og:title`/preview tags resolve correctly; added safe fallback behavior.
* **Documentation**
  * Documented the ecotype profile page layout and sightings fan-out rules.
* **Tests**
  * Added e2e and unit coverage for ecotype routing, metadata, path parsing, and prose linking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->