### PR TITLE
fix(cards): cache by how recent the subject is, not by card type

### DIFF
--- a/docs/decisions/020-map-preview-cards.md
+++ b/docs/decisions/020-map-preview-cards.md
@@ -103,24 +103,30 @@ better than a broken image.
 
 ## Consequences
 
-- **Cache lifetime follows how recent the card's subject is, not the card type**
-  (`card-renderer/cache-control.ts`). A sighting's *record* keeps changing for a
-  few days after the sighting: reports arrive late, ingest runs on a schedule,
-  counts are revised, species re-identified, photos appear. So a subject within
-  **four days** gets `max-age=300, must-revalidate`, and anything older gets 30
+- **Cache lifetime.** *As originally accepted:* occurrence cards were
+  `immutable` with a one-year `max-age` — a past sighting never moves — and a
+  day card was volatile (15 minutes) only on the day itself, `immutable`
+  thereafter. CloudFront allowed up to a year.
+
+  **Amendment (2026-07-27, superseding the paragraph above).** That had the
+  priority backwards, and is replaced by: **lifetime follows how recent the
+  card's *subject* is, not the card type** (`card-renderer/cache-control.ts`).
+
+  A sighting's *record* keeps changing for a few days after the sighting itself
+  — reports arrive late, ingest runs on a schedule, counts are revised, a
+  species is re-identified, photos appear. Under the original rule the card most
+  likely to be wrong soon was the one cached hardest, and a day went immutable
+  at midnight while its sightings were still arriving. So a subject within
+  **four days** now gets `max-age=300, must-revalidate`; anything older gets 30
   days. Four days covers ingest lag plus the tail of late community reports.
 
-  The first cut had this backwards — occurrence cards were unconditionally
-  `immutable` for a year, so the card most likely to be wrong soon was the one
-  cached hardest, and a day went immutable at midnight while its sightings were
-  still arriving.
-
-  Nothing is `immutable` any more. Curation can revise an old record
-  (decision 014), and `immutable` tells caches never to revalidate even on a
-  manual reload, which makes every correction depend on someone remembering to
-  run a CloudFront invalidation. A month of caching is nearly all the benefit
-  with an automatic way out. CloudFront's `maxTtl` caps the origin at 30 days
-  regardless, so no future change can re-create a year-long cache of a bad card.
+  **Nothing is `immutable`.** Curation can revise an old record (decision 014),
+  and `immutable` tells caches never to revalidate even on a manual reload,
+  which makes every correction depend on someone remembering to run a CloudFront
+  invalidation. A month of caching is nearly all the benefit with an automatic
+  way out. CloudFront's `maxTtl` now caps the origin at 30 days regardless, so
+  no future change can re-create a year-long cache of a bad card — which is
+  exactly what the fontless deploy needed a manual invalidation to undo.
 - The `/cards/*` behaviour has no edge function attached. Letting the OG handler
   intercept the images it just advertised is precisely the bug that once served
   an HTML body as an image; there is a test asserting it stays off.

--- a/docs/decisions/020-map-preview-cards.md
+++ b/docs/decisions/020-map-preview-cards.md
@@ -103,8 +103,24 @@ better than a broken image.
 
 ## Consequences
 
-- Occurrence cards are immutable (a past sighting never moves); today's day card
-  carries a 15-minute TTL because it is still accumulating.
+- **Cache lifetime follows how recent the card's subject is, not the card type**
+  (`card-renderer/cache-control.ts`). A sighting's *record* keeps changing for a
+  few days after the sighting: reports arrive late, ingest runs on a schedule,
+  counts are revised, species re-identified, photos appear. So a subject within
+  **four days** gets `max-age=300, must-revalidate`, and anything older gets 30
+  days. Four days covers ingest lag plus the tail of late community reports.
+
+  The first cut had this backwards — occurrence cards were unconditionally
+  `immutable` for a year, so the card most likely to be wrong soon was the one
+  cached hardest, and a day went immutable at midnight while its sightings were
+  still arriving.
+
+  Nothing is `immutable` any more. Curation can revise an old record
+  (decision 014), and `immutable` tells caches never to revalidate even on a
+  manual reload, which makes every correction depend on someone remembering to
+  run a CloudFront invalidation. A month of caching is nearly all the benefit
+  with an automatic way out. CloudFront's `maxTtl` caps the origin at 30 days
+  regardless, so no future change can re-create a year-long cache of a bad card.
 - The `/cards/*` behaviour has no edge function attached. Letting the OG handler
   intercept the images it just advertised is precisely the bug that once served
   an HTML body as an image; there is a test asserting it stays off.

