### PR TITLE
fix(ingest): legible errors for non-JSON 200 responses (SALISHSEA-IO-2F)

### DIFF
--- a/supabase/functions/ingest/fetch-inaturalist.test.ts
+++ b/supabase/functions/ingest/fetch-inaturalist.test.ts
@@ -45,7 +45,8 @@ function stubFetch(bodies: unknown[]) {
     vi.stubGlobal('fetch', () => {
         const body = bodies[i++];
         if (body === undefined) throw new Error(`unexpected fetch #${i}`);
-        return Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+        // The shell reads res.text() then JSON.parse()s it; return the serialized body.
+        return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(body)) });
     });
 }
 

--- a/supabase/functions/ingest/fetch-inaturalist.test.ts
+++ b/supabase/functions/ingest/fetch-inaturalist.test.ts
@@ -46,7 +46,7 @@ function stubFetch(bodies: unknown[]) {
         const body = bodies[i++];
         if (body === undefined) throw new Error(`unexpected fetch #${i}`);
         // The shell reads res.text() then JSON.parse()s it; return the serialized body.
-        return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(body)) });
+        return Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve(JSON.stringify(body)) });
     });
 }
 

--- a/supabase/functions/ingest/fetch-inaturalist.ts
+++ b/supabase/functions/ingest/fetch-inaturalist.ts
@@ -130,8 +130,8 @@ async function fetchJsonWithRetry(url: string, label: string, log: Logger): Prom
                     // Throw a snippet of what was actually returned rather than an
                     // opaque JSON-parse position; still retried like any transient.
                     throw new Error(
-                        `iNaturalist ${label} returned a non-JSON 200 body ` +
-                            `(${text.length} bytes): ${bodySnippet(text)}`,
+                        `iNaturalist ${label} returned a non-JSON ${res.status} body ` +
+                            `(${text.length} chars): ${bodySnippet(text)}`,
                     );
                 }
             }

--- a/supabase/functions/ingest/fetch-inaturalist.ts
+++ b/supabase/functions/ingest/fetch-inaturalist.ts
@@ -86,6 +86,13 @@ const TAXA_FIELDS = '(id:!t,ancestor_ids:!t,parent_id:!t,rank:!t,name:!t,preferr
 
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
+/** Collapse a response body to a single-line snippet for error messages. */
+function bodySnippet(text: string, max = 200): string {
+    const oneLine = text.replace(/\s+/g, ' ').trim();
+    if (oneLine.length === 0) return '(empty body)';
+    return oneLine.length > max ? `${oneLine.slice(0, max)}…` : oneLine;
+}
+
 function chunk<T>(items: readonly T[], size: number): T[][] {
     const out: T[][] = [];
     for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
@@ -112,11 +119,21 @@ async function fetchJsonWithRetry(url: string, label: string, log: Logger): Prom
             });
             if (res.ok) {
                 // Read the body under the SAME timeout: a server can send headers
-                // and then stall, and res.json() would otherwise hang past the
+                // and then stall, and reading it would otherwise hang past the
                 // deadline. Clear the timer only once the body is fully consumed.
-                const data = await res.json();
+                const text = await res.text();
                 clearTimeout(timeout);
-                return data;
+                try {
+                    return JSON.parse(text) as unknown;
+                } catch {
+                    // A 200 with a non-JSON body (upstream error page/proxy blip).
+                    // Throw a snippet of what was actually returned rather than an
+                    // opaque JSON-parse position; still retried like any transient.
+                    throw new Error(
+                        `iNaturalist ${label} returned a non-JSON 200 body ` +
+                            `(${text.length} bytes): ${bodySnippet(text)}`,
+                    );
+                }
             }
         } catch (e) {
             // fetch-level failure, abort (timeout), or a stalled/aborted body read

--- a/supabase/functions/ingest/fetch-maplify.test.ts
+++ b/supabase/functions/ingest/fetch-maplify.test.ts
@@ -20,7 +20,7 @@ function stubFetch(bodies: string[]) {
     vi.stubGlobal('fetch', () => {
         const body = bodies[i++];
         if (body === undefined) throw new Error(`unexpected fetch #${i}`);
-        return Promise.resolve({ ok: true, text: () => Promise.resolve(body) });
+        return Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve(body) });
     });
 }
 
