### PR TITLE
fix(infra): bound edge OG fetches so timeouts fail open, not 503 (salishsea-io-g9e)

### DIFF
--- a/docs/decisions/015-individual-profile-pages.md
+++ b/docs/decisions/015-individual-profile-pages.md
@@ -16,6 +16,11 @@ CloudFront/S3 has no object at `/individuals/*`, so the existing viewer-request
 Lambda@Edge (`infra/lib/edge-handler`) rewrites those paths to `/individual.html`
 for humans and synthesizes catalog-driven OG meta for crawler user-agents (same
 fail-open contract as `?o=`; unknown designations get the generic site card).
+Fail-open only works if the handler's code sees the failure: the viewer-request
+Lambda is hard-killed at 5s and CloudFront then serves a 503 (observed on the
+2026-07-22 smoke run, bd `salishsea-io-g9e`), so every SSM and Supabase call in
+the handler carries an `AbortSignal` deadline sized to keep the worst-case cold
+chain under the kill — slowness degrades to the shell, never a 503.
 The Vite dev/preview servers mirror the rewrite via a small middleware in
 `vite.config.js`.
 

--- a/infra/lib/edge-handler/index.test.ts
+++ b/infra/lib/edge-handler/index.test.ts
@@ -188,6 +188,59 @@ describe('Lambda@Edge OG meta handler', () => {
     expect(result).toBe(event.Records[0].cf.request);
   });
 
