### PR TITLE
fix: ecotype_occurrences prod timeout (stop materializing the occurrences view)

### DIFF
--- a/docs/decisions/017-ecotype-profile-pages.md
+++ b/docs/decisions/017-ecotype-profile-pages.md
@@ -36,17 +36,34 @@ the opposite of the matriline page's rule (decision 016):
   presence record the catalog can produce. (Locally, 17 distinct occurrences
   resolve to Bigg's, a real subset of the 56 raw orca occurrences.)
 
-The new `public.ecotype_occurrences` view (migration `20260708031133`) computes
-this with a recursive CTE that walks `social_groups.parent_group_id` to each
-subject's `kind='ecotype'` root, unioning `group_occurrences` (branch A) and
-`individual_occurrences` joined through maternal `group_memberships` (branch B).
+The `public.ecotype_occurrences` view computes this with a recursive CTE that
+walks `social_groups.parent_group_id` to each subject's `kind='ecotype'` root.
 It is **tree-scoped, not "all individuals"**, so when SRKW lands as a second
-ecotype each subject partitions cleanly by `ecotype_id`. One PostgREST filter
-(`ecotype_id`) powers the page; the client (`dedupeOccurrenceLinks`) collapses
-the two branches to one row per occurrence. Individuals with no maternal
-membership row are excluded from branch B (a no-op today — all cataloged
-individuals have one — and they still surface via branch A if their matriline
-is named).
+ecotype each subject partitions cleanly by `ecotype_id`. Branch A maps
+group-named reports (via `group_to_ecotype`); branch B maps individual-named
+reports (via `individual_to_ecotype`, an individual's maternal matriline — a
+birthright, so `is_current` is deliberately not required). One PostgREST filter
+(`ecotype_id`) powers the page.
+
+**Read path — candidates only (perf, migration `20260708040216`).** The first
+cut (`20260708031133`) reached the data through `group_occurrences` /
+`individual_occurrences`, both of which join the `public.occurrences` view (a
+4-way UNION with no usable index on its computed id) in their stored-claims
+branch. Filtered by one subject that branch's outer is empty and never built;
+but an ecotype-wide aggregate is *unfiltered*, so the planner materialized the
+whole occurrences union — ~62s on prod, past PostgREST's statement timeout, a
+production 500. The fix reads **only** the cached
+`occurrence_identifier_candidates` matview (which already carries
+`observed_at`/`location`) plus the small group tables, never touching
+`occurrences`: ~25ms. Consequences: (1) stored curator claims are not reflected
+in the ecotype aggregate yet — a no-op while curation volume is zero; the
+durable fix is a cheap indexed occurrence-timestamp source for the stored branch
+(bd `salishsea-io-8uz`, a prerequisite for the curation UI `salishsea-io-ek3`),
+which the per-subject views will also need before curation makes *their* stored
+branch non-empty. (2) `UNION` (not `UNION ALL`) collapses to one row per
+(ecotype, occurrence) at the database, so the unpaginated fetch stays under
+PostgREST's `max_rows`; the deduped count (869 on prod) is approaching that cap,
+tracked for pagination (bd `salishsea-io-236`).
 
 ### Invariants carried over
 
@@ -67,3 +84,6 @@ is named).
 - `ecotype_occurrences` is the first read view that fans out through the group
   tree; a future pod page (an intermediate node) would reuse the same recursive
   descendants shape scoped to the pod rather than the ecotype root.
+- Individuals mentioned in sightings but lacking any maternal `group_memberships`
+  row are invisible to the ecotype aggregate (23 occurrences on prod at launch).
+  This is a catalog data gap, not a query bug — tracked separately.

