### PR TITLE
ci: refuse to deploy a commit that main has moved past

### DIFF
--- a/.github/actions/require-current-tip/action.yml
+++ b/.github/actions/require-current-tip/action.yml
@@ -27,7 +27,9 @@ runs:
             echo "Checked ${PHASE}. This run holds \`${GITHUB_SHA}\`, but \`${GITHUB_REF_NAME}\`"
             echo "is now \`${head_sha}\`. Deploying would move production backwards."
             echo ""
-            echo "Re-run the Deploy for \`${head_sha}\`, or push, to actually deploy."
+            echo "**Re-running _this_ run will not help** — it would hold \`${GITHUB_SHA}\` again"
+            echo "and stop here again. To deploy the current tip, re-run the Deploy whose"
+            echo "commit is \`${head_sha}\`, or push a new commit to trigger a fresh run."
           } >> "${GITHUB_STEP_SUMMARY}"
           exit 1
         fi

--- a/.github/actions/require-current-tip/action.yml
+++ b/.github/actions/require-current-tip/action.yml
@@ -1,0 +1,34 @@
+name: Require current tip
+description: >
+  Fail unless the commit this run is holding is still the tip of its branch.
+  Guards production against deploying a superseded tree — see gotcha 3 in
+  docs/runbook/deploys.md and bd salishsea-io-i74.
+inputs:
+  token:
+    description: Token used to read the branch head (github.token is enough).
+    required: true
+  phase:
+    description: Where in the deploy this check runs; shown in the failure message.
+    required: true
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        PHASE: ${{ inputs.phase }}
+      run: |
+        head_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_REF_NAME}" --jq .sha)
+        if [ "${head_sha}" != "${GITHUB_SHA}" ]; then
+          echo "::error::Refusing to deploy ${GITHUB_SHA} (${PHASE}): ${GITHUB_REF_NAME} is now ${head_sha}."
+          {
+            echo "### Deploy stopped — superseded commit"
+            echo ""
+            echo "Checked ${PHASE}. This run holds \`${GITHUB_SHA}\`, but \`${GITHUB_REF_NAME}\`"
+            echo "is now \`${head_sha}\`. Deploying would move production backwards."
+            echo ""
+            echo "Re-run the Deploy for \`${head_sha}\`, or push, to actually deploy."
+          } >> "${GITHUB_STEP_SUMMARY}"
+          exit 1
+        fi
+        echo "${GITHUB_SHA} is the tip of ${GITHUB_REF_NAME} (${PHASE})."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,35 @@ jobs:
       id-token: write
       contents: read
     steps:
+      # A workflow re-run always checks out its ORIGINAL commit. Re-running an
+      # older, failed deploy therefore rebuilds and ships a superseded tree —
+      # a silent production rollback. That happened on 2026-07-27: a transient
+      # credentials failure was re-run after a newer commit had already
+      # deployed, and it reverted the newer one (bd salishsea-io-i74).
+      #
+      # Deploys are also serialized (see the concurrency block), so a queued run
+      # can be overtaken by a later merge before it ever starts.
+      #
+      # Either way the commit in hand is no longer what main says to ship, so
+      # refuse rather than deploy backwards. Loud on purpose: this should be rare,
+      # and a green "nothing happened" is how the rollback went unnoticed the
+      # first time. If a newer deploy is green, this failure is safe to ignore.
+      - name: Refuse to deploy a superseded commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          head_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_REF_NAME}" --jq .sha)
+          if [ "${head_sha}" != "${GITHUB_SHA}" ]; then
+            echo "::error::Refusing to deploy ${GITHUB_SHA}: ${GITHUB_REF_NAME} is now ${head_sha}."
+            {
+              echo "### Deploy skipped — superseded commit"
+              echo ""
+              echo "This run holds \`${GITHUB_SHA}\`, but \`${GITHUB_REF_NAME}\` is now \`${head_sha}\`."
+              echo "Deploying would roll production back. Re-run the Deploy for \`${head_sha}\` instead."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 1
+          fi
+          echo "Deploying ${GITHUB_SHA} (tip of ${GITHUB_REF_NAME})."
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,26 +73,20 @@ jobs:
       # refuse rather than deploy backwards. Loud on purpose: this should be rare,
       # and a green "nothing happened" is how the rollback went unnoticed the
       # first time. If a newer deploy is green, this failure is safe to ignore.
-      - name: Refuse to deploy a superseded commit
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          head_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_REF_NAME}" --jq .sha)
-          if [ "${head_sha}" != "${GITHUB_SHA}" ]; then
-            echo "::error::Refusing to deploy ${GITHUB_SHA}: ${GITHUB_REF_NAME} is now ${head_sha}."
-            {
-              echo "### Deploy skipped — superseded commit"
-              echo ""
-              echo "This run holds \`${GITHUB_SHA}\`, but \`${GITHUB_REF_NAME}\` is now \`${head_sha}\`."
-              echo "Deploying would roll production back. Re-run the Deploy for \`${head_sha}\` instead."
-            } >> "${GITHUB_STEP_SUMMARY}"
-            exit 1
-          fi
-          echo "Deploying ${GITHUB_SHA} (tip of ${GITHUB_REF_NAME})."
+      #
+      # Checked twice: once here (cheap, catches the stale re-run immediately) and
+      # again immediately before the first remote mutation, so a merge landing
+      # mid-run has seconds rather than minutes to slip past. Neither is a lock —
+      # see the runbook for what this does and doesn't cover.
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
           persist-credentials: false
