### PR TITLE
fix(og): use the full-size iNat photo in cards, not the 75×75 thumbnail

### DIFF
--- a/docs/decisions/019-no-fallback-preview-image.md
+++ b/docs/decisions/019-no-fallback-preview-image.md
@@ -25,6 +25,13 @@ deleted** — the deploy's `s3 sync` runs without `--delete` — so
 `https://salishsea.io/preview.jpg` stays reachable and previously-scraped cards
 don't start 404ing on their image. Nothing references it.
 
+**Amendment (2026-07-27).** An image only counts if the platforms will actually
+render it — Facebook drops `og:image` below 200×200. iNaturalist photos are
+ingested as the 75×75 `square` thumbnail, so the card references the `large`
+(1024px) variant of the same photo instead; see `cardImageUrl` in the edge
+handler (bd `salishsea-io-uum`). Declaring a thumbnail is functionally the same
+as declaring nothing, and this decision is about not pretending otherwise.
+
 ### Why no image beats a generic one
 
 A link preview is read as a picture *of the post*. A months-old map screenshot

--- a/infra/lib/edge-handler/index.test.ts
+++ b/infra/lib/edge-handler/index.test.ts
@@ -511,6 +511,12 @@ describe('og:image uses a card-sized photo, not the 75×75 iNat thumbnail', () =
     // A `square` segment on a non-iNat host is left alone — we can't assume
     // some other provider serves a `large` sibling.
     'https://example.com/photos/7/square.jpg',
+    // Lookalike authorities must not satisfy the host check: `src` is ingested
+    // data, so a substring match on "inaturalist" would be enough to redirect
+    // a card's image at an attacker-chosen origin.
+    'https://evil-inaturalist.example/photos/7/square.jpg',
+    'https://static.inaturalist.org.evil.example/photos/7/square.jpg',
+    'https://inaturalist-open-data.s3.amazonaws.com.evil.example/photos/7/square.jpg',
     // Already large: not double-rewritten.
     'https://inaturalist-open-data.s3.amazonaws.com/photos/705787369/large.jpg',
   ])('passes through %s unchanged', async (src) => {

--- a/infra/lib/edge-handler/index.test.ts
+++ b/infra/lib/edge-handler/index.test.ts
@@ -468,6 +468,56 @@ describe('SEO carve-out: /sitemap.xml and /robots.txt path-gate', () => {
   });
 });
 
