### PR TITLE
docs(ingest): backfill runbook + paginate ecotype fetch

### DIFF
--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -6,6 +6,7 @@ type PublicSchema = Database['public'];
 export type Individual = PublicSchema['Tables']['individuals']['Row'];
 export type SocialGroup = PublicSchema['Tables']['social_groups']['Row'];
 export type IndividualOccurrence = PublicSchema['Views']['individual_occurrences']['Row'];
+export type EcotypeOccurrence = PublicSchema['Views']['ecotype_occurrences']['Row'];
 
 // One (occurrence, individual) link from the individual_occurrences view, with
 // the fields the profile page needs guaranteed present.
@@ -273,13 +274,24 @@ export type EcotypeProfile = NonNullable<Awaited<ReturnType<typeof fetchEcotype>
 
 // The ecotype's sighting record is the union of every descendant's reports
 // (see docs/decisions/017); one filter on ecotype_id, deduped per occurrence.
+// Paginated: an ecotype aggregates thousands of reports and PostgREST caps a
+// single response at max_rows (1000), which would silently truncate the map and
+// the "N reports in all" count.
 export async function fetchEcotypeOccurrenceLinks(ecotypeId: number): Promise<OccurrenceLink[]> {
-  const { data } = await supabase()
-    .from('ecotype_occurrences')
-    .select()
-    .eq('ecotype_id', ecotypeId)
-    .throwOnError();
-  return dedupeOccurrenceLinks(data);
+  const PAGE = 1000;
+  const rows: EcotypeOccurrence[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const { data } = await supabase()
+      .from('ecotype_occurrences')
+      .select()
+      .eq('ecotype_id', ecotypeId)
+      .order('occurrence_id', { ascending: true }) // stable paging order
+      .range(from, from + PAGE - 1)
+      .throwOnError();
+    rows.push(...data);
+    if (data.length < PAGE) break;
+  }
+  return dedupeOccurrenceLinks(rows);
 }
 
 // The matrilines that descend from an ecotype, sorted A–Z — for the ecotype