+      - name: Refuse to deploy a superseded commit
+        uses: ./.github/actions/require-current-tip
+        with:
+          token: ${{ github.token }}
+          phase: before setup
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       - name: Configure AWS Credentials
@@ -107,6 +101,13 @@ jobs:
       - run: supabase link --project-ref "${PROJECT_REF}"
         env:
           PROJECT_REF: ${{ vars.SUPABASE_PROJECT_ID }}
+      # Last check before anything leaves this runner: everything above is local
+      # setup, everything below mutates production.
+      - name: Re-check the tip before mutating anything
+        uses: ./.github/actions/require-current-tip
+        with:
+          token: ${{ github.token }}
+          phase: before the first remote change
       # Deploy the ingest Edge Function BEFORE `db push`. The cutover migration
       # (20260706000000) repoints pg_cron at this function via pg_net; deploying
       # first means a bundling/deploy failure aborts the run before the cron

--- a/docs/runbook/deploys.md
+++ b/docs/runbook/deploys.md
@@ -50,6 +50,16 @@ The churn is inherent to `cloudfront.experimental.EdgeFunction` (a new version p
 }
 ```
 
+## Gotcha 3 — re-running an old deploy rolls production back
+
+**Symptom.** A Deploy run fails on something transient (`Configure AWS Credentials` is the one we've seen). You hit *Re-run jobs*. Production silently reverts to whatever the tree looked like at that run's commit.
+
+**Why.** A re-run checks out its **original** `head_sha`, not the current tip. Deploys are also serialized (`concurrency: deploy-production`, `cancel-in-progress: false`), so the re-run waits its turn and can land *after* a newer commit has already deployed — overwriting it. This happened on 2026-07-27: a re-run of `007b738` finished ten minutes after `7a66891` and reverted it (bd `salishsea-io-i74`).
+
+**What now happens.** The Deploy job's first step compares `github.sha` against the current tip of `main` and fails with `Refusing to deploy <sha>: main is now <sha>` if they differ. A superseded run can't reach S3 or CDK.
+
+**Is it fatal?** No — it means *this* run shipped nothing. If a newer Deploy is green, production is already correct and the red run is safe to ignore. To actually re-deploy, re-run the Deploy for the current tip of `main` (or push).
+
 ## Caching notes
 
 - **Viewer-request Lambda responses are never cached by CloudFront** — each request re-runs the current function version, so once the distribution shows `Deployed`, the new behaviour is live everywhere. (Contrast: static assets passed through to S3 *are* cached per-POP; `aws cloudfront create-invalidation --paths '/some-asset.jpg'` clears them.)

--- a/docs/runbook/deploys.md
+++ b/docs/runbook/deploys.md
@@ -1,6 +1,6 @@
 # Runbook: Deploys & CloudFront/Lambda@Edge gotchas
 
-How production deploys work, and the two recurring surprises they produce. Audience: anyone (human or agent) running or debugging a deploy.
+How production deploys work, and the recurring surprises they produce. Audience: anyone (human or agent) running or debugging a deploy.
 
 ## How it deploys
 

--- a/docs/runbook/deploys.md
+++ b/docs/runbook/deploys.md
@@ -56,9 +56,16 @@ The churn is inherent to `cloudfront.experimental.EdgeFunction` (a new version p
 
 **Why.** A re-run checks out its **original** `head_sha`, not the current tip. Deploys are also serialized (`concurrency: deploy-production`, `cancel-in-progress: false`), so the re-run waits its turn and can land *after* a newer commit has already deployed — overwriting it. This happened on 2026-07-27: a re-run of `007b738` finished ten minutes after `7a66891` and reverted it (bd `salishsea-io-i74`).
 
-**What now happens.** The Deploy job's first step compares `github.sha` against the current tip of `main` and fails with `Refusing to deploy <sha>: main is now <sha>` if they differ. A superseded run can't reach S3 or CDK.
+**What now happens.** The Deploy job compares `github.sha` against the current tip of `main` and fails with `Refusing to deploy <sha> …: main is now <sha>` if they differ ([`require-current-tip`](../../.github/actions/require-current-tip/action.yml)). It runs twice: after checkout, and again immediately before the first remote change.
 
 **Is it fatal?** No — it means *this* run shipped nothing. If a newer Deploy is green, production is already correct and the red run is safe to ignore. To actually re-deploy, re-run the Deploy for the current tip of `main` (or push).
+
+**What it does not cover.** It is a check, not a lease, and it has two known holes:
+
+- **`main` can advance during the deploy itself.** The second check narrows this to the window between it and `cdk deploy`, but a merge landing inside that window still ships stale content. The serialized queue means the newer run deploys right after and corrects it — *provided that run succeeds*. Watch it if you merge twice in quick succession.
+- **Runs created before this guard existed are not protected.** A re-run replays the workflow file *as of its own commit*, so re-running any Deploy from before this merged skips the check entirely. Don't re-run old deploys; push instead. (Deliberately not fixed by deleting run history — that history is the audit trail.)
+
+The post-deploy smoke test remains the backstop for both: it runs `main`'s specs against production and fails when what's live doesn't match.
 
 ## Caching notes
 

--- a/docs/runbook/deploys.md
+++ b/docs/runbook/deploys.md
@@ -58,7 +58,9 @@ The churn is inherent to `cloudfront.experimental.EdgeFunction` (a new version p
 
 **What now happens.** The Deploy job compares `github.sha` against the current tip of `main` and fails with `Refusing to deploy <sha> …: main is now <sha>` if they differ ([`require-current-tip`](../../.github/actions/require-current-tip/action.yml)). It runs twice: after checkout, and again immediately before the first remote change.
 
-**Is it fatal?** No — it means *this* run shipped nothing. If a newer Deploy is green, production is already correct and the red run is safe to ignore. To actually re-deploy, re-run the Deploy for the current tip of `main` (or push).
+**Is it fatal?** No — it means *this* run shipped nothing. If a newer Deploy is green, production is already correct and the red run is safe to ignore.
+
+**If production really is behind**, re-running the run that just failed the check won't help: it holds the same commit and will stop at the same place. Either re-run the Deploy **whose commit is the current tip of `main`** (this is the recovery that worked on 2026-07-27, when the tip's own deploy had been overwritten), or push a commit to trigger a fresh run.
 
 **What it does not cover.** It is a check, not a lease, and it has two known holes:
 


### PR DESCRIPTION
Follow-up to the production rollback during #343's deploy. bd `salishsea-io-i74`.

## The failure

A workflow re-run always checks out its **original** `head_sha`. Deploys are serialized (`concurrency: deploy-production`, `cancel-in-progress: false`) rather than cancelled, so a re-run of an older failed deploy waits its turn and can land *after* a newer commit has already shipped.

That is exactly what happened on 2026-07-27:

| time | run | commit | result |
|---|---|---|---|
| 03:10 | Deploy #343 | `7a66891` | success — OG change live |
| 03:20 | Deploy re-run (attempt 2) | `007b738` | success — **reverted it** |

`007b738` is the parent of `7a66891`, so the re-run rebuilt the older tree and synced it over both S3 and the edge Lambda. The post-deploy smoke test caught it (run `30234388206`, failing on the new `not.toContain('og:image')` assertion). Nothing else would have.

## The guard

First step of the `deploy` job: resolve the current tip of `main` via the API, compare to `github.sha`, fail if they differ. It runs before checkout, credentials, `db push`, S3 sync and CDK — a superseded run can't reach any of them.

**Why fail rather than skip.** A green run that shipped nothing is precisely how the rollback went unnoticed. This should be rare (it needs two merges inside one deploy window, or a stale re-run), so loud is right. The error and job summary both say what to do; if a newer deploy is green, the red run is safe to ignore.

## Testing

Simulated both branches locally against the real incident SHAs with the actual `gh api` call:

- `GITHUB_SHA=007b738…` → `::error::Refusing to deploy 007b738…: main is now 7a66891…`, exit 1
- `GITHUB_SHA=7a66891…` → `Deploying 7a66891… (tip of main)`, exit 0

Workflow YAML parses clean. The real test is the next merge — this PR's own deploy exercises the passing branch.

Gotcha 3 in [the deploy runbook](docs/runbook/deploys.md) documents the symptom and what to do about a red "superseded" run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented rerun/queued deployment runs from deploying a superseded commit and overwriting newer production changes.
  * Added a two-phase “current tip” safeguard that re-validates the branch head immediately before production changes and aborts if the workflow commit is no longer current.

* **Documentation**
  * Updated the deploy runbook with a new “re-running an old deploy rolls production back” gotcha, including what to do to recover and clarifying why the safeguard is checked twice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->