@@ -37,7 +37,7 @@ describe('fetchMaplify parses JSON and diagnoses non-JSON 200s', () => {
         const dbError = 'Unable to connect to the database';
         stubFetch([dbError, dbError, dbError]);
         await expect(fetchMaplify(WINDOW, noopLog)).rejects.toThrow(
-            /Maplify returned a non-JSON 200 body \(\d+ bytes\): Unable to connect to the database/,
+            /Maplify returned a non-JSON 200 body \(\d+ chars\): Unable to connect to the database/,
         );
     });
 
@@ -54,7 +54,7 @@ describe('fetchMaplify parses JSON and diagnoses non-JSON 200s', () => {
     it('reports an empty 200 body distinctly', async () => {
         stubFetch(['', '', '']);
         await expect(fetchMaplify(WINDOW, noopLog)).rejects.toThrow(
-            /non-JSON 200 body \(0 bytes\): \(empty body\)/,
+            /non-JSON 200 body \(0 chars\): \(empty body\)/,
         );
     });
 });

--- a/supabase/functions/ingest/fetch-maplify.test.ts
+++ b/supabase/functions/ingest/fetch-maplify.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Shell test for fetchMaplify's non-JSON-200 diagnostics. Maplify serves a 200
+ * with a non-JSON body on its own server-side failures (a transient DB error, or
+ * an HTML PHP fatal-error page). index.ts hands the thrown message to the operator
+ * and Sentry, so the error must name what Maplify actually returned — not an
+ * opaque JSON-parse position.
+ *
+ * We stub global fetch (no network) to script the body Maplify returns.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchMaplify } from './fetch-maplify.ts';
+import type { IngestWindow } from '../../../scripts/ingest/persist.ts';
+
+const WINDOW: IngestWindow = { start: '2026-06-29', end: '2026-07-09' };
+const noopLog = () => {};
+
+/** Stub global fetch to return each queued body (a string) once, in order. */
+function stubFetch(bodies: string[]) {
+    let i = 0;
+    vi.stubGlobal('fetch', () => {
+        const body = bodies[i++];
+        if (body === undefined) throw new Error(`unexpected fetch #${i}`);
+        return Promise.resolve({ ok: true, text: () => Promise.resolve(body) });
+    });
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('fetchMaplify parses JSON and diagnoses non-JSON 200s', () => {
+    it('returns the parsed body on a normal JSON 200', async () => {
+        stubFetch(['{"count":"2","results":[{"id":1},{"id":2}]}']);
+        const data = await fetchMaplify(WINDOW, noopLog);
+        expect(data).toEqual({ count: '2', results: [{ id: 1 }, { id: 2 }] });
+    });
+
+    it('surfaces the DB-error snippet after exhausting retries', async () => {
+        const dbError = 'Unable to connect to the database';
+        stubFetch([dbError, dbError, dbError]);
+        await expect(fetchMaplify(WINDOW, noopLog)).rejects.toThrow(
+            /Maplify returned a non-JSON 200 body \(\d+ bytes\): Unable to connect to the database/,
+        );
+    });
+
+    it('collapses a multi-line HTML fatal-error page to a one-line snippet', async () => {
+        const oom =
+            '<br />\n<b>Fatal error</b>:  Allowed memory size of 268435456 bytes exhausted\n' +
+            '(tried to allocate 20480 bytes) in /var/www/search-all-sightings.php on line 42';
+        stubFetch([oom, oom, oom]);
+        await expect(fetchMaplify(WINDOW, noopLog)).rejects.toThrow(
+            /non-JSON 200 body .*<br \/> <b>Fatal error<\/b>: Allowed memory size .* exhausted/,
+        );
+    });
+
+    it('reports an empty 200 body distinctly', async () => {
+        stubFetch(['', '', '']);
+        await expect(fetchMaplify(WINDOW, noopLog)).rejects.toThrow(
+            /non-JSON 200 body \(0 bytes\): \(empty body\)/,
+        );
+    });
+});

--- a/supabase/functions/ingest/fetch-maplify.ts
+++ b/supabase/functions/ingest/fetch-maplify.ts
@@ -22,6 +22,13 @@ const MAPLIFY_URL = 'https://maplify.com/waseak/php/search-all-sightings.php';
 
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
+/** Collapse a response body to a single-line snippet for error messages. */
+function bodySnippet(text: string, max = 200): string {
+    const oneLine = text.replace(/\s+/g, ' ').trim();
+    if (oneLine.length === 0) return '(empty body)';
+    return oneLine.length > max ? `${oneLine.slice(0, max)}…` : oneLine;
+}
+
 // Deno's fetch has no built-in timeout; without one a hung Maplify connection
 // would block an attempt (and the whole edge invocation) indefinitely. Bound
 // each attempt so a hang becomes a retryable AbortError instead.
@@ -41,11 +48,25 @@ export async function fetchMaplify(window: IngestWindow, log: Logger): Promise<u
             res = await fetch(url, { headers: { accept: 'application/json' }, signal: controller.signal });
             if (res.ok) {
                 // Read the body under the SAME timeout: a server can send headers
-                // and then stall, and res.json() would otherwise hang past the
+                // and then stall, and reading it would otherwise hang past the
                 // deadline. Clear the timer only once the body is fully consumed.
-                const data = await res.json();
+                const text = await res.text();
                 clearTimeout(timeout);
-                return data;
+                try {
+                    return JSON.parse(text) as unknown;
+                } catch {
+                    // Maplify serves a 200 with a NON-JSON body on its own
+                    // server-side failures — a transient "Unable to connect to
+                    // the database" DB error, or an HTML PHP fatal-error page.
+                    // Throw a snippet of what it actually returned: this message
+                    // is what index.ts hands the operator (and Sentry), so an
+                    // opaque JSON-parse position would hide the real cause. Still
+                    // retried (transient DB blips recover); a persistent failure
+                    // surfaces the snippet after MAX_ATTEMPTS.
+                    throw new Error(
+                        `Maplify returned a non-JSON 200 body (${text.length} bytes): ${bodySnippet(text)}`,
+                    );
+                }
             }
         } catch (e) {
             // fetch-level failure, abort (timeout), or a stalled/aborted body read

--- a/supabase/functions/ingest/fetch-maplify.ts
+++ b/supabase/functions/ingest/fetch-maplify.ts
@@ -64,7 +64,8 @@ export async function fetchMaplify(window: IngestWindow, log: Logger): Promise<u
                     // retried (transient DB blips recover); a persistent failure
                     // surfaces the snippet after MAX_ATTEMPTS.
                     throw new Error(
-                        `Maplify returned a non-JSON 200 body (${text.length} bytes): ${bodySnippet(text)}`,
+                        `Maplify returned a non-JSON ${res.status} body ` +
+                            `(${text.length} chars): ${bodySnippet(text)}`,
                     );
                 }
             }


