### PR TITLE
feat(ingest): id-keyset pagination for iNaturalist (SALISHSEA-IO-7up)

### DIFF
--- a/docs/decisions/011-ingest-imperative-shell.md
+++ b/docs/decisions/011-ingest-imperative-shell.md
@@ -1,6 +1,6 @@
 # 011 — Network ingest as a TypeScript imperative shell over a functional core
 
-**Status:** accepted · **Decided:** 2026-07-05
+**Status:** accepted · **Decided:** 2026-07-05 · **Amended by:** [018](018-inat-id-keyset-pagination.md) (iNaturalist completeness proof is now an id-keyset terminal-page sweep, not a `total_results` page-count sum)
 
 ## Context
 

--- a/docs/decisions/018-inat-id-keyset-pagination.md
+++ b/docs/decisions/018-inat-id-keyset-pagination.md
@@ -23,7 +23,7 @@ that still cannot express a window larger than iNat's `page * per_page ≤ 10 00
 
 Sweep the window by **ascending observation id** (id-keyset / cursor pagination):
 
-```
+```text
 order_by=id & order=asc & id_above=<lastMaxId> & per_page=200   (id_above=0 to start)
 ```
 

--- a/docs/decisions/018-inat-id-keyset-pagination.md
+++ b/docs/decisions/018-inat-id-keyset-pagination.md
@@ -1,0 +1,83 @@
+# 018 — iNaturalist ingest paginates by id-keyset, not page number
+
+**Status:** accepted · **Decided:** 2026-07-10 · **Amends:** [011](011-ingest-imperative-shell.md)
+
+## Context
+
+Decision [011](011-ingest-imperative-shell.md) made a *provably complete* fetch the precondition
+for reconcile: the shell may delete stored rows the fetch no longer returns only if it can prove
+it saw the whole window. For iNaturalist the original proof was a **page-number sweep**: fetch
+`page=1..N` where `N = ceil(total_results / per_page)`, and require that every page reported the
+same `total_results`, the page numbers were exactly `1..N`, and the per-page counts summed to
+`total_results`.
+
+That proof depends on `total_results` and per-page offsets being **stable across the whole
+sweep**, but iNaturalist's window is live (`d2` = "today"). An observation created, edited, or
+deleted between two sequential page requests shifts `total_results` or slides records across the
+`per_page` offset boundary, and the accumulated pages fail the completeness check. This surfaced
+as Sentry **SALISHSEA-IO-2D**. PR #327 added a bounded **re-page** (retry the whole window a few
+times, hoping it settles) — a mitigation that narrows the race window but never closes it, and
+that still cannot express a window larger than iNat's `page * per_page ≤ 10 000` hard cap.
+
+## Decision
+
+Sweep the window by **ascending observation id** (id-keyset / cursor pagination):
+
+```
+order_by=id & order=asc & id_above=<lastMaxId> & per_page=200   (id_above=0 to start)
+```
+
+Loop, advancing the cursor to each page's **max raw id**, until a page returns **fewer than
+`per_page` rows** — the **terminal page**. Under ascending-id ordering a short (or empty) page
+cannot be followed by more, so it *is* the completeness proof.
+
+- **`total_results` is no longer load-bearing.** iNat still returns it; the shell records it (as
+  raw records fetched) but never gates completeness on it. This is the specific amendment to
+  011's completeness invariant: the proof is now "a terminal short page was reached," not "the
+  per-page counts summed to `total_results`."
+- **The cursor is an immutable id**, so a mutation mid-sweep cannot drift the proof: a new
+  observation always gets a *higher* id (naturally swept if in range, ignored if past the
+  cursor), an edit keeps its id and place, a deletion simply doesn't appear. This eliminates the
+  drift class outright rather than retrying around it — so **PR #327's re-page loop is removed**.
+- **iNat's `page * per_page ≤ 10 000` cap no longer applies** (it bounds offset pagination, not
+  `id_above`), so the old `MAX_PAGE` guard is gone. A single generous `MAX_KEYSET_PAGES` backstop
+  (1000 pages ≈ 200 000 records) turns a pathological window or cursor bug into a loud throw
+  instead of a hung edge invocation.
+- **The cursor is computed over RAW page ids**, before the shell skips out-of-scope
+  `time_observed_at = null` records, so a trailing skipped record still advances the sweep.
+- Split unchanged per 011: `isTerminalPage` / `isPaginationComplete` are pure predicates in the
+  functional core ([`scripts/ingest/inaturalist.ts`](../../scripts/ingest/inaturalist.ts)); the
+  sweep loop is the shell
+  ([`supabase/functions/ingest/fetch-inaturalist.ts`](../../supabase/functions/ingest/fetch-inaturalist.ts)).
+  The shell asserts `isPaginationComplete` after the loop as a defensive invariant.
+
+## Rejected alternatives
+
+- **Keep page-number pagination, widen PR #327's re-page retries.** Only shrinks the race; a busy
+  window can drift on every attempt, and the 10 000-record cap remains. Treats a structural flaw
+  as a flake.
+- **Snapshot the window by a frozen upper time bound** (fetch only `updated_at < run_start`) to
+  make offset pagination atomic. Adds a time-boundary correctness argument of its own and still
+  inherits the 10 000-record cap; id-keyset needs neither.
+- **Trust `total_results` for a light cross-check** alongside keyset. Reintroduces the exact
+  drifting quantity this decision removes from the trusted path; its only honest use now is a log
+  field.
+
+## Consequences
+
+- One extra request per window in the exact-multiple-of-`per_page` case (a full last page forces
+  one confirming empty page). Negligible against the drift-retry requests this removes.
+- `ingest.runs.total_results` now records **raw records fetched across the sweep**, not iNat's
+  reported total — the same number on a complete fetch, and the honest one under keyset.
+- Windows over 10 000 records are now ingestable in a single run (still bounded by
+  `MAX_KEYSET_PAGES` and the edge invocation's wall clock).
+- A genuinely short *non-terminal* page (an iNat server returning fewer than `per_page` rows while
+  more exist) would be read as terminal and truncate the sweep. This is outside the documented
+  cursor contract; `isPaginationComplete`'s "every page but the last is full" assertion is the
+  guard, and the self-healing 10-day window re-fetches on the next run.
+
+## Reference
+
+Issue: `salishsea-io-7up` (durable fix for `salishsea-io-2f`/Sentry SALISHSEA-IO-2D). Amends the
+completeness invariant of [011](011-ingest-imperative-shell.md). Prior mitigation: PR #327
+(bounded re-page). Upstream-mirror boundary: [008](008-source-schemas-are-upstream-mirrors.md).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -18,3 +18,7 @@ Product and technical decisions with rationale and rejected alternatives. Add a 
 | [012](012-ingest-heartbeat.md) | Ingest heartbeat: external observer via scheduled GitHub Action | accepted |
 | [013](013-orcasound-acoustic-occurrences.md) | OrcaSound acoustic occurrences from curated biophony bouts, identified by upstream tags | accepted (our side); pending upstream adoption |
 | [014](014-trust-and-curation-model.md) | Trust & curation: claims have status, people have reputation, curators assert both | proposed (direction) |
+| [015](015-individual-profile-pages.md) | Individual profile pages at `/individuals/<designation>` | accepted |
+| [016](016-matriline-profile-pages.md) | Matriline profile pages | accepted |
+| [017](017-ecotype-profile-pages.md) | Ecotype profile pages | accepted |
+| [018](018-inat-id-keyset-pagination.md) | iNaturalist ingest paginates by id-keyset, not page number (amends 011) | accepted |

--- a/scripts/ingest/inaturalist.test.ts
+++ b/scripts/ingest/inaturalist.test.ts
@@ -20,7 +20,7 @@ import {
     referencedTaxonIds,
     referencedTaxonIdsFromTaxa,
     missingTaxonIds,
-    expectedPageCount,
+    isTerminalPage,
     isPaginationComplete,
     reconcile,
     InatObservationSchema,
@@ -106,7 +106,23 @@ describe('parseInatResponse', () => {
 
     test('accepts an authoritative empty result set (total_results=0)', () => {
         const r = parseInatResponse({ total_results: 0, page: 1, per_page: 200, results: [] });
-        expect(r).toMatchObject({ ok: true, observations: [], totalResults: 0, recordCount: 0 });
+        expect(r).toMatchObject({ ok: true, observations: [], totalResults: 0, recordCount: 0, maxId: null });
+    });
+
+    test('reports the max raw id as the keyset cursor (incl. a skipped null-time record)', () => {
+        const r = parseInatResponse({
+            total_results: 3,
+            results: [
+                { ...rawObs, id: 10 },
+                { ...rawObs, id: 30, time_observed_at: null }, // out of scope: skipped but still the max id
+                { ...rawObs, id: 20 },
+            ],
+        });
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        expect(r.observations.map((o) => o.id)).toEqual([10, 20]); // null-time record skipped
+        expect(r.recordCount).toBe(3); // but counted (drives terminal detection)
+        expect(r.maxId).toBe(30); // cursor advances past the skipped record
     });
 
     test('blank description → null; blank orcid → null; blank photo license → null', () => {
@@ -226,72 +242,41 @@ describe('taxon closure diffs', () => {
     });
 });
 
-describe('pagination completeness', () => {
-    test('expectedPageCount: empty total needs the one reporting page', () => {
-        expect(expectedPageCount(0, 200)).toBe(1);
-    });
-    test('expectedPageCount: ceil(total/perPage)', () => {
-        expect(expectedPageCount(200, 200)).toBe(1);
-        expect(expectedPageCount(201, 200)).toBe(2);
-        expect(expectedPageCount(1826, 200)).toBe(10);
+describe('pagination completeness (id-keyset)', () => {
+    test('isTerminalPage: a short (or empty) page ends the sweep; a full page does not', () => {
+        expect(isTerminalPage(0, 200)).toBe(true);
+        expect(isTerminalPage(50, 200)).toBe(true);
+        expect(isTerminalPage(199, 200)).toBe(true);
+        expect(isTerminalPage(200, 200)).toBe(false); // full page → more may follow
     });
 
-    const page = (over: Partial<FetchedPage> & { page: number }): FetchedPage => ({
-        totalResults: 0, recordCount: 0, ...over,
+    const page = (recordCount: number, maxId: number | null = recordCount): FetchedPage => ({
+        recordCount, maxId,
     });
 
-    test('a single empty page (total=0) is complete and authoritative', () => {
-        expect(isPaginationComplete([page({ page: 1, totalResults: 0, recordCount: 0 })], 200)).toBe(true);
+    test('a single empty page is complete and authoritative', () => {
+        expect(isPaginationComplete([page(0, null)], 200)).toBe(true);
     });
 
-    test('all pages present with counts summing to total → complete', () => {
-        const pages = [
-            page({ page: 1, totalResults: 450, recordCount: 200 }),
-            page({ page: 2, totalResults: 450, recordCount: 200 }),
-            page({ page: 3, totalResults: 450, recordCount: 50 }),
-        ];
-        expect(isPaginationComplete(pages, 200)).toBe(true);
+    test('a single short first page is complete (fits in one page)', () => {
+        expect(isPaginationComplete([page(50)], 200)).toBe(true);
     });
 
-    test('a missing final page → incomplete', () => {
-        const pages = [
-            page({ page: 1, totalResults: 450, recordCount: 200 }),
-            page({ page: 2, totalResults: 450, recordCount: 200 }),
-        ];
-        expect(isPaginationComplete(pages, 200)).toBe(false);
+    test('full pages followed by a terminal short page → complete', () => {
+        expect(isPaginationComplete([page(200), page(200), page(50)], 200)).toBe(true);
     });
 
-    test('a gap in page numbers → incomplete', () => {
-        const pages = [
-            page({ page: 1, totalResults: 450, recordCount: 200 }),
-            page({ page: 3, totalResults: 450, recordCount: 250 }),
-        ];
-        expect(isPaginationComplete(pages, 200)).toBe(false);
+    test('an exactly-full window then a terminal empty page → complete', () => {
+        // total is a multiple of per_page: the last full page is followed by a 0-row page.
+        expect(isPaginationComplete([page(200), page(200), page(0, null)], 200)).toBe(true);
     });
 
-    test('a duplicated page number → incomplete', () => {
-        const pages = [
-            page({ page: 1, totalResults: 400, recordCount: 200 }),
-            page({ page: 1, totalResults: 400, recordCount: 200 }),
-        ];
-        expect(isPaginationComplete(pages, 200)).toBe(false);
+    test('a full last page (no terminal short page) → incomplete', () => {
+        expect(isPaginationComplete([page(200), page(200)], 200)).toBe(false);
     });
 
-    test('inconsistent total_results across pages → incomplete', () => {
-        const pages = [
-            page({ page: 1, totalResults: 400, recordCount: 200 }),
-            page({ page: 2, totalResults: 401, recordCount: 200 }),
-        ];
-        expect(isPaginationComplete(pages, 200)).toBe(false);
-    });
-
-    test('record counts that do not sum to total → incomplete', () => {
-        const pages = [
-            page({ page: 1, totalResults: 450, recordCount: 200 }),
-            page({ page: 2, totalResults: 450, recordCount: 200 }),
-            page({ page: 3, totalResults: 450, recordCount: 40 }), // 440 != 450
-        ];
-        expect(isPaginationComplete(pages, 200)).toBe(false);
+    test('a short page BEFORE the last (mid-sweep truncation) → incomplete', () => {
+        expect(isPaginationComplete([page(200), page(150), page(50)], 200)).toBe(false);
     });
 
     test('no pages fetched at all → incomplete', () => {

--- a/scripts/ingest/inaturalist.ts
+++ b/scripts/ingest/inaturalist.ts
@@ -14,12 +14,16 @@
  * The two hard parts of iNat ingest (decision 011) both reduce to pure helpers
  * this module owns; the loops/effects around them are the shell's job:
  *
- *   1. Pagination completeness — `isPaginationComplete` decides whether the shell
- *      has accumulated every page through `total_results`. A fetch is COMPLETE
- *      only if page 1..N (N = ceil(total/per_page)) each returned 200 with a
- *      well-formed body and the record counts sum to `total_results`. An empty
- *      first page (`total_results = 0`) is complete and authoritative. Any missing
- *      or failed page → not complete → the shell writes nothing.
+ *   1. Pagination completeness — the shell sweeps the window by ASCENDING id
+ *      (id-keyset/cursor pagination, decision 018), not by page number. A fetch is
+ *      COMPLETE once a TERMINAL page returns fewer than `per_page` rows: iNat
+ *      returns exactly `per_page` rows for every page but the last, so a short (or
+ *      empty) page cannot be followed by more. `isTerminalPage` is that stop
+ *      signal; `isPaginationComplete` is the post-hoc invariant (every page but the
+ *      last full, the last terminal). An empty first page is terminal — an
+ *      authoritative empty window. `total_results` is no longer load-bearing:
+ *      immutable ids give a consistent forward snapshot even as the live window
+ *      mutates mid-sweep. Any missing/failed page → not complete → write nothing.
  *
  *   2. Taxon-ancestor closure — `referencedTaxonIds` extracts the taxon ids an
  *      observation batch needs (self + ancestors); `missingTaxonIds` diffs that
@@ -256,10 +260,16 @@ export type InatParseResult =
     | {
           readonly ok: true;
           readonly observations: readonly NormalizedObservation[];
+          /** iNat's reported total; informational only under id-keyset pagination (decision 018). */
           readonly totalResults: number;
-          /** Raw page result count BEFORE null-time skipping — feeds the completeness sum. */
+          /** Raw page result count BEFORE null-time skipping — drives terminal-page detection. */
           readonly recordCount: number;
-          readonly page: number | null;
+          /**
+           * Max raw observation id on the page (the next `id_above` cursor), or null
+           * for an empty page. Computed over RAW results so the cursor still advances
+           * past out-of-scope null-time records the shell skips.
+           */
+          readonly maxId: number | null;
       }
     | { readonly ok: false; readonly error: string };
 
@@ -285,12 +295,16 @@ export function parseInatResponse(raw: unknown): InatParseResult {
         if (observedAt == null) continue; // out of scope; skip (mirrors live SQL)
         observations.push(normalizeObservation(r, observedAt));
     }
+    const maxId = parsed.data.results.reduce<number | null>(
+        (m, r) => (m == null || r.id > m ? r.id : m),
+        null,
+    );
     return {
         ok: true,
         observations,
         totalResults: parsed.data.total_results,
         recordCount: parsed.data.results.length,
-        page: parsed.data.page ?? null,
+        maxId,
     };
 }
 
@@ -356,56 +370,48 @@ export function missingTaxonIds(
 }
 
 // --------------------------------------------------------------------------
-// Pagination completeness (the core safety predicate).
+// Pagination completeness (the core safety predicate), id-keyset variant.
+// See decision 018: the shell sweeps the window by ascending observation id
+// (order_by=id&order=asc&id_above=<cursor>) rather than by page number, so
+// live-window mutation no longer drifts a total_results-based completeness sum
+// and iNat's page*per_page ≤ 10 000 cap no longer applies.
 // --------------------------------------------------------------------------
 
-/** Metadata the shell records for each page it successfully fetched & parsed. */
+/** Metadata the shell records for each keyset page it successfully fetched & parsed. */
 export type FetchedPage = {
-    readonly page: number;
-    readonly totalResults: number;
     /** Raw result count for this page (before null-time skipping). */
     readonly recordCount: number;
+    /** Max raw observation id on the page (the cursor for the next fetch); null if empty. */
+    readonly maxId: number | null;
 };
 
 /**
- * Number of pages that must be fetched to cover `totalResults` at `perPage`.
- * `totalResults === 0` still requires the ONE page (page 1) that authoritatively
- * reported the empty result. NB: iNat caps page-based pagination at 10 000
- * records, so a window with total > 10 000 cannot be completed by this route —
- * `isPaginationComplete` will (honestly) never return true for it, and the shell
- * aborts rather than persist a truncated view.
+ * Whether a keyset page is the TERMINAL page — the stop signal the shell's sweep
+ * loop watches for. iNat returns exactly `perPage` rows for every page except the
+ * last, so a page with fewer rows (including zero) cannot be followed by more and
+ * ends the ascending-id sweep. This replaces the old total_results cross-check.
  */
-export function expectedPageCount(totalResults: number, perPage: number): number {
-    if (perPage <= 0) return 0;
-    if (totalResults <= 0) return 1;
-    return Math.ceil(totalResults / perPage);
+export function isTerminalPage(recordCount: number, perPage: number): boolean {
+    return recordCount < perPage;
 }
 
 /**
- * Whether the accumulated pages constitute a PROVABLY COMPLETE fetch (decision
- * 011's central invariant). Complete iff:
- *   - at least page 1 was fetched;
- *   - every page reports the same total_results (no shifting ground);
- *   - the fetched page numbers are exactly 1..N with no gap or duplicate,
- *     where N = expectedPageCount(total, perPage);
- *   - the per-page record counts sum to total_results.
- * Any hole, an extra/short page, or a mid-pagination failure (which leaves a page
- * un-accumulated) → false → the shell writes nothing.
+ * Whether the accumulated keyset pages constitute a PROVABLY COMPLETE fetch
+ * (decision 011's central invariant, revised for id-cursor pagination in 018).
+ * Complete iff:
+ *   - at least one page was fetched;
+ *   - every page but the last returned a FULL `perPage` rows (no short page mid-sweep);
+ *   - the last page is terminal (fewer than `perPage` rows).
+ * An empty first page (recordCount 0) is itself terminal — an authoritative empty
+ * window. The shell asserts this after its loop as a defensive invariant; the
+ * loop's terminal-page exit already guarantees it.
  */
 export function isPaginationComplete(pages: readonly FetchedPage[], perPage: number): boolean {
     if (pages.length === 0) return false;
-    const total = pages[0]!.totalResults;
-    if (pages.some((p) => p.totalResults !== total)) return false;
-
-    const expected = expectedPageCount(total, perPage);
-    if (pages.length !== expected) return false;
-
-    const nums = new Set(pages.map((p) => p.page));
-    if (nums.size !== expected) return false;
-    for (let i = 1; i <= expected; i++) if (!nums.has(i)) return false;
-
-    const sum = pages.reduce((n, p) => n + p.recordCount, 0);
-    return sum === total;
+    for (let i = 0; i < pages.length - 1; i++) {
+        if (pages[i]!.recordCount !== perPage) return false;
+    }
+    return isTerminalPage(pages[pages.length - 1]!.recordCount, perPage);
 }
 
 // --------------------------------------------------------------------------

--- a/supabase/functions/ingest/fetch-inaturalist.test.ts
+++ b/supabase/functions/ingest/fetch-inaturalist.test.ts
@@ -1,11 +1,13 @@
 /**
- * Shell test for fetchAllObservationPages' bounded re-page loop (salishsea-io-h79
- * / Sentry SALISHSEA-IO-2D). iNat page-based pagination is not atomic over a live
- * window; a mutation between two page requests drifts total_results so the
- * accumulated pages fail isPaginationComplete. The shell must re-page the whole
- * window a bounded number of times before surfacing that as a real failure.
+ * Shell test for fetchAllObservationPages' id-keyset sweep (salishsea-io-7up /
+ * decision 018, durable fix for Sentry SALISHSEA-IO-2D). The shell walks the
+ * window by ASCENDING observation id (id_above=<lastId>) until a page returns
+ * fewer than per_page rows. Because the cursor is an immutable id, a mutation
+ * mid-sweep no longer drifts a completeness sum — the class of failure PR #327's
+ * bounded re-page only retried around.
  *
- * We stub global fetch (no network) to script drift-then-consistent responses.
+ * We stub global fetch (no network) to script keyset pages and assert both the
+ * accumulated snapshot and that the id_above cursor advances by each page's max id.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fetchAllObservationPages } from './fetch-inaturalist.ts';
@@ -29,67 +31,114 @@ function record(id: number) {
     };
 }
 
-/** A page body: `total_results` reported plus `count` real records (from startId). */
-function pageBody(page: number, totalResults: number, count: number, startId: number) {
+/**
+ * A keyset page: `count` records with ascending ids from `startId`. `totalResults`
+ * is deliberately variable to prove the sweep ignores it (it is no longer
+ * load-bearing under id-keyset pagination).
+ */
+function pageBody(count: number, startId: number, totalResults = 9999) {
     return {
         total_results: totalResults,
-        page,
+        page: 1,
         per_page: 200,
         results: Array.from({ length: count }, (_, i) => record(startId + i)),
     };
 }
 
-/** Stub global fetch to return each queued body once, in order. */
-function stubFetch(bodies: unknown[]) {
+/** Stub global fetch to return each queued body once, in order; returns the URLs seen. */
+function stubFetch(bodies: unknown[]): string[] {
+    const urls: string[] = [];
     let i = 0;
-    vi.stubGlobal('fetch', () => {
+    vi.stubGlobal('fetch', (url: string) => {
+        urls.push(String(url));
         const body = bodies[i++];
         if (body === undefined) throw new Error(`unexpected fetch #${i}`);
         // The shell reads res.text() then JSON.parse()s it; return the serialized body.
         return Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve(JSON.stringify(body)) });
     });