--- a/docs/runbook/deploys.md
+++ b/docs/runbook/deploys.md
@@ -87,6 +87,21 @@ docker run --rm --platform linux/amd64 \
 
 Dropping `-e FONTCONFIG_PATH` reproduces the boxes, which is the check that the check works.
 
+### Cached cards after a rendering change
+
+Cards are cached by how recent their subject is ([decision 020](../decisions/020-map-preview-cards.md)): a sighting or day within four days revalidates every five minutes, anything older is cached for 30 days. So a change to how cards *look* reaches recent cards within minutes and older ones over a month.
+
+**A deploy does not clear them** — the deploy step invalidates only `/` and `/index.html`. If a rendering change needs to take effect everywhere at once (or a bad card shipped), invalidate explicitly:
+
+```sh
+aws cloudfront create-invalidation --profile <profile> \
+  --distribution-id "$(aws cloudfront list-distributions --profile <profile> \
+    --query "DistributionList.Items[?contains(Aliases.Items,'salishsea.io')].Id" --output text)" \
+  --paths '/cards/*'
+```
+
+This is not in the deploy workflow on purpose: most deploys don't touch the renderer, and invalidating every card on every deploy would discard the cache for no reason. The first 1,000 invalidation paths a month are free.
+
 ## Caching notes
 
 - **Viewer-request Lambda responses are never cached by CloudFront** — each request re-runs the current function version, so once the distribution shows `Deployed`, the new behaviour is live everywhere. (Contrast: static assets passed through to S3 *are* cached per-POP; `aws cloudfront create-invalidation --paths '/some-asset.jpg'` clears them.)

--- a/infra/lib/card-renderer/cache-control.test.ts
+++ b/infra/lib/card-renderer/cache-control.test.ts
@@ -1,0 +1,87 @@
+import {
+  FRESH, FRESH_WINDOW_DAYS, MISS, SETTLED, cacheControlForDate, cacheControlForInstant,
+} from './cache-control';
+import { pacificDayRange } from './pacific-day';
+
+const NOW = new Date('2026-07-27T18:00:00Z'); // 11:00 PDT
+const daysBefore = (n: number) => new Date(NOW.getTime() - n * 24 * 3600_000).toISOString();
+
+describe('the policies themselves', () => {
+  it('keeps a recent subject briefly and revalidated', () => {
+    expect(FRESH).toContain('max-age=300');
+    expect(FRESH).toContain('must-revalidate');
+  });
+
+  it('never marks a card immutable', () => {
+    // Curation can revise an old record; `immutable` would make every such
+    // correction depend on someone remembering to invalidate CloudFront.
+    for (const policy of [FRESH, SETTLED, MISS]) {
+      expect(policy).not.toContain('immutable');
+    }
+  });
+
+  it('settles to a month, not a year', () => {
+    expect(SETTLED).toBe(`public, max-age=${30 * 24 * 3600}`);
+  });
+});
+
+describe('cacheControlForInstant (occurrence cards)', () => {
+  it('treats a sighting from minutes ago as fresh', () => {
+    expect(cacheControlForInstant(daysBefore(0), NOW)).toBe(FRESH);
+  });
+
+  it.each([1, 2, 3])('treats a sighting from %i day(s) ago as fresh', (days) => {
+    expect(cacheControlForInstant(daysBefore(days), NOW)).toBe(FRESH);
+  });
+
+  it('is fresh right up to the window edge', () => {
+    const justInside = new Date(NOW.getTime() - FRESH_WINDOW_DAYS * 24 * 3600_000 + 60_000);
+    expect(cacheControlForInstant(justInside.toISOString(), NOW)).toBe(FRESH);
+  });
+
+  it('settles once past the window', () => {
+    const justOutside = new Date(NOW.getTime() - FRESH_WINDOW_DAYS * 24 * 3600_000 - 60_000);
+    expect(cacheControlForInstant(justOutside.toISOString(), NOW)).toBe(SETTLED);
+  });
+
+  it.each([5, 30, 400])('treats a sighting from %i days ago as settled', (days) => {
+    expect(cacheControlForInstant(daysBefore(days), NOW)).toBe(SETTLED);
+  });
+
+  it('treats a future timestamp as fresh, not as a month-old record', () => {
+    // Clock skew or a bad observed_at should not earn a long cache.
+    expect(cacheControlForInstant(daysBefore(-2), NOW)).toBe(FRESH);
+  });
+
+  it('falls back to fresh on an unparseable timestamp', () => {
+    expect(cacheControlForInstant('not a date', NOW)).toBe(FRESH);
+  });
+});
+
+describe('cacheControlForDate (day cards)', () => {
+  const forDate = (date: string, now = NOW) =>
+    cacheControlForDate(date, pacificDayRange(date).endIso, now);
+
+  it('keeps today fresh', () => {
+    expect(forDate('2026-07-27')).toBe(FRESH);
+  });
+
+  it.each(['2026-07-26', '2026-07-25', '2026-07-24'])('keeps %s fresh', (date) => {
+    // Sightings keep arriving for a day well after it ends — ingest lag and
+    // late community reports — so yesterday is not settled.
+    expect(forDate(date)).toBe(FRESH);
+  });
+
+  it('settles a day once four days have passed since it ended', () => {
+    expect(forDate('2026-07-20')).toBe(SETTLED);
+  });
+
+  it('measures from the end of the day, so a day is fresh from its first minute', () => {
+    const justAfterMidnightPacific = new Date('2026-07-27T07:01:00Z');
+    expect(forDate('2026-07-27', justAfterMidnightPacific)).toBe(FRESH);
+  });
+
+  it('treats a future date as fresh', () => {
+    expect(forDate('2026-08-15')).toBe(FRESH);
+  });
+});