+  // salishsea-io-g9e: the viewer-request Lambda is killed at 5s and CloudFront
+  // serves a 503 — every network call must carry its own deadline so slowness
+  // surfaces as a catchable error inside the fail-open try/catch instead.
+  it('bounds the Supabase fetch with an AbortSignal deadline', async () => {
+    const mockFetch = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => [sampleOccurrence],
+    } as Response);
+    await handler(makeEvent('facebookexternalhit/1.1', 'o=abc123'));
+    const options = mockFetch.mock.calls[0]?.[1] as RequestInit;
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('bounds the SSM credential calls with an AbortSignal deadline', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => [sampleOccurrence],
+    } as Response);
+    const { SSMClient } = jest.requireMock('@aws-sdk/client-ssm') as { SSMClient: jest.Mock };
+    const mockSend = jest.fn().mockResolvedValue({ Parameter: { Value: 'mock-value' } });
+    SSMClient.mockImplementation(() => ({ send: mockSend }));
+
+    await handler(makeEvent('facebookexternalhit/1.1', 'o=abc123'));
+    for (const call of mockSend.mock.calls) {
+      expect((call[1] as { abortSignal: unknown }).abortSignal).toBeInstanceOf(AbortSignal);
+    }
+    expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns request (fail-open) when the SSM credential call times out', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch');
+    const { SSMClient } = jest.requireMock('@aws-sdk/client-ssm') as { SSMClient: jest.Mock };
+    SSMClient.mockImplementation(() => ({
+      send: jest.fn().mockRejectedValue(new DOMException('The operation timed out.', 'TimeoutError')),
+    }));
+
+    const event = makeEvent('facebookexternalhit/1.1', 'o=abc123');
+    const result = await handler(event);
+    expect(result).toBe(event.Records[0].cf.request);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('fail-open when the Supabase fetch aborts on its deadline still rewrites profile paths', async () => {
+    mockSsmCredentials();
+    jest.spyOn(global, 'fetch')
+      .mockRejectedValue(new DOMException('The operation timed out.', 'TimeoutError'));
+
+    const event = makeEvent('facebookexternalhit/1.1', '', '/individuals/T065A');
+    const result = await handler(event);
+    expect(result).toBe(event.Records[0].cf.request);
+    expect(result.uri).toBe('/individual.html');
+  });
+
   it('calls SSM once and caches credentials for subsequent invocations', async () => {
     const mockFetch = jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,

--- a/infra/lib/edge-handler/index.test.ts
+++ b/infra/lib/edge-handler/index.test.ts
@@ -218,7 +218,8 @@ describe('Lambda@Edge OG meta handler', () => {
   });
 
   it('returns request (fail-open) when the SSM credential call times out', async () => {
-    const fetchSpy = jest.spyOn(global, 'fetch');
+    const fetchSpy = jest.spyOn(global, 'fetch')
+      .mockRejectedValue(new Error('unexpected network call'));
     const { SSMClient } = jest.requireMock('@aws-sdk/client-ssm') as { SSMClient: jest.Mock };
     SSMClient.mockImplementation(() => ({
       send: jest.fn().mockRejectedValue(new DOMException('The operation timed out.', 'TimeoutError')),

--- a/infra/lib/edge-handler/index.ts
+++ b/infra/lib/edge-handler/index.ts
@@ -23,6 +23,13 @@ function isBot(userAgent: string): boolean {
 // must pass through to origin as raw bytes, never be intercepted for OG-meta HTML.
 const STATIC_ASSET_RE = /\.(jpe?g|png|gif|svg|webp|ico|avif)$/i;
 
+// Network deadlines: the viewer-request Lambda is hard-killed at 5s, and a kill
+// bypasses the fail-open catch — CloudFront serves a 503 (salishsea-io-g9e).
+// Budgets must leave the worst-case cold chain (SSM + one data fetch) comfortably
+// under 5s so a slow dependency degrades to the shell instead.
+const SSM_TIMEOUT_MS = 1500;
+const FETCH_TIMEOUT_MS = 2000;
+
 // Module-scoped credential cache — survives warm Lambda invocations
 let supabaseUrl: string | undefined;
 let supabaseKey: string | undefined;
@@ -36,9 +43,10 @@ export function _clearCredentialCache(): void {
 async function getCredentials(): Promise<{ url: string; key: string }> {
   if (supabaseUrl && supabaseKey) return { url: supabaseUrl, key: supabaseKey };
   const ssm = new SSMClient({ region: 'us-east-1' });
+  const abortSignal = AbortSignal.timeout(SSM_TIMEOUT_MS);
   const [urlParam, keyParam] = await Promise.all([
-    ssm.send(new GetParameterCommand({ Name: '/salishsea/supabase-url' })),
-    ssm.send(new GetParameterCommand({ Name: '/salishsea/supabase-anon-key', WithDecryption: true })),
+    ssm.send(new GetParameterCommand({ Name: '/salishsea/supabase-url' }), { abortSignal }),
+    ssm.send(new GetParameterCommand({ Name: '/salishsea/supabase-anon-key', WithDecryption: true }), { abortSignal }),
   ]);
   supabaseUrl = urlParam.Parameter!.Value!;
   supabaseKey = keyParam.Parameter!.Value!;
@@ -168,6 +176,7 @@ async function individualPreview(designation: string): Promise<any> {
     + '&select=primary_designation,sex,born_earliest,born_latest,life_status,nicknames(name,status)&limit=1';
   const res = await fetch(apiUrl, {
     headers: { 'apikey': key, 'Authorization': `Bearer ${key}` },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
   if (!res.ok) return htmlResponse(genericPreviewTags());
   const individuals = await res.json() as Individual[];
@@ -202,6 +211,7 @@ async function matrilinePreview(designation: string): Promise<any> {
     + '&kind=eq.matriline&select=designation,nicknames(name,status)&limit=1';
   const res = await fetch(apiUrl, {
     headers: { 'apikey': key, 'Authorization': `Bearer ${key}` },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
   if (!res.ok) return htmlResponse(genericPreviewTags());
   const groups = await res.json() as SocialGroup[];
@@ -239,6 +249,7 @@ async function ecotypePreview(designation: string): Promise<any> {
     + '&kind=eq.ecotype&select=designation,nicknames(name,status)&limit=1';
   const res = await fetch(apiUrl, {
     headers: { 'apikey': key, 'Authorization': `Bearer ${key}` },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
   if (!res.ok) return htmlResponse(genericPreviewTags());
   const groups = await res.json() as SocialGroup[];
@@ -323,6 +334,7 @@ export const handler = async (event: any): Promise<any> => {
     const apiUrl = `${url}/rest/v1/occurrences?id=eq.${encodeURIComponent(occurrenceId)}&select=id,taxon,observed_at,count,photos&limit=1`;
     const res = await fetch(apiUrl, {
       headers: { 'apikey': key, 'Authorization': `Bearer ${key}` },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
     if (!res.ok) {
       return {


### PR DESCRIPTION
## Summary

The 2026-07-22 smoke run failed with a 503 on `GET /individuals/T065A` (bot UA). The CloudFront access log shows `LambdaExecutionError` with time-taken **5.019s**: the viewer-request OG handler hit its 5-second hard cap on a cold start, which bypasses the decision-015 fail-open catch entirely — CloudFront serves a 503 instead of the page shell. A successful cold invocation two minutes later took 3.0s, so the normal cold path (init + cross-region SSM ×2 + Supabase fetch) already runs ~3s and occasionally exceeds 5s.

## Change

- Every network call in `infra/lib/edge-handler/index.ts` now carries its own `AbortSignal` deadline: **1.5s** for the two SSM `GetParameter` calls (shared signal), **2s** for each Supabase REST fetch. Worst-case cold chain is now ~3.5s + init, comfortably under the 5s kill, and any slow dependency throws into the existing fail-open catch — bots get the SPA/page shell, never a 503.
- Tests: assert the signals are passed, and that SSM/Supabase `TimeoutError` aborts fail open (including the profile-path shell rewrite).
- Decision 015 updated with the timeout-budget rationale.

Investigation details in bd `salishsea-io-g9e`. Related follow-up: `salishsea-io-e4q` (edge function has written no CloudWatch logs since May 4, which is why this was diagnosed from CloudFront access logs).

## Testing

- `npm test` in `infra/`: 57 tests pass (5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added explicit request timeouts for profile preview and OG metadata lookups.
  * Improved fail-open behavior so slow/unavailable upstreams fall back to the standard page experience instead of returning an error.
  * Ensured profile path rewriting to the expected page shell continues even when metadata requests time out.

* **Tests**
  * Added coverage for timeout and fail-open scenarios for preview and metadata handling.

* **Documentation**
  * Clarified how the delivery fallback works when edge execution hits its time limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->