### PR TITLE
chore(infra): bump Lambda@Edge to nodejs24.x; upgrade aws-cdk CLI

### DIFF
--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -46,7 +46,7 @@ export class InfraStack extends cdk.Stack {
 
     // Lambda@Edge function — automatically provisioned in us-east-1 regardless of stack region
     const ogFunction = new cloudfront.experimental.EdgeFunction(this, 'OgMetaFunction', {
-      runtime: lambda.Runtime.NODEJS_22_X,
+      runtime: lambda.Runtime.NODEJS_24_X,
       handler: 'index.handler',
       // Ship only the runtime .js — a test-file edit must not republish the
       // edge function (each publish is a CloudFront distribution update).

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -16,8 +16,8 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
-        "@types/node": "22.7.9",
-        "aws-cdk": "^2.1118.2",
+        "@types/node": "^24.13.3",
+        "aws-cdk": "^2.1133.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
@@ -45,6 +45,7 @@
         "semver"
       ],
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "jsonschema": "^1.5.0",
         "semver": "^7.8.5"
@@ -103,6 +104,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1110,13 +1112,14 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.7.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.9.tgz",
-      "integrity": "sha512-jrTfRC7FM6nChvU7X2KqcrgquofrWLFDeYC1hKfwNWomVvrn7JIksqf344WN2X/y8xrgqBd2dJATZV4GbatBfg==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1243,9 +1246,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1118.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1118.2.tgz",
-      "integrity": "sha512-jHuShSx0JI14enDz2Hk2Qe0LYTDPzLyF2nBhWCvoXyRCpz31sI3XsCh4KO5ZXKfw9ET0bHvDTVnMZQPBpswg8A==",
+      "version": "2.1133.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1133.0.tgz",
+      "integrity": "sha512-DGlCBwqxSHTe1u/IoT5WV+Bbd2K3UhwFHsdMqb2nQa1fkJmaQgoNFu0It+p3HxyMWeW+gKsVzT5KcjQPQ6Kzuw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1802,6 +1805,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -2001,7 +2005,8 @@
       "version": "10.5.1",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.5.1.tgz",
       "integrity": "sha512-f/TfFXiS3G/yVIXDjOQn9oTlyu9Wo7Fxyjj7lb8r92iO81jR2uST+9MstxZTmDGx/CgIbxCXkFXgupnLTNxQZg==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2670,6 +2675,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -4158,6 +4164,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -4225,6 +4232,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4248,9 +4256,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/infra/package.json
+++ b/infra/package.json
@@ -12,8 +12,8 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/node": "22.7.9",
-    "aws-cdk": "^2.1118.2",
+    "@types/node": "^24.13.3",
+    "aws-cdk": "^2.1133.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
Bumps the OG-meta Lambda@Edge function from `nodejs22.x` to `nodejs24.x` (Lambda@Edge has supported Node 24 since Nov 2025), matching the `.nvmrc` pin. The handler is already `async`, so it satisfies Node 24 Lambda's drop of callback-style handlers with no code change. `@types/node` follows to 24.x.

**Also unbreaks deploys.** The Deploy run for #338 failed at `cdk deploy`:

> Cloud assembly schema version mismatch: Maximum schema version supported is 53.x.x, but found 54.0.0. You need at least CLI version 2.1132.1

That bump took `aws-cdk-lib` to 2.260.0 while the `aws-cdk` CLI stayed pinned at 2.1118.2. CLI bumped to 2.1133.0 here; `cdk synth` now succeeds and emits `"Runtime": "nodejs24.x"`.

Note that merging republishes the edge function, which is a CloudFront distribution update (~10 min propagation).

Verified: `npm run build`, `npm test` (59 passing), `npx cdk synth`.

Closes salishsea-io-2hh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the runtime environment for edge functions to Node.js 24.
  * Updated infrastructure tooling and Node.js type definitions to newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->