--- a/infra/lib/card-renderer/cache-control.ts
+++ b/infra/lib/card-renderer/cache-control.ts
@@ -1,0 +1,76 @@
+// How long a card may be cached.
+//
+// The governing fact is that a sighting's *record* keeps changing for a few days
+// after the sighting itself. Reports arrive late, ingest runs on a schedule,
+// counts get revised, a species gets re-identified, photos appear. A card
+// rendered an hour after a sighting is the one most likely to be wrong soon, and
+// under the original rule it was the one cached hardest — occurrence cards were
+// unconditionally immutable for a year.
+//
+// So freshness is keyed on how recent the *subject* is, not on the card type.
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How long a subject stays volatile. Four days covers ingest lag plus the tail
+ * of late community reports; past that a day's set has effectively settled.
+ */
+export const FRESH_WINDOW_DAYS = 4;
+
+/**
+ * Recent subject: short enough that a correction shows up quickly, long enough
+ * that a burst of crawlers hitting a freshly-shared link doesn't re-render (and
+ * re-fetch ~18 basemap tiles) per request. Not zero for that reason.
+ */
+export const FRESH = 'public, max-age=300, must-revalidate';
+
+/**
+ * Settled subject. Deliberately NOT `immutable`: curation can revise an old
+ * record (decision 014), and `immutable` tells caches never to revalidate even
+ * on a manual reload, which would make every correction depend on someone
+ * remembering to run a CloudFront invalidation. A month of cache is nearly all
+ * the benefit with an automatic way out.
+ */
+export const SETTLED = 'public, max-age=2592000';
+
+/**
+ * A 404. Long enough that a crawler storm over one bad id doesn't hammer
+ * Supabase, short enough that a genuinely new occurrence isn't 404-locked.
+ */
+export const MISS = 'public, max-age=300';
+
+function isWithinFreshWindow(subjectMs: number, now: Date): boolean {
+  // Future-dated subjects count as fresh: a clock skew or a bad observed_at
+  // should not earn a month of caching.
+  return now.getTime() - subjectMs < FRESH_WINDOW_DAYS * DAY_MS;
+}
+
+/**
+ * Cache-Control for a card whose subject is an instant — an occurrence's
+ * `observed_at`.
+ *
+ * Known limitation: this reads the observation time, not the record's last
+ * modification, which the API does not expose. An old sighting ingested today
+ * is treated as settled even though it is brand new to us. Bounded in practice,
+ * since the first render happens after ingest.
+ */
+export function cacheControlForInstant(observedAtIso: string, now = new Date()): string {
+  const observed = Date.parse(observedAtIso);
+  // An unparseable timestamp is a data problem; cache it briefly rather than
+  // for a month, so it self-corrects.
+  if (Number.isNaN(observed)) return FRESH;
+  return isWithinFreshWindow(observed, now) ? FRESH : SETTLED;
+}
+
+/**
+ * Cache-Control for a card whose subject is a whole Pacific calendar day.
+ * The day is treated as ending at its own midnight, so "today" is fresh from
+ * its first minute.
+ */
+export function cacheControlForDate(pacificDate: string, dayEndsIso: string, now = new Date()): string {
+  const dayEnds = Date.parse(dayEndsIso);
+  if (Number.isNaN(dayEnds)) return FRESH;
+  // Measure from the END of the day: a card for today is fresh all day, and a
+  // card for four days ago settles four days after that day finished.
+  return isWithinFreshWindow(dayEnds, now) ? FRESH : SETTLED;
+}