+    return urls;
 }
 
 afterEach(() => vi.unstubAllGlobals());
 
-describe('fetchAllObservationPages re-pages on live-window drift', () => {
-    it('returns the snapshot on the first consistent pass (no drift)', async () => {
-        // total 250 → 2 pages (200 + 50), totals stable → complete on attempt 1.
-        stubFetch([pageBody(1, 250, 200, 1), pageBody(2, 250, 50, 201)]);
+describe('fetchAllObservationPages sweeps the window by ascending id', () => {
+    it('completes on a single short first page (one request, id_above=0)', async () => {
+        const urls = stubFetch([pageBody(50, 1)]);
 
         const result = await fetchAllObservationPages(WINDOW, noopLog);
 
-        expect(result.totalResults).toBe(250);
-        expect(result.pages.map((p) => p.recordCount)).toEqual([200, 50]);
-        expect(result.observations).toHaveLength(250);
+        expect(result.recordCount).toBe(50);
+        expect(result.observations).toHaveLength(50);
+        expect(result.pages.map((p) => p.recordCount)).toEqual([50]);
+        expect(urls).toHaveLength(1);
+        expect(urls[0]).toContain('id_above=0');
     });
 
-    it('retries the whole window and succeeds once the dataset settles', async () => {
-        // Attempt 1: page 2 reports a drifted total (251) → incomplete.
-        // Attempt 2: totals agree (250) → complete.
-        stubFetch([
-            pageBody(1, 250, 200, 1),
-            pageBody(2, 251, 51, 201),
-            pageBody(1, 250, 200, 1),
-            pageBody(2, 250, 50, 201),
+    it('advances the id_above cursor by each page\'s max id, ending on a terminal short page', async () => {
+        const urls = stubFetch([
+            pageBody(200, 1),   // ids 1..200   → cursor 200
+            pageBody(200, 201), // ids 201..400 → cursor 400
+            pageBody(50, 401),  // ids 401..450 → terminal (< 200)
         ]);
 
         const result = await fetchAllObservationPages(WINDOW, noopLog);
 
-        expect(result.totalResults).toBe(250);
-        expect(result.pages.map((p) => p.recordCount)).toEqual([200, 50]);
+        expect(result.recordCount).toBe(450);
+        expect(result.observations).toHaveLength(450);
+        expect(result.pages.map((p) => p.recordCount)).toEqual([200, 200, 50]);
+        expect(urls[0]).toContain('id_above=0');
+        expect(urls[1]).toContain('id_above=200');
+        expect(urls[2]).toContain('id_above=400');
     });
 
-    it('throws after exhausting attempts when the window never settles', async () => {
-        // Every attempt drifts (page 2 total ≠ page 1 total): 3 attempts × 2 pages.
-        stubFetch([
-            pageBody(1, 250, 200, 1), pageBody(2, 251, 51, 201),
-            pageBody(1, 250, 200, 1), pageBody(2, 251, 51, 201),
-            pageBody(1, 250, 200, 1), pageBody(2, 251, 51, 201),
+    it('treats a drifting total_results as noise (immune to live-window mutation)', async () => {
+        // Wildly inconsistent total_results across pages — the OLD total-sum check
+        // would have failed this; the id-keyset sweep completes on the short page.
+        const urls = stubFetch([
+            pageBody(200, 1, 9999),
+            pageBody(200, 201, 5),
+            pageBody(10, 401, 123456),
         ]);
+
+        const result = await fetchAllObservationPages(WINDOW, noopLog);
+
+        expect(result.recordCount).toBe(410);
+        expect(result.pages.map((p) => p.recordCount)).toEqual([200, 200, 10]);
+        expect(urls).toHaveLength(3);
+    });
+
+    it('follows an exactly-full window with a terminal empty page', async () => {
+        // total is a multiple of per_page: the last full page yields a 0-row page.
+        const urls = stubFetch([pageBody(200, 1), pageBody(0, 201)]);
+
+        const result = await fetchAllObservationPages(WINDOW, noopLog);
+
+        expect(result.recordCount).toBe(200);
+        expect(result.observations).toHaveLength(200);
+        expect(urls[1]).toContain('id_above=200');
+    });
+
+    it('completes on an authoritative empty window (first page has no records)', async () => {
+        stubFetch([pageBody(0, 1)]);
+
+        const result = await fetchAllObservationPages(WINDOW, noopLog);
+
+        expect(result.recordCount).toBe(0);
+        expect(result.observations).toHaveLength(0);
+    });
+
+    it('throws when the sweep never terminates (runaway bound)', async () => {
+        // Always return a full page with advancing ids: the cursor keeps moving but
+        // no terminal page ever arrives, so the sweep must hit MAX_KEYSET_PAGES.
+        let startId = 1;
+        vi.stubGlobal('fetch', () => {
+            const body = pageBody(200, startId);
+            startId += 200;
+            return Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve(JSON.stringify(body)) });
+        });
 
         await expect(fetchAllObservationPages(WINDOW, noopLog)).rejects.toThrow(
-            /pagination incomplete after 3 attempts/,
+            /keyset sweep exceeded 1000 pages/,
         );
     });
 });

--- a/supabase/functions/ingest/fetch-inaturalist.ts
+++ b/supabase/functions/ingest/fetch-inaturalist.ts
@@ -7,9 +7,14 @@
  * completeness invariant: they either produce a PROVABLY COMPLETE fetch or they
  * throw — and a throw makes index.ts write nothing.
  *
- *   A. fetchAllObservationPages — page 1..N through `total_results`; every page
- *      must parse; `isPaginationComplete` must hold; else throw. An empty first
- *      page (total_results = 0) is complete and authoritative.
+ *   A. fetchAllObservationPages — sweep the window by ASCENDING observation id
+ *      (id-keyset/cursor pagination, decision 018): fetch `id_above=<lastId>`
+ *      pages until one returns fewer than `per_page` rows (the terminal page).
+ *      Every page must parse; else throw. An empty first page is terminal — an
+ *      authoritative empty window. Immutable ids give a consistent forward
+ *      snapshot, so a mutation mid-sweep no longer drifts completeness (the class
+ *      of failure PR #327's bounded re-page only retried around), and iNat's
+ *      page*per_page ≤ 10 000 cap no longer applies.
  *
  *   B. resolveTaxonClosure — resolve the FULL taxon-ancestor closure before the
  *      caller opens the persist transaction (no HTTP inside the DB write). Fetch
@@ -37,7 +42,7 @@ import {
     referencedTaxonIds,
     referencedTaxonIdsFromTaxa,
     missingTaxonIds,
-    expectedPageCount,
+    isTerminalPage,
     isPaginationComplete,
     type FetchedPage,
     type NormalizedObservation,
@@ -54,19 +59,15 @@ const TAXA_URL = 'https://api.inaturalist.org/v2/taxa';
 // becomes a retryable AbortError instead of blocking the invocation.
 const FETCH_TIMEOUT_MS = 20_000;
 
-// iNat page-based pagination caps at page * per_page <= 10 000 records.
-const MAX_PAGE = Math.floor(10_000 / PER_PAGE);
-
 // iNat caps the `/taxa` `id` param at ~30 ids per request.
 const TAXA_ID_CHUNK = 30;
 
-// iNat page-based pagination is NOT atomic over a live window: `window.end` is
-// "today", so an observation created/edited/deleted between two sequential page
-// requests drifts `total_results` or the per-page counts, and the accumulated
-// pages fail `isPaginationComplete`. That is transient and self-heals on a fresh
-// pass, so re-page the whole window this many times before treating the
-// incompleteness as real (a genuine, persistent failure the next cron retries).
-const PAGINATION_ATTEMPTS = 3;
+// id-keyset pagination has no page*per_page cap and no live-window drift, but a
+// pathological window (or a cursor bug) could otherwise loop unbounded and hang
+// the edge invocation. Bound the sweep so a runaway fails loudly instead. The
+// 10-day rolling window realistically holds hundreds of records; 1000 pages
+// (200 000 records) is a generous backstop, not an expected limit.
+const MAX_KEYSET_PAGES = 1000;
 
 // v2 `/observations` field selection. Extends the legacy SQL path's set with the
 // fields the functional core now requires: `updated_at` (drives the
@@ -159,7 +160,10 @@ async function fetchJsonWithRetry(url: string, label: string, log: Logger): Prom
     throw lastError ?? new Error(`iNaturalist ${label} fetch failed`);
 }
 
-function observationsUrl(window: IngestWindow, page: number): string {
+// id-keyset page: ascending id, records with id strictly greater than `idAbove`
+// (0 → from the smallest id). No `page` param — the cursor, not an offset, walks
+// the window, which is what makes the sweep immune to live-window drift.
+function observationsUrl(window: IngestWindow, idAbove: number): string {
     const params = new URLSearchParams({
         d1: window.start,
         d2: window.end,
@@ -171,8 +175,10 @@ function observationsUrl(window: IngestWindow, page: number): string {
         taxon_id: INAT_ROOT_TAXON_IDS.join(','),
         geoprivacy: 'open',
         taxon_geoprivacy: 'open',
+        order_by: 'id',
+        order: 'asc',
+        id_above: String(idAbove),
         per_page: String(PER_PAGE),
-        page: String(page),
         fields: OBSERVATION_FIELDS,
     });
     return `${OBSERVATIONS_URL}?${params.toString()}`;
@@ -191,90 +197,75 @@ function taxaUrl(ids: readonly number[]): string {
 export type ObservationFetchResult = {
     readonly pages: readonly FetchedPage[];
     readonly observations: readonly NormalizedObservation[];
-    readonly totalResults: number;
+    /** Raw records fetched across the window (sum of per-page counts). */
+    readonly recordCount: number;
 };
 
 /**
- * Fetch every page of the window through `total_results` ONCE, accumulating
- * FetchedPage metadata and normalized observations. Throws on any parse/HTTP
- * failure or on a window that exceeds iNat's 10 000-record pagination cap. Does
- * NOT assert completeness — the caller checks `isPaginationComplete` and re-pages
- * if the live window drifted mid-fetch.
- */
-async function collectObservationPages(
-    window: IngestWindow,
-    log: Logger,
-): Promise<ObservationFetchResult> {
-    const pages: FetchedPage[] = [];
-    const observations: NormalizedObservation[] = [];
-    let totalResults = 0;
-
-    for (let page = 1; ; page++) {
-        const raw = await fetchJsonWithRetry(observationsUrl(window, page), 'observations', log);
-        const result = parseInatResponse(raw);
-        if (!result.ok) {
-            throw new Error(`iNaturalist observations parse failed (page ${page}): ${result.error}`);
-        }
-        pages.push({ page, totalResults: result.totalResults, recordCount: result.recordCount });
-        observations.push(...result.observations);
-        totalResults = result.totalResults;
-
-        const expected = expectedPageCount(totalResults, PER_PAGE);
-        if (expected > MAX_PAGE) {
-            throw new Error(
-                `window exceeds iNaturalist pagination cap: total_results=${totalResults} ` +
-                    `needs ${expected} pages (max ${MAX_PAGE}); narrow the window`,
-            );
-        }
-        log('inat observations page', {
-            page, totalResults, recordCount: result.recordCount, expected,
-        });
-        if (page >= expected) break;
-    }
-
-    return { pages, observations, totalResults };
-}
-
-/**
- * Loop A. Fetch every page of the window through `total_results` and return only
- * a PROVABLY COMPLETE snapshot (decision 011) — the precondition reconcile() and
- * persist require.
+ * Loop A. Sweep the window by ASCENDING observation id (id-keyset pagination,
+ * decision 018) and return only a PROVABLY COMPLETE snapshot (decision 011) — the
+ * precondition reconcile() and persist require.
  *
- * iNat's page-based pagination is not atomic over a live window (see
- * PAGINATION_ATTEMPTS): a mutation between two sequential page requests drifts
- * `total_results` or the per-page counts and fails `isPaginationComplete`. That
- * is transient, so re-page the whole window up to PAGINATION_ATTEMPTS times
- * before giving up. Still throws on parse/HTTP failure, on a window over iNat's
- * 10 000-record cap, or if every attempt drifted — a genuine (persistent)
- * incompleteness the next 5-minute cron will retry.
+ * Each request asks for the next `id_above=<lastId>` page; the sweep ends at the
+ * TERMINAL page (fewer than `per_page` rows), which under ascending-id ordering
+ * cannot be followed by more. Because the cursor is an immutable id, an
+ * observation created/edited/deleted between two requests no longer drifts a
+ * completeness sum — the class of transient failure PR #327's bounded re-page
+ * only retried around. Still throws on parse/HTTP failure, or if the sweep
+ * exceeds MAX_KEYSET_PAGES (a runaway) — a genuine failure the next cron retries.
  */
 export async function fetchAllObservationPages(
     window: IngestWindow,
     log: Logger,
 ): Promise<ObservationFetchResult> {
-    let last: ObservationFetchResult | null = null;
+    const pages: FetchedPage[] = [];
+    const observations: NormalizedObservation[] = [];
+    let cursor = 0; // id_above=0 → start from the smallest id
 
-    for (let attempt = 1; attempt <= PAGINATION_ATTEMPTS; attempt++) {
-        const result = await collectObservationPages(window, log);
-        if (isPaginationComplete(result.pages, PER_PAGE)) return result;
-
-        last = result;
-        if (attempt < PAGINATION_ATTEMPTS) {
-            const delay = retryDelayMs(attempt);
-            log('inat pagination incomplete (live window drifted mid-fetch), re-paging', {
-                attempt,
-                pages: result.pages.length,
-                totalResults: result.totalResults,
-                delayMs: delay,
-            });
-            await sleep(delay);
+    for (let pageNum = 1; ; pageNum++) {
+        if (pageNum > MAX_KEYSET_PAGES) {
+            throw new Error(
+                `iNaturalist keyset sweep exceeded ${MAX_KEYSET_PAGES} pages ` +
+                    `(cursor id_above=${cursor}); window implausibly large or a cursor bug`,
+            );
         }
+
+        const raw = await fetchJsonWithRetry(observationsUrl(window, cursor), 'observations', log);
+        const result = parseInatResponse(raw);
+        if (!result.ok) {
+            throw new Error(
+                `iNaturalist observations parse failed (id_above ${cursor}): ${result.error}`,
+            );
+        }
+        pages.push({ recordCount: result.recordCount, maxId: result.maxId });
+        observations.push(...result.observations);
+        log('inat observations page', {
+            page: pageNum, idAbove: cursor, recordCount: result.recordCount, maxId: result.maxId,
+        });
+
+        if (isTerminalPage(result.recordCount, PER_PAGE)) break;
+
+        // A full page must carry a max id to advance the cursor past; recordCount
+        // === PER_PAGE implies maxId != null, but guard rather than loop forever.
+        if (result.maxId == null) {
+            throw new Error(
+                `iNaturalist keyset cursor stuck: full page with no max id at id_above=${cursor}`,
+            );
+        }
+        cursor = result.maxId;
     }
 
-    throw new Error(
-        `iNaturalist pagination incomplete after ${PAGINATION_ATTEMPTS} attempts: ` +
-            `fetched ${last!.pages.length} page(s) for total_results=${last!.totalResults}`,
-    );
+    // The terminal-page exit structurally proves completeness; assert decision
+    // 011's invariant defensively before the caller reconciles/persists.
+    if (!isPaginationComplete(pages, PER_PAGE)) {
+        throw new Error(
+            `iNaturalist keyset pagination did not converge to a complete snapshot ` +
+                `(${pages.length} page(s))`,
+        );
+    }
+
+    const recordCount = pages.reduce((n, p) => n + p.recordCount, 0);
+    return { pages, observations, recordCount };
 }
 
 /**

--- a/supabase/functions/ingest/index.ts
+++ b/supabase/functions/ingest/index.ts
@@ -113,7 +113,7 @@ async function ingestInaturalist(
     dryRun: boolean,
     logger: typeof log,
 ): Promise<IngestOutcome> {
-    const { pages, observations, totalResults } = await fetchAllObservationPages(window, logger);
+    const { pages, observations, recordCount } = await fetchAllObservationPages(window, logger);
     const taxa = await resolveTaxonClosure(sql, observations, logger);
 
     const existing = await fetchObservationWindowIds(sql, window);
@@ -127,7 +127,9 @@ async function ingestInaturalist(
         upserted: result.observationsUpserted,
         deleted: result.observationsDeleted,
         pagesFetched: pages.length,
-        totalResults,
+        // ingest.runs.total_results now records raw records fetched across the
+        // id-keyset sweep (decision 018); iNat's drifting total is no longer used.
+        totalResults: recordCount,
     };
 }
 


### PR DESCRIPTION
## What

Replaces iNaturalist's page-number pagination with an **ascending-id keyset sweep** (`order_by=id&order=asc&id_above=<lastId>`), looping until a page returns fewer than `per_page` rows (the terminal page).

## Why

Decision 011 requires a *provably complete* fetch before reconcile may delete rows. The old proof — every page `200` through `total_results`, per-page counts summing to `total_results` — depends on `total_results` and page offsets being stable across the whole sweep. But iNat's window is live (`d2` = "today"), so a create/edit/delete between two page requests drifts the sum and fails the check (Sentry **SALISHSEA-IO-2D**). PR #327 added a bounded re-page that only *retries around* the race.

Because a keyset cursor is an **immutable id**, mid-sweep mutation can no longer drift the proof — this eliminates the drift class rather than retrying it, and also sidesteps iNat's `page * per_page ≤ 10 000` offset cap.

## Changes

- **Functional core** (`scripts/ingest/inaturalist.ts`): `parseInatResponse` now returns `maxId` (max *raw* page id → next cursor, computed before null-time records are skipped). Replaces `expectedPageCount`/`isPaginationComplete`'s total-sum logic with `isTerminalPage` + a keyset `isPaginationComplete` (every page but the last full; last terminal).
- **Shell** (`fetch-inaturalist.ts`): `fetchAllObservationPages` is now a single keyset loop; removes the re-page retry loop, `PAGINATION_ATTEMPTS`, and `MAX_PAGE`; adds a `MAX_KEYSET_PAGES` runaway backstop and a defensive post-loop completeness assert.
- **`index.ts`**: `ingest.runs.total_results` now records raw records fetched (iNat's drifting total is no longer trusted).
- **Docs**: new decision record [018](docs/decisions/018-inat-id-keyset-pagination.md); amends [011](docs/decisions/011-ingest-imperative-shell.md); README table updated (015–018).
- **Tests**: rewritten core + shell suites cover terminal detection, cursor advance, drift-immunity, exact-multiple + empty-terminal, and the runaway bound. 40 pass.

## Verification

`npx vitest run scripts/ingest supabase/functions/ingest` (87 pass, 17 DB-integration skipped), `npx tsc --noEmit`, and `deno check` on the edge function all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iNaturalist imports by switching to stable ID-based (keyset) pagination, making results resilient to changing total counts during a sweep.
  * Imports now determine completion via terminal-page detection and handle empty/partial/truncated sweeps more accurately.
  * Added a fail-fast safeguard to stop unusually long, non-terminating imports.
  * Updated what’s recorded as the iNaturalist ingest “total results” to reflect raw records fetched in the sweep.

* **Documentation**
  * Updated and added decision records covering pagination and related profile-page decisions.

* **Tests**
  * Expanded coverage for cursor advancement, completion scenarios, skipped records, and inconsistent totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->