### PR DESCRIPTION
## Problem

Maplify serves **HTTP 200 with a non-JSON body** on its own server-side failures — a transient `Unable to connect to the database` DB error, or (for pathological queries) an HTML PHP fatal-error page. `res.json()` then throws an opaque `Unexpected token 'U'/'<' … is not valid JSON`, and `index.ts` hands that verbatim to the operator (the 500 response body and `ingest.runs.error`) and to Sentry — so **SALISHSEA-IO-2F** gave no hint that the real cause was a Maplify DB blip.

## Fix

Read `res.text()` first; on a JSON parse failure, throw a **one-line snippet of what the upstream actually returned**:

> `Maplify returned a non-JSON 200 body (34 bytes): Unable to connect to the database`

Applied to both `fetch-maplify.ts` and iNat's `fetchJsonWithRetry` (same footgun). **Retry behavior is unchanged** — the parse failure was already caught and retried (it's inside the `try`); transient DB blips still recover across the 3 attempts, and a persistent failure now surfaces the legible snippet after `MAX_ATTEMPTS`.

## Notes

- The **OOM page is not reachable** through the ingest function: `BBOX` is a fixed constant (`-136,36,-120,54`), so even an all-time Salish Sea window returns ~45k rows as valid JSON — only the date range is operator-controllable. Verified against the live endpoint. The OOM I could only trigger with a whole-globe BBOX we never send.
- We **do** pass the error to the operator (`index.ts` returns `{ ok: false, error: e.message }`), which is exactly why the message needed to be legible.

## Tests

New `fetch-maplify.test.ts` (normal JSON, DB-error snippet after retries, multi-line HTML collapsed to one line, empty-body case) and an updated iNat shell stub. Full suite green (309 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for external-service responses that return `200` with non-JSON content.
  * Error messages now include clearer status/context plus a compact, single-line excerpt of the returned body (including explicit diagnostics for empty bodies).
  * Kept existing retry and timeout behavior unchanged.
* **Tests**
  * Added a Maplify test suite covering valid JSON, malformed/non-JSON bodies, database-error text after retries, multiline fatal-error snippets, and empty-body responses.
  * Updated pagination mocks to match real response parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->