### PR TITLE
fix(infra): await the edge init warmup instead of racing it

### DIFF
--- a/infra/lib/edge-handler/index.test.ts
+++ b/infra/lib/edge-handler/index.test.ts
@@ -241,6 +241,95 @@ describe('Lambda@Edge OG meta handler', () => {
     }
   });
 
+  // salishsea-io-cwd: the first real fetch must reuse the warmup's connection
+  // rather than race it, but must never be held hostage by a stalled warmup.
+  describe('init warmup handoff', () => {
+    // Load a fresh copy of the module with the Lambda env guard satisfied, so
+    // the warmup runs and its promise is live for the handler to wait on.
+    function loadInLambda(warmupFetch: () => Promise<Response>) {
+      const fetchSpy = jest.spyOn(global, 'fetch').mockImplementationOnce(warmupFetch);
+      const prevEnv = process.env.AWS_LAMBDA_FUNCTION_NAME;
+      process.env.AWS_LAMBDA_FUNCTION_NAME = 'test-fn';
+      let mod: typeof import('./index');
+      try {
+        jest.isolateModules(() => {
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          mod = require('./index');
+        });
+      } finally {
+        if (prevEnv === undefined) delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+        else process.env.AWS_LAMBDA_FUNCTION_NAME = prevEnv;
+      }
+      return { mod: mod!, fetchSpy };
+    }
+
+    const occurrenceResponse = {
+      ok: true,
+      status: 200,
+      json: async () => [sampleOccurrence],
+    } as Response;
+
+    it('waits for an in-flight warmup before issuing the first Supabase fetch', async () => {
+      let releaseWarmup: () => void;
+      const warmupDone = new Promise<void>(resolve => { releaseWarmup = resolve; });
+      const { mod, fetchSpy } = loadInLambda(async () => {
+        await warmupDone;
+        return { ok: true, status: 200, arrayBuffer: async () => new ArrayBuffer(0) } as Response;
+      });
+
+      let realFetchIssued = false;
+      fetchSpy.mockImplementation(async () => { realFetchIssued = true; return occurrenceResponse; });
+
+      const pending = mod.handler(makeEvent('facebookexternalhit/1.1', 'o=abc123'));
+      await Promise.resolve();
+      expect(realFetchIssued).toBe(false); // still waiting on the warmup
+
+      releaseWarmup!();
+      await pending;
+      expect(realFetchIssued).toBe(true);
+    });
+
+    it('gives up on a stalled warmup and fetches anyway, on a reduced deadline', async () => {
+      jest.useFakeTimers();
+      try {
+        // A warmup that never settles — the handler must not hang on it.
+        const { mod, fetchSpy } = loadInLambda(() => new Promise<Response>(() => {}));
+        fetchSpy.mockResolvedValue(occurrenceResponse);
+
+        const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        const pending = mod.handler(makeEvent('facebookexternalhit/1.1', 'o=abc123'));
+        await jest.advanceTimersByTimeAsync(1000); // WARMUP_WAIT_MS
+        const result = await pending;
+
+        expect(result.status).toBe('200');
+        // Warmup call is mockImplementationOnce; the real read is the next one.
+        const options = fetchSpy.mock.calls[1]?.[1] as RequestInit;
+        expect(options.signal).toBeInstanceOf(AbortSignal);
+        // Waited the full cap and no longer — and that time came out of the
+        // fetch's own deadline rather than extending the total budget.
+        const line = logSpy.mock.calls.map(c => String(c[0])).find(m => m.includes('"og-fetch"'));
+        expect(JSON.parse(line!)).toMatchObject({ msg: 'og-fetch', warmupMs: 1000 });
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('does not wait again once a fetch has already waited out the warmup', async () => {
+      const { mod, fetchSpy } = loadInLambda(
+        async () => ({ ok: true, status: 200, arrayBuffer: async () => new ArrayBuffer(0) } as Response),
+      );
+      fetchSpy.mockResolvedValue(occurrenceResponse);
+
+      await mod.handler(makeEvent('facebookexternalhit/1.1', 'o=abc123'));
+
+      const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      await mod.handler(makeEvent('facebookexternalhit/1.1', 'o=abc123'));
+
+      const line = logSpy.mock.calls.map(c => String(c[0])).find(m => m.includes('"og-fetch"'));
+      expect(JSON.parse(line!)).toMatchObject({ msg: 'og-fetch', warmupMs: 0 });
+    });
+  });
+
   it('does not touch the network at import time outside Lambda (no env guard)', () => {
     const fetchSpy = jest.spyOn(global, 'fetch')
       .mockRejectedValue(new Error('unexpected network call'));

--- a/infra/lib/edge-handler/index.ts
+++ b/infra/lib/edge-handler/index.ts
@@ -37,18 +37,37 @@ const STATIC_ASSET_RE = /\.(jpe?g|png|gif|svg|webp|ico|avif)$/i;
 // fetch, so 3s leaves ample room to degrade to the shell instead.
 const FETCH_TIMEOUT_MS = 3000;
 
+// How long the first real fetch will wait for the init warmup before giving up
+// and opening its own connection. Spent FROM the deadline above, never added to
+// it (see timedFetch) — the total network budget stays 3s.
+const WARMUP_WAIT_MS = 1000;
+
+// Floor on what's left for the fetch after waiting. A near-zero deadline would
+// abort instantly and fail open, which is worse than slightly overrunning the
+// budget; 1s + the 1s cap above still lands well inside the 5s kill.
+const MIN_FETCH_BUDGET_MS = 1000;
+
+// The in-flight init warmup, or null once someone has waited on it.
+let pendingWarmup: Promise<void> | null = null;
+
 // Warm the fetch stack during init. The init phase runs at full CPU while the
 // handler runs at the ~1/13 vCPU a 128MB viewer-request Lambda is capped at, so
 // without this the first fetch per container pays ~2.5s (measured, og-fetch)
 // for lazy undici load + DNS + TLS; later fetches run ~150-275ms. Calling
 // fetch() here does the expensive stack load synchronously at full speed, and
 // the handshake to the same origin proceeds so the handler's real fetch can
-// reuse it. Fire-and-forget: never awaited, and a failure is irrelevant — the
-// real fetch has its own deadline and fail-open. The env-var guard keeps
-// imports outside Lambda (unit tests) from touching the network.
+// reuse it. The env-var guard keeps imports outside Lambda (unit tests) from
+// touching the network.
+//
+// The promise is kept (not fire-and-forget) so the first real fetch can wait
+// for it: an invocation arriving while the warmup is still in flight used to
+// open a SECOND connection, and two TLS handshakes competing for 1/13 vCPU is
+// how a cold container blew the 3s deadline and served the bare shell
+// (salishsea-io-cwd). Ending in .catch means awaiting it can only delay the
+// handler, never throw into it.
 if (SUPABASE_URL && process.env.AWS_LAMBDA_FUNCTION_NAME) {
   const warmupStarted = Date.now();
-  fetch(`${SUPABASE_URL}/auth/v1/health`, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
+  pendingWarmup = fetch(`${SUPABASE_URL}/auth/v1/health`, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
     .then(async res => {
       // Drain: undici returns the socket to its per-origin pool only once the
       // body is consumed — and reuse is half the point of warming.
@@ -56,6 +75,22 @@ if (SUPABASE_URL && process.env.AWS_LAMBDA_FUNCTION_NAME) {
       console.log(JSON.stringify({ msg: 'og-warmup', ms: Date.now() - warmupStarted, status: res.status }));
     })
     .catch(err => console.log(JSON.stringify({ msg: 'og-warmup', ms: Date.now() - warmupStarted, error: String(err) })));
+}
+
+// Wait out the init warmup, but never longer than `budgetMs`. A warmup slower
+// than that is abandoned rather than awaited — it keeps running, and whatever
+// connection it opens is still there for the next invocation. Only the first
+// caller ever waits; after that the container has a live socket either way.
+async function awaitWarmup(budgetMs: number): Promise<void> {
+  const warmup = pendingWarmup;
+  if (!warmup) return;
+  pendingWarmup = null;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  await Promise.race([
+    warmup,
+    new Promise<void>(resolve => { timer = setTimeout(resolve, budgetMs); }),
+  ]);
+  clearTimeout(timer);
 }
 
 function getCredentials(): { url: string; key: string } {
@@ -71,16 +106,24 @@ function getCredentials(): { url: string; key: string } {
 // `kind` names the lookup (individual/matriline/ecotype/occurrence) so a slow or
 // failing step is attributable straight from the log.
 async function timedFetch(kind: string, apiUrl: string, key: string): Promise<Response> {
+  const waitStarted = Date.now();
+  await awaitWarmup(WARMUP_WAIT_MS);
+  const warmupMs = Date.now() - waitStarted;
+
+  // Whatever the wait consumed comes off this fetch's own deadline, so a cold
+  // invocation still degrades to the shell inside the total 3s (salishsea-io-g9e).
+  const budgetMs = Math.max(FETCH_TIMEOUT_MS - warmupMs, MIN_FETCH_BUDGET_MS);
+
   const started = Date.now();
   try {
     const res = await fetch(apiUrl, {
       headers: { 'apikey': key, 'Authorization': `Bearer ${key}` },
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      signal: AbortSignal.timeout(budgetMs),
     });
-    console.log(JSON.stringify({ msg: 'og-fetch', kind, ms: Date.now() - started, status: res.status }));
+    console.log(JSON.stringify({ msg: 'og-fetch', kind, ms: Date.now() - started, warmupMs, status: res.status }));
     return res;
   } catch (err) {
-    console.error(JSON.stringify({ msg: 'og-fetch-error', kind, ms: Date.now() - started, error: String(err) }));
+    console.error(JSON.stringify({ msg: 'og-fetch-error', kind, ms: Date.now() - started, warmupMs, error: String(err) }));
     throw err;
   }
 }


### PR DESCRIPTION
Fixes the cold-start failure that turned [smoke run 30227586725](https://github.com/salish-sea/salishsea-io/actions/runs/30227586725) red: a bot UA on `/individuals/T065A` got the static shell instead of profile OG meta.

## What was happening

The init warmup added in #334 is fire-and-forget. When the first invocation lands while that warmup is still in flight, the handler can't reuse its socket — it opens a **second** connection, and two TLS handshakes then compete for the ~1/13 vCPU a 128MB viewer-request Lambda is capped at. In that window the warmup makes the first fetch slower rather than faster. From the failing container in us-east-2:

```
00:31:07.093  handler starts its individual fetch
00:31:07.579  {"msg":"og-warmup","ms":602,"status":401}   <- warmup finishes AFTER the fetch began
00:31:10.096  {"msg":"og-fetch-error","kind":"individual","ms":3003,"TimeoutError"}
00:31:10.096  {"msg":"og-fail-open","uri":"/individuals/T065A"}
```

Later fetches on that same container: matriline 988ms, ecotype 1685ms. So the connection was fine once established — only the racing first fetch lost.

This is pre-existing behavior, not a regression from the nodejs24 bump in #341: the same runtime served 486ms (us-west-1) and 1248ms (us-west-2) individual fetches in the same window, and the smoke run two minutes earlier passed. Republishing the edge function does flush every replica worldwide, which is why the odds of hitting it spiked right after that deploy.

## The fix

Keep the warmup promise and have the first real fetch `await` it, so it reuses the warmed socket. Two bounds keep this from trading one failure mode for a worse one:

- **The wait is capped at 1s.** A stalled warmup is abandoned, not awaited.
- **The wait is spent _from_ the 3s network budget, not added to it.** Whatever the wait consumed comes off the fetch's own deadline, so the worst case can't drift toward the 5s hard kill that yields a 503 (`salishsea-io-g9e`). A floor keeps the fetch from inheriting a near-zero deadline.

Only the first caller ever waits; after that the container has a live socket either way. `og-fetch` / `og-fetch-error` lines gained a `warmupMs` field so the handoff is visible in the logs.

## Tests

Three new tests under `init warmup handoff`. I verified they discriminate by disabling the `awaitWarmup` call and re-running — the first two fail without the fix:

```
✕ waits for an in-flight warmup before issuing the first Supabase fetch
✕ gives up on a stalled warmup and fetches anyway, on a reduced deadline
✓ does not wait again once a fetch has already waited out the warmup
```

Full suite: 62 passing. `npm run build` and `npx cdk synth` clean.

Closes salishsea-io-cwd

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the first request’s handling during service startup by waiting briefly for initialization to complete.
  * Added a maximum wait limit so requests continue even if startup does not finish.
  * Preserved request timeout protection by accounting for initialization time.
  * Enhanced request logs with initialization wait timing for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->