+// A 75×75 thumbnail is below Facebook's 200×200 og:image floor, so declaring one
+// is as good as declaring nothing. iNat serves `large` (1024px) off the same path.
+describe('og:image uses a card-sized photo, not the 75×75 iNat thumbnail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(global, 'fetch').mockReset();
+  });
+
+  const withPhoto = (src: string) => ({ ...sampleOccurrence, photos: [{ src, license: 'cc0' }] });
+
+  const cardFor = async (src: string) => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => [withPhoto(src)],
+    } as Response);
+    const result = await handler(makeEvent('facebookexternalhit/1.1', 'o=abc123')) as { body: string };
+    return result.body.match(/<meta property="og:image" content="([^"]*)">/)?.[1];
+  };
+
+  it('rewrites the iNaturalist square variant to large', async () => {
+    expect(await cardFor('https://inaturalist-open-data.s3.amazonaws.com/photos/705787369/square.jpg'))
+      .toBe('https://inaturalist-open-data.s3.amazonaws.com/photos/705787369/large.jpg');
+  });
+
+  it('preserves the original extension', async () => {
+    expect(await cardFor('https://inaturalist-open-data.s3.amazonaws.com/photos/1/square.jpeg'))
+      .toBe('https://inaturalist-open-data.s3.amazonaws.com/photos/1/large.jpeg');
+  });
+
+  it('rewrites photos served from static.inaturalist.org too', async () => {
+    expect(await cardFor('https://static.inaturalist.org/photos/42/square.png'))
+      .toBe('https://static.inaturalist.org/photos/42/large.png');
+  });
+
+  it.each([
+    // HappyWhale and Spotter URLs carry no size variant — nothing to rewrite.
+    'https://au-hw-media-m.happywhale.com/49f1c4f4-1f5b-4c6f-9c7a-000000000000.jpg',
+    'https://spotter-production.s3.amazonaws.com/images/photo.jpg',
+    // Our own uploads are already full-size.
+    'https://salishsea-io.s3.us-west-2.amazonaws.com/Js-susan.jpg',
+    // A `square` segment on a non-iNat host is left alone — we can't assume
+    // some other provider serves a `large` sibling.
+    'https://example.com/photos/7/square.jpg',
+    // Already large: not double-rewritten.
+    'https://inaturalist-open-data.s3.amazonaws.com/photos/705787369/large.jpg',
+  ])('passes through %s unchanged', async (src) => {
+    expect(await cardFor(src)).toBe(src);
+  });
+});
+
 describe('Image-asset carve-out: og:image must serve bytes, not OG HTML', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/infra/lib/edge-handler/index.ts
+++ b/infra/lib/edge-handler/index.ts
@@ -245,10 +245,13 @@ const OPEN_LICENSES = ['cc0', 'cc-by'];
 // rendering without one (salishsea-io-uum). The same path serves `large`
 // (1024px, ~150-800KB), so swap that single segment when building the card.
 //
-// Keyed on the variant segment, not a host allowlist: every iNat photo we hold
-// is `square` and no other provider uses these variant names, so this is a no-op
-// for HappyWhale, Spotter and our own uploads (which are already full-size).
-const INAT_SQUARE_RE = /^(https:\/\/[^/]*inaturalist[^/]*\/photos\/\d+\/)square(\.[a-z]+)$/i;
+// The hosts are matched exactly, not by substring: `src` is ingested data, and a
+// lookalike authority (evil-inaturalist.example, or …amazonaws.com.evil.example)
+// must not talk us into rewriting a URL whose `large` sibling we know nothing
+// about. Everything else — HappyWhale, Spotter, our own uploads — has no variant
+// segment to match and passes through untouched.
+const INAT_SQUARE_RE =
+  /^(https:\/\/(?:inaturalist-open-data\.s3\.amazonaws\.com|static\.inaturalist\.org)\/photos\/\d+\/)square(\.[a-z]+)$/i;
 
 /** Full-size variant of a photo URL, for use as og:image. */
 function cardImageUrl(src: string): string {

--- a/infra/lib/edge-handler/index.ts
+++ b/infra/lib/edge-handler/index.ts
@@ -237,6 +237,23 @@ function individualPreviewTags(individual: Individual): OgTags {
 
 // Only cc0 and cc-by are unambiguously open for re-use
 const OPEN_LICENSES = ['cc0', 'cc-by'];
+
+// iNaturalist photos are ingested as the 75×75 `square` thumbnail — the right
+// size for the map UI, and far below what the social platforms accept: Facebook
+// drops og:image under 200×200 and Twitter's summary_large_image wants at least
+// 300×157. So the one card type that DOES carry an image was very likely still
+// rendering without one (salishsea-io-uum). The same path serves `large`
+// (1024px, ~150-800KB), so swap that single segment when building the card.
+//
+// Keyed on the variant segment, not a host allowlist: every iNat photo we hold
+// is `square` and no other provider uses these variant names, so this is a no-op
+// for HappyWhale, Spotter and our own uploads (which are already full-size).
+const INAT_SQUARE_RE = /^(https:\/\/[^/]*inaturalist[^/]*\/photos\/\d+\/)square(\.[a-z]+)$/i;
+
+/** Full-size variant of a photo URL, for use as og:image. */
+function cardImageUrl(src: string): string {
+  return src.replace(INAT_SQUARE_RE, '$1large$2');
+}
 // Public Facebook App ID — links shared content to our FB app for Domain Insights.
 // Not a secret; it appears in page meta by design.
 const FB_APP_ID = '678644427974059';
@@ -457,7 +474,7 @@ export const handler = async (event: any): Promise<any> => {
       'og:url': `https://salishsea.io/?o=${encodeURIComponent(occurrenceId)}`,
       'og:title': title,
       'og:description': description,
-      ...(photo ? { 'og:image': photo.src } : {}),
+      ...(photo ? { 'og:image': cardImageUrl(photo.src) } : {}),
       'twitter:card': photo ? 'summary_large_image' : 'summary',
       'fb:app_id': FB_APP_ID,
     };


### PR DESCRIPTION
Follow-up to #343. bd `salishsea-io-uum`.

## The problem

After #343, an occurrence card declares `og:image` only when the photo is `cc0`/`cc-by`. But that photo is the iNaturalist **`square` variant — 75×75**, verified on prod:

```
$ curl -sS .../photos/686550971/square.jpg | file -
JPEG image data, ... 75x75
```

Facebook drops `og:image` below **200×200**; Twitter's `summary_large_image` wants ≥300×157. So the one card type that *does* promise an image was very likely still rendering without one — the exact complaint #343 set out to fix, one layer down.

## The fix

Rewrite the variant segment when building the card: `square` → `large` (1024px). Confirmed `200 OK` at 150–780 KB for six real photos, comfortably inside both platforms' size limits.

The rewrite keys on the **variant segment**, not a host allowlist. Survey of prod:

| host | photos | `square` |
|---|---|---|
| `inaturalist-open-data.s3.amazonaws.com` | 39,308 | 39,308 |
| `au-hw-media-m.happywhale.com` | 16,687 | 0 |
| `spotter-production.s3.amazonaws.com` | 1,175 | 0 |
| our own uploads (Supabase + S3) | 105 | 0 |

Every iNat photo is `square` and nothing else uses these names, so this is a no-op for every other provider — and their photos are already full-size.

## Testing

8 new unit tests (70 total in `infra`): both iNat hosts, extension preserved, and pass-through for HappyWhale, Spotter, our uploads, a `square` on a non-iNat host (we can't assume a `large` sibling exists), and an already-`large` URL (no double-rewrite).

Not added to the prod smoke suite — that would pin it to one occurrence id. I'll verify against a real shared link after this deploys.

Decision 019 amended: an image only counts if the platforms will actually render it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved social media previews by selecting larger iNaturalist images when available.
  * Added iNaturalist-aware `og:image` URL mapping for better preview rendering across supported domains.
* **Bug Fixes**
  * Prevents low-resolution “square” thumbnails from being used as preview images.
  * Preserves original image file extensions when switching to the larger variant.
* **Tests**
  * Added coverage to verify iNaturalist URL rewriting behavior and unchanged handling for non-iNaturalist “square” and already-large URLs.
* **Documentation**
  * Updated the decision notes clarifying when fallback images do (or do not) “count” for social previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->