### PR TITLE
fix(ingest): re-page iNaturalist window on live-fetch drift (SALISHSEA-IO-2D)

### DIFF
--- a/supabase/functions/ingest/fetch-inaturalist.test.ts
+++ b/supabase/functions/ingest/fetch-inaturalist.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Shell test for fetchAllObservationPages' bounded re-page loop (salishsea-io-h79
+ * / Sentry SALISHSEA-IO-2D). iNat page-based pagination is not atomic over a live
+ * window; a mutation between two page requests drifts total_results so the
+ * accumulated pages fail isPaginationComplete. The shell must re-page the whole
+ * window a bounded number of times before surfacing that as a real failure.
+ *
+ * We stub global fetch (no network) to script drift-then-consistent responses.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchAllObservationPages } from './fetch-inaturalist.ts';
+import type { IngestWindow } from '../../../scripts/ingest/persist.ts';
+
+const WINDOW: IngestWindow = { start: '2026-06-29', end: '2026-07-09' };
+const noopLog = () => {};
+
+/** One minimal valid v2 /observations record (passes InatObservationSchema). */
+function record(id: number) {
+    return {
+        id,
+        geojson: { coordinates: [-123, 48] },
+        license_code: 'cc-by',
+        uri: `https://www.inaturalist.org/observations/${id}`,
+        updated_at: '2026-07-01T00:00:00+00:00',
+        time_observed_at: '2026-07-01T00:00:00+00:00',
+        observation_photos: [],
+        taxon: { id: 152871, ancestor_ids: [152871] },
+        user: { id: 1, login: 'observer' },
+    };
+}
+
+/** A page body: `total_results` reported plus `count` real records (from startId). */
+function pageBody(page: number, totalResults: number, count: number, startId: number) {
+    return {
+        total_results: totalResults,
+        page,
+        per_page: 200,
+        results: Array.from({ length: count }, (_, i) => record(startId + i)),
+    };
+}
+
+/** Stub global fetch to return each queued body once, in order. */
+function stubFetch(bodies: unknown[]) {
+    let i = 0;
+    vi.stubGlobal('fetch', () => {
+        const body = bodies[i++];
+        if (body === undefined) throw new Error(`unexpected fetch #${i}`);
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+    });
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('fetchAllObservationPages re-pages on live-window drift', () => {
+    it('returns the snapshot on the first consistent pass (no drift)', async () => {
+        // total 250 → 2 pages (200 + 50), totals stable → complete on attempt 1.
+        stubFetch([pageBody(1, 250, 200, 1), pageBody(2, 250, 50, 201)]);
+
+        const result = await fetchAllObservationPages(WINDOW, noopLog);
+
+        expect(result.totalResults).toBe(250);
+        expect(result.pages.map((p) => p.recordCount)).toEqual([200, 50]);
+        expect(result.observations).toHaveLength(250);
+    });
+
+    it('retries the whole window and succeeds once the dataset settles', async () => {
+        // Attempt 1: page 2 reports a drifted total (251) → incomplete.
+        // Attempt 2: totals agree (250) → complete.
+        stubFetch([
+            pageBody(1, 250, 200, 1),
+            pageBody(2, 251, 51, 201),
+            pageBody(1, 250, 200, 1),
+            pageBody(2, 250, 50, 201),
+        ]);
+
+        const result = await fetchAllObservationPages(WINDOW, noopLog);
+
+        expect(result.totalResults).toBe(250);
+        expect(result.pages.map((p) => p.recordCount)).toEqual([200, 50]);
+    });
+
+    it('throws after exhausting attempts when the window never settles', async () => {
+        // Every attempt drifts (page 2 total ≠ page 1 total): 3 attempts × 2 pages.
+        stubFetch([
+            pageBody(1, 250, 200, 1), pageBody(2, 251, 51, 201),
+            pageBody(1, 250, 200, 1), pageBody(2, 251, 51, 201),
+            pageBody(1, 250, 200, 1), pageBody(2, 251, 51, 201),
+        ]);
+
+        await expect(fetchAllObservationPages(WINDOW, noopLog)).rejects.toThrow(
+            /pagination incomplete after 3 attempts/,
+        );
+    });
+});

--- a/supabase/functions/ingest/fetch-inaturalist.ts
+++ b/supabase/functions/ingest/fetch-inaturalist.ts
@@ -60,6 +60,14 @@ const MAX_PAGE = Math.floor(10_000 / PER_PAGE);
 // iNat caps the `/taxa` `id` param at ~30 ids per request.
 const TAXA_ID_CHUNK = 30;
 
+// iNat page-based pagination is NOT atomic over a live window: `window.end` is
+// "today", so an observation created/edited/deleted between two sequential page
+// requests drifts `total_results` or the per-page counts, and the accumulated
+// pages fail `isPaginationComplete`. That is transient and self-heals on a fresh
+// pass, so re-page the whole window this many times before treating the
+// incompleteness as real (a genuine, persistent failure the next cron retries).
+const PAGINATION_ATTEMPTS = 3;
+
 // v2 `/observations` field selection. Extends the legacy SQL path's set with the
 // fields the functional core now requires: `updated_at` (drives the
 // newer-wins upsert), the observation_photo `id`, and `user.orcid` (minted into
@@ -170,13 +178,13 @@ export type ObservationFetchResult = {
 };
 
 /**
- * Loop A. Fetch every page of the window through `total_results`, accumulating
+ * Fetch every page of the window through `total_results` ONCE, accumulating
  * FetchedPage metadata and normalized observations. Throws on any parse/HTTP
- * failure, on a window that exceeds iNat's 10 000-record pagination cap, or if
- * the accumulated pages are not provably complete. Returns only on a complete
- * fetch — the precondition reconcile() and persist require.
+ * failure or on a window that exceeds iNat's 10 000-record pagination cap. Does
+ * NOT assert completeness — the caller checks `isPaginationComplete` and re-pages
+ * if the live window drifted mid-fetch.
  */
-export async function fetchAllObservationPages(
+async function collectObservationPages(
     window: IngestWindow,
     log: Logger,
 ): Promise<ObservationFetchResult> {
@@ -207,14 +215,49 @@ export async function fetchAllObservationPages(
         if (page >= expected) break;
     }
 
-    if (!isPaginationComplete(pages, PER_PAGE)) {
-        throw new Error(
-            `iNaturalist pagination incomplete: fetched ${pages.length} page(s) for ` +
-                `total_results=${totalResults}`,
-        );
+    return { pages, observations, totalResults };
+}
+
+/**
+ * Loop A. Fetch every page of the window through `total_results` and return only
+ * a PROVABLY COMPLETE snapshot (decision 011) — the precondition reconcile() and
+ * persist require.
+ *
+ * iNat's page-based pagination is not atomic over a live window (see
+ * PAGINATION_ATTEMPTS): a mutation between two sequential page requests drifts
+ * `total_results` or the per-page counts and fails `isPaginationComplete`. That
+ * is transient, so re-page the whole window up to PAGINATION_ATTEMPTS times
+ * before giving up. Still throws on parse/HTTP failure, on a window over iNat's
+ * 10 000-record cap, or if every attempt drifted — a genuine (persistent)
+ * incompleteness the next 5-minute cron will retry.
+ */
+export async function fetchAllObservationPages(
+    window: IngestWindow,
+    log: Logger,
+): Promise<ObservationFetchResult> {
+    let last: ObservationFetchResult | null = null;
+
+    for (let attempt = 1; attempt <= PAGINATION_ATTEMPTS; attempt++) {
+        const result = await collectObservationPages(window, log);
+        if (isPaginationComplete(result.pages, PER_PAGE)) return result;
+
+        last = result;
+        if (attempt < PAGINATION_ATTEMPTS) {
+            const delay = retryDelayMs(attempt);
+            log('inat pagination incomplete (live window drifted mid-fetch), re-paging', {
+                attempt,
+                pages: result.pages.length,
+                totalResults: result.totalResults,
+                delayMs: delay,
+            });
+            await sleep(delay);
+        }
     }
 
-    return { pages, observations, totalResults };
+    throw new Error(
+        `iNaturalist pagination incomplete after ${PAGINATION_ATTEMPTS} attempts: ` +
+            `fetched ${last!.pages.length} page(s) for total_results=${last!.totalResults}`,
+    );
 }
 
 /**


### PR DESCRIPTION
## Problem

Sentry **SALISHSEA-IO-2D** (escalating, ~25 events over 2 days, ~4% of the `*/5` cron runs) throws:

> `iNaturalist pagination incomplete: fetched N page(s) for total_results=X`

**Root cause:** the ingest window ends at `current_date` (today), so the dataset is actively mutating. iNat's page-based pagination is not atomic — between two sequential page requests (~1–2s apart) an observation is created/edited/deleted, so `total_results` drifts or the per-page counts stop summing to it, and `isPaginationComplete` (correctly) refuses the snapshot. Decision 011 then aborts the run and writes nothing.

Reproduced against the live `v2/observations` API. No data is permanently lost (the next 5-minute cron re-covers the same 10-day window), but it surfaces as escalating error noise and delays fresh data.

## Fix

Wrap the single page loop in a **bounded whole-window re-page** (`PAGINATION_ATTEMPTS = 3`, reusing `retry.ts` backoff). Only a completeness *drift* triggers a re-page; parse/HTTP/pagination-cap failures still abort immediately per decision 011. The pure invariant (`isPaginationComplete`) is untouched. Independent ~4% drift per pass → persistent failure drops to ~0.006%, while a genuinely broken upstream still throws (with a new "after 3 attempts" message).

## Tests

New shell test (`fetch-inaturalist.test.ts`) stubs `fetch` to script drift-then-consistent responses: happy path, retry-then-succeed, and throw-after-exhaustion. Full suite green (305 passed).

## Durable follow-up

Switch to id-keyset pagination (`order_by=id&id_above=<lastId>`), which is atomic over a live tail and sidesteps iNat's 10k page cap. Tracked in bd `salishsea-io-h79`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved observation ingestion when pagination totals change during an active data window.
  * Automatically retries incomplete pagination attempts before reporting an error.
  * Provides clearer failure reporting when all retry attempts are exhausted.

* **Tests**
  * Added coverage for consistent pagination, successful retries after drift, and persistent pagination failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->