--- a/infra/lib/card-renderer/handler.ts
+++ b/infra/lib/card-renderer/handler.ts
@@ -10,15 +10,11 @@
 
 import { renderDayCard, renderOccurrenceCard } from './cards.js';
 import { configFromEnv, fetchOccurrence, fetchOccurrencesBetween } from './data.js';
-import { currentPacificDate, isValidDate, pacificDayRange } from './pacific-day.js';
+import { MISS as MISS_CACHE, cacheControlForDate, cacheControlForInstant } from './cache-control.js';
+import { isValidDate, pacificDayRange } from './pacific-day.js';
 
-// A past sighting never moves, so its card is immutable. Today's day card still
-// gains sightings as they arrive, so it gets a short life instead.
-const IMMUTABLE = 'public, max-age=31536000, immutable';
-const VOLATILE = 'public, max-age=900';
-// Long enough that a crawler storm over one bad id doesn't reach Supabase
-// repeatedly; short enough that a genuinely new occurrence isn't 404-locked.
-const MISS = 'public, max-age=300';
+// Cache lifetimes are keyed on how recent the card's subject is — see
+// cache-control.ts for why, and for the window.
 
 const OCCURRENCE_PATH = /^\/cards\/o\/(.+)\.jpg$/;
 const DAY_PATH = /^\/cards\/day\/([0-9]{4}-[0-9]{2}-[0-9]{2})\.jpg$/;
@@ -44,7 +40,7 @@ const image = (jpeg: Buffer, cacheControl: string): Result => ({
 
 const miss = (reason: string): Result => ({
   statusCode: 404,
-  headers: { 'content-type': 'text/plain; charset=utf-8', 'cache-control': MISS },
+  headers: { 'content-type': 'text/plain; charset=utf-8', 'cache-control': MISS_CACHE },
   body: reason,
 });
 
@@ -65,7 +61,7 @@ export const handler = async (event: FunctionUrlEvent): Promise<Result> => {
       console.log(JSON.stringify({
         msg: 'card', kind: 'occurrence', id, ms: Date.now() - started, bytes: jpeg.length,
       }));
-      return image(jpeg, IMMUTABLE);
+      return image(jpeg, cacheControlForInstant(occ.observedAt));
     }
 
     const dayMatch = path.match(DAY_PATH);
@@ -79,7 +75,7 @@ export const handler = async (event: FunctionUrlEvent): Promise<Result> => {
         msg: 'card', kind: 'day', date, fetched: occurrences.length,
         ms: Date.now() - started, bytes: jpeg.length,
       }));