--- a/supabase/migrations/20260708040216_ecotype_occurrences_perf.sql
+++ b/supabase/migrations/20260708040216_ecotype_occurrences_perf.sql
@@ -1,0 +1,77 @@
+-- Fix a production timeout in ecotype_occurrences (bd salishsea-io-zw6).
+--
+-- The original definition (20260708031133) reached the ecotype's sightings
+-- through group_occurrences and individual_occurrences, both of which join the
+-- public.occurrences VIEW in their stored-claims branch. occurrences is a 4-way
+-- UNION (maplify/inaturalist/happywhale/native) with photo/observer aggregation
+-- and no usable index on its computed text id. Filtered by a single subject
+-- (the individual/matriline pages) the planner leaves that branch's outer empty
+-- and never builds it — but an ecotype-wide aggregate is unfiltered, so the
+-- planner materialized the entire occurrences union: ~62s on prod, past
+-- PostgREST's statement timeout, so the REST endpoint 500'd.
+--
+-- This reads only the cached occurrence_identifier_candidates matview (which
+-- already carries observed_at/location per resolved code) and the small group
+-- tables, never touching occurrences: ~25ms. Stored curator claims
+-- (identifications) are consequently not reflected in the ecotype aggregate yet
+-- — a no-op while curation volume is zero; the durable fix is a cheap indexed
+-- occurrence-timestamp source the stored branch can join instead of the
+-- occurrences view (bd salishsea-io-8uz, a prerequisite for the curation UI
+-- salishsea-io-ek3). Every row here is an unverified text mention, which is what
+-- the ecotype page presents.
+CREATE OR REPLACE VIEW public.ecotype_occurrences AS
+WITH RECURSIVE group_ecotype AS (
+  SELECT id AS group_id, id AS node_id, parent_group_id, kind, ARRAY[id] AS visited
+  FROM public.social_groups
+  UNION ALL
+  SELECT ge.group_id, p.id, p.parent_group_id, p.kind, ge.visited || p.id
+  FROM group_ecotype ge
+  JOIN public.social_groups p ON p.id = ge.parent_group_id
+  -- Stop at the ecotype root (don't walk past it) and never revisit (cycle guard).
+  WHERE ge.kind <> 'ecotype' AND NOT p.id = ANY(ge.visited)
+),
+group_to_ecotype AS (
+  SELECT group_id, node_id AS ecotype_id
+  FROM group_ecotype
+  WHERE kind = 'ecotype'
+),
+-- An individual's ecotype is a birthright: use its maternal matriline whether or
+-- not the membership is still current (a deceased or reorganized member's
+-- historical sightings still belong to the ecotype).
+individual_to_ecotype AS (
+  SELECT DISTINCT gm.individual_id, gte.ecotype_id
+  FROM public.group_memberships gm
+  JOIN group_to_ecotype gte ON gte.group_id = gm.group_id
+  WHERE gm.basis = 'maternal'
+)
+-- UNION (not UNION ALL) collapses the bit-identical rows an occurrence produces
+-- when it names both a matriline and one of its members, so the result is one
+-- row per (ecotype, occurrence) and never overflows PostgREST's max_rows cap.
+--
+-- Branch A: a descendant matriline named as a unit.
+SELECT
+  gte.ecotype_id,
+  c.occurrence_id,
+  c.observed_at,
+  c.location,
+  true AS is_present,
+  'candidate'::public.identification_status AS status
+FROM public.occurrence_identifier_candidates c
+JOIN group_to_ecotype gte ON gte.group_id = c.social_group_id
+WHERE c.social_group_id IS NOT NULL
+UNION
+-- Branch B: an individual named directly, via its maternal matriline.
+SELECT
+  ite.ecotype_id,
+  c.occurrence_id,
+  c.observed_at,
+  c.location,
+  true AS is_present,
+  'candidate'::public.identification_status AS status
+FROM public.occurrence_identifier_candidates c
+JOIN individual_to_ecotype ite ON ite.individual_id = c.individual_id
+WHERE c.individual_id IS NOT NULL;
+
+-- Restated for a self-contained migration (CREATE OR REPLACE preserves the
+-- existing grant, but be explicit).
+GRANT SELECT ON public.ecotype_occurrences TO anon, authenticated;


### PR DESCRIPTION
## The incident

`GET /rest/v1/ecotype_occurrences?ecotype_id=eq.1` was 500ing as a timeout in production.

**Cause** (verified on prod via `EXPLAIN ANALYZE`): the view reached its data through `group_occurrences` / `individual_occurrences`, both of which join the `public.occurrences` view — a 4-way UNION with no usable index on its computed text `id`. Filtered by a single subject (the per-individual and per-matriline pages), that stored-claims branch has an empty outer and is never built. But an ecotype-wide aggregate is **unfiltered**, so the planner materialized the entire occurrences union: **~62,000ms**, past PostgREST's statement timeout.

## The fix

Read **only** the cached `occurrence_identifier_candidates` matview (which already carries `observed_at`/`location`) plus the small group tables — never touching `occurrences`. **~25ms.**

- `UNION` (not `UNION ALL`) collapses the bit-identical rows an occurrence produces when it names both a matriline and a member → one row per (ecotype, occurrence). This matters: the raw union was 1,414 rows and PostgREST's `max_rows=1000` would have silently truncated the unpaginated fetch to ~600 of 869 occurrences.
- Individual→ecotype mapping now uses maternal membership **regardless of `is_current`** (ecotype is a birthright).
- Recursion guard stops at the ecotype root.

Applied to prod already (hotfix via `db query --linked`) to stop the bleeding; this migration makes it durable and reproducible (identical `CREATE OR REPLACE`).

## Tradeoff & follow-ups

Stored curator claims are no longer reflected in the ecotype aggregate — a no-op today (0 claims, no curation UI). Filed:
- `salishsea-io-8uz` (P1): an `occurrence_index` matview so stored-claims branches can join an indexed timestamp source instead of the occurrences view — a prerequisite for the curation UI, and a latent issue for the per-subject views too.
- `salishsea-io-236` (P2): paginate the ecotype fetch before the deduped count (869, growing) crosses `max_rows`.
- `salishsea-io-0f6` (P3): 23 occurrences invisible because their mentioned individuals lack a maternal membership row (catalog data gap).

## Testing

- Prod `EXPLAIN ANALYZE`: 62,000ms → 25ms; 869 rows = 869 distinct (no truncation).
- Local migration applies; `npm test` 302 pass; infra jest 53 pass; types unchanged.
- This fix was reviewed by a second agent, which caught the `UNION`/`max_rows` truncation bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ecotype occurrence pages now load from a faster, optimized data path, improving responsiveness and reducing timeout errors.

* **Bug Fixes**
  * Fixed cases where ecotype occurrence results could fail to appear because the previous lookup path was too expensive.
  * Improved matching for group- and individual-reported sightings, making ecotype results more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->