### PR TITLE
fix(ui): render obs-summary with an explicit closing tag (SALISHSEA-IO-2B)

### DIFF
--- a/src/obs-summary.ts
+++ b/src/obs-summary.ts
@@ -184,11 +184,14 @@ export class ObsSummary extends LitElement {
 
   protected willUpdate(changedProperties: PropertyValues): void {
     if (changedProperties.has('contributor') || changedProperties.has('sighting')) {
-      this.ownObservation = !!(this.contributor && this.sighting.contributor_id === this.contributor.id);
+      this.ownObservation = !!(this.contributor && this.sighting?.contributor_id === this.contributor.id);
     }
   }
 
   public render() {
+    // `sighting` is a required property, but a reactive update (e.g. a context
+    // change) can fire before it is assigned; render nothing rather than throw.
+    if (!this.sighting) return nothing;
     const {
       body, count, observed_at, photos, provider_slug, taxon: {scientific_name, vernacular_name}, url
     } = this.sighting;

--- a/src/salish-sea.ts
+++ b/src/salish-sea.ts
@@ -333,7 +333,7 @@ export default class SalishSea extends LitElement {
             const id = sighting.id;
             const classes = {focused: id === this.focusedOccurrenceId};
             return html`
-              <obs-summary class=${classMap(classes)} id=${`summary-${id}`} ?focused=${classes.focused} .sighting=${sighting} />
+              <obs-summary class=${classMap(classes)} id=${`summary-${id}`} ?focused=${classes.focused} .sighting=${sighting}></obs-summary>
             `;
           })}
         </obs-panel>


### PR DESCRIPTION
## Problem

Sentry **SALISHSEA-IO-2B**: `TypeError: Cannot destructure property 'body' of 'this.sighting' as it is undefined` — an unhandled promise rejection from a Lit render.

**Root cause:** `salish-sea.ts` rendered the panel rows as `<obs-summary ... />` — a **self-closing custom element**. HTML doesn't support self-closing on non-void/custom elements: the parser ignores the `/` and leaves the tag open, so adjacent `repeat()` instances nest and some `obs-summary` elements never receive their `.sighting` binding. When a later reactive update fires (e.g. the `@consume` contributor/user context changing on login), those instances run `render()` with `sighting` undefined and throw. It's the only custom element in the file that was self-closed (`obs-map`, `obs-panel` use explicit closing tags).

## Fix

- Close the tag explicitly: `<obs-summary ...></obs-summary>`.
- Guard `render()` and `willUpdate()` against an unset `sighting` (renders `nothing` instead of throwing) — defense-in-depth against any other pre-assignment update.

## Verification

Drove the prod-built app against production data (`?d=2026-07-03`): the panel renders Gray Whale / Pacific Harbor Seal / Humpback Whale cards as correct siblings, no console errors. `tsc`, unit tests, and full `npm run build` (html-validate + CSP hash) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented observation summaries from producing errors while sighting data is still loading or updating.
  * Improved stability during reactive updates when required observation details are temporarily unavailable.
  * Preserved observation summary display and focus behavior in the sightings list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->