-      return image(jpeg, date === currentPacificDate() ? VOLATILE : IMMUTABLE);
+      return image(jpeg, cacheControlForDate(date, endIso));
     }
 
     return miss('unrecognized card path');

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -196,9 +196,20 @@ export class InfraStack extends cdk.Stack {
           cachePolicy: new cloudfront.CachePolicy(this, 'CardCachePolicy', {
             cachePolicyName: 'salishsea-cards',
             comment: 'Preview card images; keyed on path alone, TTL from origin',
-            defaultTtl: cdk.Duration.days(30),
+            // These bound whatever the renderer asks for, and exist as a
+            // backstop rather than a policy: the renderer sets Cache-Control
+            // per card (see card-renderer/cache-control.ts).
+            //
+            // defaultTtl applies only if the renderer ever sends no header at
+            // all — five minutes, so a header regression costs minutes rather
+            // than the month it would otherwise inherit.
+            defaultTtl: cdk.Duration.minutes(5),
             minTtl: cdk.Duration.seconds(0),
-            maxTtl: cdk.Duration.days(365),
+            // maxTtl caps the origin's own max-age. A year of caching over a
+            // card that turned out to be broken is exactly what happened on
+            // 2026-07-27 (fontless cards, cached immutable); this makes the
+            // worst case a month even if a future change asks for longer.
+            maxTtl: cdk.Duration.days(30),
             queryStringBehavior: cloudfront.CacheQueryStringBehavior.none(),
             cookieBehavior: cloudfront.CacheCookieBehavior.none(),
             headerBehavior: cloudfront.CacheHeaderBehavior.none(),

--- a/infra/test/infra.test.ts
+++ b/infra/test/infra.test.ts
@@ -99,6 +99,20 @@ describe('InfraStack', () => {
       });
     });
 
+    it('caps how long a card can be cached, whatever the origin asks for', () => {
+      // A year-long cache over cards that turned out to be broken is what made
+      // the fontless deploy need a manual invalidation to undo.
+      template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
+        CachePolicyConfig: Match.objectLike({
+          Name: 'salishsea-cards',
+          MaxTTL: 30 * 24 * 3600,
+          // Applies only if the renderer sends no Cache-Control at all.
+          DefaultTTL: 300,
+          MinTTL: 0,
+        }),
+      });
+    });
+
     it('caches cards on the path alone', () => {
       template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
         CachePolicyConfig: Match.objectLike({


### PR DESCRIPTION
Follow-up on card lifetimes and invalidation. The original scheme had the priority backwards.

## What was wrong

| card | old | problem |
|---|---|---|
| occurrence | `immutable`, 1 year — always | The sighting reported an hour ago is the one most likely to change, and it was cached hardest |
| day | 15 min for *today*, `immutable` after | A day went immutable at midnight while its sightings were still arriving |

A sighting's **record** keeps changing for a few days after the sighting: reports arrive late, ingest runs on a schedule, counts are revised, a species gets re-identified, photos appear. Freshness should track the subject, not the card type.

## What it does now

- **Subject within 4 days** → `public, max-age=300, must-revalidate`
- **Older** → `public, max-age=2592000` (30 days)

Four days covers ingest lag plus the tail of late community reports. For day cards the window is measured from the **end** of the day, so today is fresh from its first minute and a day settles four days after it finishes.

**Not zero for the fresh case.** A freshly-shared link is exactly when crawlers arrive in a burst, and every miss re-fetches ~18 basemap tiles. Five minutes bounds staleness tightly while absorbing that. Happy to take it to 0 if you'd rather.

**Nothing is `immutable` any more.** Curation can revise an old record (decision 014), and `immutable` tells caches never to revalidate *even on a manual reload* — which makes every correction depend on someone remembering to run an invalidation. 30 days is nearly all the caching benefit with an automatic way out.

## Invalidation

Two changes on that front:

- **CloudFront now caps the origin.** `maxTtl` drops from 365 days to 30, so no future change can re-create a year-long cache of a bad card — which is precisely what made the fontless deploy need a manual invalidation to undo. `defaultTtl` drops from 30 days to 5 minutes, so if the renderer ever stops sending `Cache-Control`, that costs minutes rather than a month.
- **The runbook documents the explicit invalidation** for rendering changes. Deliberately *not* added to the deploy workflow: most deploys don't touch the renderer, and invalidating every card each time discards the cache for nothing.

## Known limitation, stated at the function

Freshness reads `observed_at`, not a record modification time — the API doesn't expose one. An old sighting ingested today is treated as settled even though it's new to us. Bounded in practice since the first render happens after ingest, but it's a real gap rather than an oversight.

## Testing

155 infra tests (up from 133), including both window boundaries to the minute, future-dated and unparseable timestamps, day cards measured from the day's end, and an assertion that no policy contains `immutable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved preview card caching rules to refresh recent cards more frequently while keeping older cards cached up to 30 days.
  - Updated caching to stop using immutable responses, so corrected content can appear without manual invalidations.
  - Added safeguards to prevent overly long caching via CloudFront limits.

- **Documentation**
  - Added runbook guidance on cache behavior after rendering changes, including when manual invalidations of card URLs may be needed.

- **Tests**
  - Added unit tests for cache-control computation and date boundary handling.
  - Added infrastructure tests verifying CloudFront cache-policy TTL settings and caps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->