--- a/supabase/functions/ingest/README.md
+++ b/supabase/functions/ingest/README.md
@@ -1,0 +1,91 @@
+# Ingest endpoint — operator guide
+
+The `ingest` Edge Function is the imperative shell for network ingest (Maplify,
+iNaturalist). Design and rationale: [decision 011](../../../docs/decisions/011-ingest-imperative-shell.md).
+It runs two ways:
+
+- **Scheduled** — `pg_cron` + `pg_net` call it every 5 minutes with a rolling
+  10-day window (see `20260706000000_cutover_ingest_to_edge_function.sql`).
+- **Manual** — a curator calls it with an explicit window to **backfill** or
+  **preview** a range. This file is about that path.
+
+## Request
+
+`POST` to the function URL with the trigger secret header. The body schema is
+the source of truth in [`index.ts`](index.ts) (`RequestSchema`):
+
+| field | values | notes |
+|---|---|---|
+| `source` | `maplify` \| `inaturalist` | required |
+| `start`, `end` | `YYYY-MM-DD` | both or neither; `end` exclusive |
+| `dry_run` | boolean | preview: fetch + reconcile, write nothing |
+| `trigger` | `cron` \| `manual` | recorded on the run |
+
+Both the URL and the secret live in Supabase **Vault** (`ingest_function_url`,
+`ingest_trigger_secret`) and as an Edge Function secret — not in the repo.
+
+## Triggering a backfill without the plaintext secret
+
+The cleanest path reuses the cron mechanism: a Vault-authenticated
+`net.http_post` from the database, so you never handle the secret. Run it with
+`npx supabase db query --linked` (or any prod SQL console):
+
+```sql
+SELECT net.http_post(
+  url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='ingest_function_url'),
+  headers := jsonb_build_object(
+    'content-type','application/json',
+    'x-ingest-secret',(SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='ingest_trigger_secret')),
+  body := jsonb_build_object('source','maplify','start','2025-08-01','end','2025-09-01','dry_run',true,'trigger','manual'),
+  timeout_milliseconds := 120000
+);
+```
+
+`net.http_post` is **async** — it enqueues and returns a request id. The function
+runs a few seconds later and records the outcome in `ingest.runs`; read it there:
+
+```sql
+SELECT window_start, window_end, outcome, dry_run, total_results,
+       rows_upserted, rows_deleted, error
+FROM ingest.runs
+WHERE source='maplify' AND window_start='2025-08-01'
+ORDER BY id DESC LIMIT 1;
+```
+
+If you have the plaintext secret, a plain `curl` to the function URL with an
+`x-ingest-secret` header and the same JSON body works too, and returns the
+outcome synchronously.
+
+## The one caveat: reconcile is authoritative per window
+
+Within the fetched window, the function **deletes** any of that source's stored
+rows not present in the fetch (decision 011's completeness invariant). So:
+
+- **Safe for filling a gap** — if the window has no rows for that source yet,
+  it is pure upsert (verify with `dry_run` first: `rows_deleted` should be 0).
+- It only touches the **source's own table** (`maplify.sightings` /
+  `inaturalist.observations`); native `SalishSea.io Direct` records are never
+  affected.
+- **Don't** run a narrow/partial re-fetch over a window you already have good
+  data for unless you intend the fetch to be the new source of truth.
+
+## After a backfill
+
+Resolved identifier codes (which power the individual/matriline/ecotype pages)
+come from the `occurrence_identifier_candidates` matview, refreshed by cron
+within ~5 minutes. To see backfilled sightings immediately:
+
+```sql
+REFRESH MATERIALIZED VIEW CONCURRENTLY public.occurrence_identifier_candidates;
+```
+
+## Practical notes
+
+- **Chunk by month.** Maplify fetches a whole window in one request and
+  iNaturalist paginates + resolves a taxon closure; month-sized windows keep
+  each transaction bounded and give one legible `ingest.runs` row per month.
+  Non-overlapping windows can be enqueued together (no reconcile conflict).
+- **Coverage reality (2026-07):** live Maplify/iNaturalist ingest began
+  2025-09-01; earlier history is only present where it has been manually
+  backfilled. The upstream APIs still serve it — the Maplify window is just
+  `search-all-sightings.php?start=&end=&BBOX=` (see [`fetch-maplify.ts`](fetch-maplify.ts)).


### PR DESCRIPTION
Follow-up to the ecotype data-gap investigation.

## Context

The ecotype page showed no Bigg's occurrences before September 2025. Root cause: live Maplify/iNaturalist ingest began **2025-09-01** and earlier history was never backfilled, even though the upstream APIs still serve it. I backfilled Jan–Aug 2025 for both sources via the existing ingest endpoint's manual-window path (~17.7k rows, verified with a dry-run first; reconcile `rows_deleted` = 0 throughout). August 2025 went from 0 → 101 Bigg's occurrences; the whole trough is filled.

## This PR

1. **`supabase/functions/ingest/README.md`** — an operator runbook for the manual backfill path. The endpoint's *contract* was in [decision 011](docs/decisions/011-ingest-imperative-shell.md), but the *recipe* wasn't written down: the Vault-authenticated `net.http_post` trigger (no plaintext secret needed), the request schema, the **reconcile-is-authoritative** caveat, `dry_run` first, and reading outcomes from `ingest.runs`.

2. **Paginate `fetchEcotypeOccurrenceLinks`** — the backfill pushed `ecotype_occurrences` to **1,911 distinct** occurrences, past PostgREST's `max_rows=1000`, which silently truncated the ecotype page's map and "N reports in all" count to 1000. `.range()` pagination fetches all pages. Closes `salishsea-io-236`.

## Testing

- `npm test` 302 pass; `npm run build` clean (html-validate + CSP).
- Backfill verified on prod: 8 Maplify + 8 iNaturalist months, all `outcome=success`, 0 deletes; `ecotype_occurrences` now populated across Jan–Aug 2025.
- Pagination verified against the new 1,911-row count (was truncating at 1000 pre-fix); confirmed live once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of ecotype occurrence links to handle large result sets reliably and avoid missing or incomplete results.
* **New Features**
  * Added support for a new ecotype occurrence row type for use across the app.
* **Documentation**
  * Added an operator guide for the ingest workflow, including request format, invocation options, and guidance for preview/backfill runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->