### PR TITLE
Make the DwC-A guard's floors injectable so the row-floor test asserts something

### DIFF
--- a/scripts/dwca/guard.test.ts
+++ b/scripts/dwca/guard.test.ts
@@ -3,11 +3,21 @@
  *
  * Tests:
  *   1. Guard passes when all metrics are above floor values.
- *   2. Guard trips when zip size <= ZIP_FLOOR_BYTES.
- *   3. Guard trips when parquet size <= PARQUET_FLOOR_BYTES.
- *   4. Guard trips when dwc.occurrences row count <= ROW_FLOOR (DSN-gated).
- *   5. Guard never logs the DSN to stdout/stderr.
- *   6. guard-diff.txt content shape matches the documented format.
+ *   2. Guard trips when zip size <= the zip floor.
+ *   3. Guard trips when parquet size <= the parquet floor.
+ *   4. Guard trips when dwc.occurrences row count <= the row floor.
+ *   4b. The same against a live database, exercising ATTACH + COUNT (DSN-gated).
+ *   5. floorsFromEnv reads the environment when called, not when imported.
+ *   6. Guard never logs the DSN to stdout/stderr.
+ *   7. guard-diff.txt content shape matches the documented format.
+ *
+ * Every test passes floors to `main()` explicitly. They used to be module-level
+ * `const`s in guard.ts, read once at import, so a test setting
+ * `process.env.ROW_FLOOR` in its body changed nothing: the row-floor case passed
+ * only because CI's seed fixture sits below the *default* floor of 1,000. It
+ * asserted nothing there, and failed outright against a populated local database
+ * (salish-52s). Passing floors in also stops a developer's ambient
+ * ZIP_FLOOR_BYTES/PARQUET_FLOOR_BYTES from perturbing the mocked size cases.
  *
  * Cross-reference:
  *   - 07-01-PLAN.md Task 1 for the full behavior spec.
@@ -44,7 +54,17 @@ vi.mock('@duckdb/node-api', () => ({
 import * as fs from 'node:fs';
 import * as fsPromises from 'node:fs/promises';
 import * as duckdbModule from '@duckdb/node-api';
-import { main } from './guard.ts';
+import { main, floorsFromEnv, type GuardFloors } from './guard.ts';
+
+/**
+ * The G-02 defaults, stated explicitly so these tests assert against known
+ * numbers rather than whatever the ambient environment happens to hold.
+ */
+const FLOORS: GuardFloors = {
+    zipBytes: 51_200,
+    parquetBytes: 10_240,
+    rows: 1_000n,
+};
 
 // ---------------------------------------------------------------------------
 // DSN gating (mirrors build.test.ts pattern)
@@ -93,6 +113,16 @@ describe('guard', () => {
     let origDsn: string | undefined;
 
     beforeEach(() => {
+        // Pin the floor variables for the whole suite. Several tests below call
+        // main() with no argument on purpose, to exercise the floorsFromEnv
+        // default — and those are exactly the ones a developer's exported
+        // ZIP_FLOOR_BYTES would perturb. vi.stubEnv is undone by
+        // vi.unstubAllEnvs() in afterEach, and a test that needs a specific value
+        // (the ROW_FLOOR cases) stubs over the top of these.
+        vi.stubEnv('ZIP_FLOOR_BYTES', String(FLOORS.zipBytes));
+        vi.stubEnv('PARQUET_FLOOR_BYTES', String(FLOORS.parquetBytes));
+        vi.stubEnv('ROW_FLOOR', String(FLOORS.rows));
+
         // Capture and suppress console + process.exit.
         consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
         consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -110,6 +140,7 @@ describe('guard', () => {
     });
 
     afterEach(() => {
+        vi.unstubAllEnvs();
         vi.restoreAllMocks();
         if (origDsn === undefined) delete process.env['SUPABASE_DB_URL'];
         else process.env['SUPABASE_DB_URL'] = origDsn;
@@ -124,7 +155,7 @@ describe('guard', () => {
         vi.mocked(fsPromises.stat).mockImplementation(makeStatMock(204_800, 51_200));
         makeDuckdbMock(BigInt(5000));
 
-        await main();
+        await main(FLOORS);
 
         expect(processExitSpy).not.toHaveBeenCalled();
         expect(vi.mocked(fs.writeFileSync)).not.toHaveBeenCalled();
@@ -142,7 +173,7 @@ describe('guard', () => {
         vi.mocked(fsPromises.stat).mockImplementation(makeStatMock(10_240, 51_200));
         makeDuckdbMock(BigInt(5000));
 
-        await expect(main()).rejects.toThrow('process.exit called');
+        await expect(main(FLOORS)).rejects.toThrow('process.exit called');
 
         expect(processExitSpy).toHaveBeenCalledWith(1);
         expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledOnce();
@@ -165,7 +196,7 @@ describe('guard', () => {
         vi.mocked(fsPromises.stat).mockImplementation(makeStatMock(204_800, 1_024));
         makeDuckdbMock(BigInt(5000));
 
-        await expect(main()).rejects.toThrow('process.exit called');
+        await expect(main(FLOORS)).rejects.toThrow('process.exit called');
 
         expect(processExitSpy).toHaveBeenCalledWith(1);
         expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledOnce();
@@ -180,46 +211,273 @@ describe('guard', () => {
     });
 
     // -----------------------------------------------------------------------
-    // Test 4: row count floor trip (DSN-gated)
+    // Test 4: row count floor trip
+    //
+    // Runs everywhere, against a mocked count. The row floor was previously only
+    // covered by the DSN-gated test below, so on a machine without a local
+    // database it was not covered at all.
+    // -----------------------------------------------------------------------
+
+    test('guard trips when row count <= the row floor', async () => {
+        // Both file sizes comfortably above their floors, so only the row count
+        // can trip: 999 against a floor of 1,000.
+        vi.mocked(fsPromises.stat).mockImplementation(makeStatMock(204_800, 51_200));
+        makeDuckdbMock(999n);
+
+        await expect(main(FLOORS)).rejects.toThrow('process.exit called');
+
+        expect(processExitSpy).toHaveBeenCalledWith(1);
+        expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledOnce();
+
+        const [, content] = vi.mocked(fs.writeFileSync).mock.calls[0] as [string, string];
+        const parsed = JSON.parse(content.match(/Raw: (.+)/)![1]!);
+        expect(parsed.row_ok).toBe(false);
+        expect(parsed.zip_ok).toBe(true);
+        expect(parsed.parquet_ok).toBe(true);
+        expect(parsed.row_count).toBe(999);
+        expect(parsed.row_floor).toBe(1_000);
+    });
+
+    test('guard passes on the row floor boundary at floor + 1', async () => {
+        // The floor is exclusive: `rowCount > floor`. 1,000 must trip and 1,001
+        // must pass, which is what pins the comparison as `>` rather than `>=`.
+        vi.mocked(fsPromises.stat).mockImplementation(makeStatMock(204_800, 51_200));
+        makeDuckdbMock(1_000n);
+        await expect(main(FLOORS)).rejects.toThrow('process.exit called');
+
+        vi.mocked(fs.writeFileSync).mockClear();
+        makeDuckdbMock(1_001n);
+        await main(FLOORS);
+        expect(vi.mocked(fs.writeFileSync)).not.toHaveBeenCalled();
+    });
+
+    test('guard honours explicit non-default floors', async () => {
+        // Every other always-run test passes floors equal to the G-02 defaults,
+        // so it would still pass if main() ignored its argument and re-read the
+        // environment. This one uses floors that differ from the defaults in
+        // both directions, so only a main() that actually uses the argument
+        // behaves as asserted.
+        const custom: GuardFloors = {
+            zipBytes: 300_000,      // above the mocked 204,800 -> trips
+            parquetBytes: 1_000,    // below the mocked 51,200  -> passes
+            rows: 10_000n,          // above the mocked 5,000   -> trips
+        };
+        vi.mocked(fsPromises.stat).mockImplementation(makeStatMock(204_800, 51_200));
+        makeDuckdbMock(5_000n);
+
+        await expect(main(custom)).rejects.toThrow('process.exit called');
+
+        const [, content] = vi.mocked(fs.writeFileSync).mock.calls[0] as [string, string];
+        const parsed = JSON.parse(content.match(/Raw: (.+)/)![1]!);
+        // Under the defaults this input passes cleanly; under `custom` two floors trip.
+        expect(parsed.zip_ok).toBe(false);
+        expect(parsed.row_ok).toBe(false);
+        expect(parsed.parquet_ok).toBe(true);
+        // The report echoes the floors it was given, not the defaults.
+        expect(parsed.zip_floor).toBe(300_000);
+        expect(parsed.parquet_floor).toBe(1_000);
+        expect(parsed.row_floor).toBe(10_000);
+    });
+
+    // -----------------------------------------------------------------------
+    // Test 4c: floors that would disable the guard are rejected
+    // -----------------------------------------------------------------------
+
+    test.each([
+        ['zip floor of zero', { ...FLOORS, zipBytes: 0 }],
+        ['parquet floor of zero', { ...FLOORS, parquetBytes: 0 }],
+        ['row floor of zero', { ...FLOORS, rows: 0n }],
+        ['negative floor', { ...FLOORS, zipBytes: -1 }],
+        ['unparseable floor (NaN)', { ...FLOORS, zipBytes: Number.NaN }],
+        // GuardFloors is erased at runtime, so a JavaScript caller can pass these.
+        // `NaN < 1n` is false, so a bare range check would let them through.
+        ['row floor passed as a number', { ...FLOORS, rows: 1_000 as unknown as bigint }],
+        ['row floor of NaN', { ...FLOORS, rows: Number.NaN as unknown as bigint }],
+    ])('guard refuses to run with a %s', async (_label, floors) => {
+        // A zero floor passes everything, so an empty env var — Number('') === 0
+        // — would otherwise silently disable the check on an empty archive.
+        vi.mocked(fsPromises.stat).mockImplementation(makeStatMock(204_800, 51_200));
+        makeDuckdbMock(5_000n);
+
+        await expect(main(floors as GuardFloors)).rejects.toThrow('process.exit called');
+
+        expect(processExitSpy).toHaveBeenCalledWith(1);
+        const errors = consoleErrorSpy.mock.calls.flat().join(' ');
+        expect(errors).toContain('guard floors are invalid');
+
+        // The diff file says the guard did not run, rather than reporting a trip
+        // with fabricated numbers — and overwrites the workflow's pre-seeded
+        // "failed before guard.ts could run", which would be wrong here.
+        const [diffPath, body] = vi.mocked(fs.writeFileSync).mock.calls[0] as [string, string];
+        expect(diffPath).toBe('dist/dwca/guard-diff.txt');
+        expect(body).toContain('guard did not run');
+        expect(body).toContain('guard floors are invalid');
+        expect(body).not.toContain('Raw:'); // not a trip report
+    });
+
+    test('a bad row-floor type is reported as a type problem, not a range one', async () => {
+        // Distinct messages: a JS caller passing the wrong type needs to hear
+        // "bigint", an operator with a bad env value needs to hear "integer".
+        vi.mocked(fsPromises.stat).mockImplementation(makeStatMock(204_800, 51_200));
+        makeDuckdbMock(5_000n);
+
+        await expect(
+            main({ ...FLOORS, rows: 1_000 as unknown as bigint }),
+        ).rejects.toThrow('process.exit called');
+
+        const errors = consoleErrorSpy.mock.calls.flat().join(' ');
+        expect(errors).toContain('rows must be a bigint, got number');
+    });
+
+    // -----------------------------------------------------------------------
+    // Test 4b: row count floor trip against a live database (DSN-gated)
+    //
+    // The only test that exercises the real DuckDB ATTACH + COUNT path, so it
+    // earns its keep even though test 4 covers the same branch. The floor is set
+    // above any plausible row count, which makes the trip deterministic whether
+    // the database holds CI's seed fixture or a full local import — the previous
+    // version tried to do this through process.env.ROW_FLOOR, which guard.ts had
+    // already read at import time, so it silently ran against the default floor
+    // of 1,000 and passed only where the data happened to sit below it.
     // -----------------------------------------------------------------------
 
     const testRowFloor = HAS_DSN ? test : test.skip;
-    testRowFloor('guard trips when dwc.occurrences row count <= ROW_FLOOR', async () => {
-            // Both file sizes above floor; set ROW_FLOOR to a very large value
-            // so the real row count (from the live DB) trips the floor.
-            vi.mocked(fsPromises.stat).mockImplementation(makeStatMock(204_800, 51_200));
+    testRowFloor('guard trips on row count against a live database', async () => {
+        vi.mocked(fsPromises.stat).mockImplementation(makeStatMock(204_800, 51_200));
 
-            // Wire real DuckDB for this DSN-gated test. mockRestore() only works on
-            // vi.spyOn() mocks; this module uses vi.fn(), so we importActual and
-            // delegate via mockImplementation instead.
-            const { DuckDBInstance: RealDuckDBInstance } =
-                await vi.importActual<typeof import('@duckdb/node-api')>('@duckdb/node-api');
-            vi.mocked(duckdbModule.DuckDBInstance.create).mockImplementation(
-                RealDuckDBInstance.create.bind(RealDuckDBInstance),
-            );
+        // Wire real DuckDB for this DSN-gated test. mockRestore() only works on
+        // vi.spyOn() mocks; this module uses vi.fn(), so we importActual and
+        // delegate via mockImplementation instead.
+        const { DuckDBInstance: RealDuckDBInstance } =
+            await vi.importActual<typeof import('@duckdb/node-api')>('@duckdb/node-api');
+        vi.mocked(duckdbModule.DuckDBInstance.create).mockImplementation(
+            RealDuckDBInstance.create.bind(RealDuckDBInstance),
+        );
 
-            const origFloor = process.env['ROW_FLOOR'];
-            process.env['ROW_FLOOR'] = '9999999999'; // above any real row count
-            // Also restore the real DSN.
-            process.env['SUPABASE_DB_URL'] = DSN as string;
+        process.env['SUPABASE_DB_URL'] = DSN as string;
 
-            try {
-                await expect(main()).rejects.toThrow('process.exit called');
+        await expect(
+            main({ ...FLOORS, rows: 9_999_999_999n }),
+        ).rejects.toThrow('process.exit called');
 
-                expect(processExitSpy).toHaveBeenCalledWith(1);
-                expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledOnce();
+        expect(processExitSpy).toHaveBeenCalledWith(1);
+        expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledOnce();
 
-                const [, content] = vi.mocked(fs.writeFileSync).mock.calls[0] as [string, string];
-                const rawMatch = content.match(/Raw: (.+)/);
-                expect(rawMatch).toBeTruthy();
-                const parsed = JSON.parse(rawMatch![1]!);
-                expect(parsed.row_ok).toBe(false);
-            } finally {
-                if (origFloor === undefined) delete process.env['ROW_FLOOR'];
-                else process.env['ROW_FLOOR'] = origFloor;
-            }
-        },
-    );
+        const [, content] = vi.mocked(fs.writeFileSync).mock.calls[0] as [string, string];
+        const parsed = JSON.parse(content.match(/Raw: (.+)/)![1]!);
+        expect(parsed.row_ok).toBe(false);
+        // The count came from the database rather than a mock: dwc.occurrences is
+        // non-empty in both CI (ci-seed.sql) and a local import. Without this the
+        // test would still pass if ATTACH silently yielded nothing.
+        expect(parsed.row_count).toBeGreaterThan(0);
+    });
+
+    // -----------------------------------------------------------------------
+    // Test 5: floors are read from the environment at call time
+    //
+    // The direct regression test for salish-52s. As module-level consts these
+    // were fixed at import, so the workflow's ZIP_FLOOR_BYTES/ROW_FLOOR did still
+    // apply (it sets them before node starts) but nothing could vary them after.
+    // -----------------------------------------------------------------------
+
+    test('floorsFromEnv reads the environment when called', () => {
+        expect(floorsFromEnv({})).toEqual(FLOORS);
+
+        expect(
+            floorsFromEnv({
+                ZIP_FLOOR_BYTES: '1',
+                PARQUET_FLOOR_BYTES: '2',
+                ROW_FLOOR: '3',
+            }),
+        ).toEqual({ zipBytes: 1, parquetBytes: 2, rows: 3n });
+
+        // Reading process.env on each call is what makes the floors testable.
+        vi.stubEnv('ROW_FLOOR', '4242');
+        expect(floorsFromEnv().rows).toBe(4_242n);
+    });
+
+    test.each([
+        ['a fractional value', '1.5'],
+        ['a non-numeric value', 'lots'],
+        ['a negative value', '-1'],
+        ['an empty value', ''],
+        ['zero', '0'],
+        ['a padded zero', '  00  '],
+        ['a plus-prefixed value', '+1'],
+    ])('main() refuses a ROW_FLOOR that is %s', async (_label, raw) => {
+        // BigInt() throws on all but the empty case, so without screening these
+        // escaped as an opaque SyntaxError instead of the guard's own message.
+        vi.mocked(fsPromises.stat).mockImplementation(makeStatMock(204_800, 51_200));
+        makeDuckdbMock(5_000n);
+
+        vi.stubEnv('ROW_FLOOR', raw);
+
+        await expect(main()).rejects.toThrow('process.exit called');
+
+        expect(processExitSpy).toHaveBeenCalledWith(1);
+        const errors = consoleErrorSpy.mock.calls.flat().join(' ');
+        expect(errors).toContain('guard floors are invalid');
+        expect(errors).toContain('rows must be a positive integer');
+    });
+
+    test('main() refuses a malformed ZIP_FLOOR_BYTES the same way', async () => {
+        // Number('lots') is NaN rather than a throw, so this arrives at
+        // assertValidFloors instead of the screen in floorsFromEnv. Same message.
+        vi.mocked(fsPromises.stat).mockImplementation(makeStatMock(204_800, 51_200));
+        makeDuckdbMock(5_000n);
+
+        vi.stubEnv('ZIP_FLOOR_BYTES', 'lots');
+
+        await expect(main()).rejects.toThrow('process.exit called');
+        const errors = consoleErrorSpy.mock.calls.flat().join(' ');
+        expect(errors).toContain('guard floors are invalid');
+        expect(errors).toContain('zipBytes must be a positive integer');
+    });
+
+    test('guard applies the floors it validated, not later mutations', async () => {
+        // main() awaits fs.stat and DuckDB between validating the floors and
+        // applying them. A caller mutating its object in that window must not be
+        // able to swap in floors that were never checked — here, zeroing them all
+        // mid-run would otherwise turn a tripped guard into "guard ok".
+        const mutable: GuardFloors = { ...FLOORS };
+        const statMock = makeStatMock(204_800, 1_024);
+        vi.mocked(fsPromises.stat).mockImplementation(
+            vi.fn().mockImplementation(async (path: unknown) => {
+                // Mutate mid-run, in the window between validation and comparison.
+                mutable.zipBytes = 0;
+                mutable.parquetBytes = 0;
+                mutable.rows = 0n;
+                return statMock(path);
+            }),
+        );
+        makeDuckdbMock(5_000n);
+
+        // parquet is 1,024 against the snapshotted floor of 10,240 -> trips.
+        await expect(main(mutable)).rejects.toThrow('process.exit called');
+
+        const [, content] = vi.mocked(fs.writeFileSync).mock.calls[0] as [string, string];
+        const parsed = JSON.parse(content.match(/Raw: (.+)/)![1]!);
+        expect(parsed.parquet_ok).toBe(false);
+        expect(parsed.parquet_floor).toBe(10_240); // the validated value, not 0
+    });
+
+    test('main() defaults to the environment, read at call time', async () => {
+        // End-to-end version of the above, and the assertion the original
+        // row-floor test believed it was making: set ROW_FLOOR *after* guard.ts
+        // was imported, call main() with no argument, and require it to bite.
+        // Against the old module-level consts this passed silently.
+        vi.mocked(fsPromises.stat).mockImplementation(makeStatMock(204_800, 51_200));
+        makeDuckdbMock(1_001n);
+
+        vi.stubEnv('ROW_FLOOR', '1001'); // equal to the count, and `>` is strict
+
+        await expect(main()).rejects.toThrow('process.exit called');
+
+        const [, content] = vi.mocked(fs.writeFileSync).mock.calls[0] as [string, string];
+        const parsed = JSON.parse(content.match(/Raw: (.+)/)![1]!);
+        expect(parsed.row_ok).toBe(false);
+        expect(parsed.row_floor).toBe(1_001);
+    });
 
     // -----------------------------------------------------------------------
     // Test 5: DSN is never logged
@@ -233,7 +491,7 @@ describe('guard', () => {
         const testDsn = 'postgres://leaktest:secret@host:5432/db';
         process.env['SUPABASE_DB_URL'] = testDsn;
 
-        await expect(main()).rejects.toThrow('process.exit called');
+        await expect(main(FLOORS)).rejects.toThrow('process.exit called');
 
         // Assert no spy call contains the DSN
         const allLogArgs = [
@@ -258,7 +516,7 @@ describe('guard', () => {
         vi.mocked(fsPromises.stat).mockImplementation(makeStatMock(204_800, 512));
         makeDuckdbMock(BigInt(5000));
 
-        await expect(main()).rejects.toThrow('process.exit called');
+        await expect(main(FLOORS)).rejects.toThrow('process.exit called');
 
         expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledOnce();
         const [writePath] = vi.mocked(fs.writeFileSync).mock.calls[0] as [string, string];
@@ -274,7 +532,7 @@ describe('guard', () => {
         vi.mocked(fsPromises.stat).mockImplementation(makeStatMock(1_024, 51_200)); // zip below floor
         makeDuckdbMock(BigInt(5000));
 
-        await expect(main()).rejects.toThrow('process.exit called');
+        await expect(main(FLOORS)).rejects.toThrow('process.exit called');
 
         expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledOnce();
         const [writePath, content] = vi.mocked(fs.writeFileSync).mock.calls[0] as [string, string];

--- a/scripts/dwca/guard.ts
+++ b/scripts/dwca/guard.ts
@@ -11,7 +11,7 @@
  *   Per T-7-01, any error message that could contain the DSN is scrubbed via maskDsn().
  *
  * CLI invocation:
- *   npx tsx scripts/dwca/guard.ts
+ *   pnpm exec tsx scripts/dwca/guard.ts
  *
  * Cross-reference:
  *   - 07-01-PLAN.md Task 1 for the full behavior spec.
@@ -24,21 +24,124 @@ import { writeFileSync } from 'node:fs';
 import { DuckDBInstance } from '@duckdb/node-api';
 
 // ---------------------------------------------------------------------------
-// Constants (all env-overridable with documented defaults)
+// Constants and thresholds
 // ---------------------------------------------------------------------------
 
 const ZIP_PATH = 'dist/dwca/salishsea-occurrences-v1.zip';
 const PARQUET_PATH = 'dist/dwca/salishsea-occurrences-v1.parquet';
 const DIFF_PATH = 'dist/dwca/guard-diff.txt';
 
-/** G-02: 50 KB floor for the zip archive. */
-const ZIP_FLOOR_BYTES = Number(process.env['ZIP_FLOOR_BYTES'] ?? 51200);
+/** The three G-02 hard floors. A metric must be strictly greater to pass. */
+export interface GuardFloors {
+    /** G-02: 50 KB floor for the zip archive. */
+    zipBytes: number;
+    /** CONTEXT: 10 KB floor for the parquet sidecar (symmetry with the zip floor). */
+    parquetBytes: number;
+    /** G-02: 1,000 row floor for dwc.occurrences. */
+    rows: bigint;
+}
 
-/** CONTEXT: 10 KB floor for the parquet sidecar (symmetry with zip floor). */
-const PARQUET_FLOOR_BYTES = Number(process.env['PARQUET_FLOOR_BYTES'] ?? 10240);
+/**
+ * Read the floors from the environment, applying the G-02 defaults.
+ *
+ * Deliberately a function rather than module-level `const`s. As constants these
+ * were frozen at import time, which silently made the floors untestable: a test
+ * that set `process.env.ROW_FLOOR` after importing this module had no effect,
+ * and the row-floor test passed only because CI's seed fixture happens to sit
+ * below the *default* floor. It asserted nothing, and failed outright against a
+ * realistically populated database. Prefer passing floors to `main()` directly;
+ * this exists so the CLI keeps honouring the env vars the workflow sets.
+ */
+export function floorsFromEnv(env: NodeJS.ProcessEnv = process.env): GuardFloors {
+    const floors: GuardFloors = {
+        zipBytes: Number(env['ZIP_FLOOR_BYTES'] ?? 51200),
+        parquetBytes: Number(env['PARQUET_FLOOR_BYTES'] ?? 10240),
+        rows: parseRowFloor(env['ROW_FLOOR']),
+    };
+    // Validate here too, not only in main(). This is exported, and returning a
+    // silently NaN or zero floor to a direct caller would be the same trap in a
+    // new place. main() still validates, to cover floors it was handed directly.
+    assertValidFloors(floors);
+    return floors;
+}
 
-/** G-02: 1,000 row floor for dwc.occurrences. */
-const ROW_FLOOR = BigInt(process.env['ROW_FLOOR'] ?? 1000);
+/**
+ * Parse ROW_FLOOR, rejecting anything that is not a positive integer.
+ *
+ * Screened with a regex before `BigInt()` because BigInt throws on non-integral
+ * input — `BigInt('1.5')` and `BigInt('abc')` are both SyntaxErrors — which would
+ * escape as an opaque stack trace while a malformed ZIP_FLOOR_BYTES gets a clear
+ * message. Number() needs no equivalent: it yields NaN, which assertValidFloors
+ * rejects. The range check lives here too so that a bad *value* from the
+ * environment always reports the same way, whether it is '0' or 'lots'.
+ *
+ * Stricter than a bare BigInt(): '+1' and '0x10' were previously accepted and are
+ * now refused. Nothing in the repo uses those forms, and refusing them loudly
+ * beats accepting a form nobody intended.
+ */
+function parseRowFloor(raw: string | undefined): bigint {
+    if (raw === undefined) return 1000n;
+    if (/^\s*\d+\s*$/.test(raw)) {
+        const parsed = BigInt(raw);
+        if (parsed >= 1n) return parsed;
+    }
+    rejectFloors([`rows must be a positive integer, got ${JSON.stringify(raw)}`]);
+}
+
+/**
+ * Reject floors that would quietly weaken or disable the guard.
+ *
+ * The dangerous input is not a wild value but an empty one: `Number('')` is `0`
+ * and `BigInt('')` is `0n`, so a workflow that references an unset variable —
+ * `ZIP_FLOOR_BYTES: ${{ vars.SOMETHING_MISSING }}` — yields a floor of zero, and
+ * a zero floor passes everything. The guard would go on reporting "guard ok" for
+ * an empty archive, which is the single outcome it exists to prevent.
+ *
+ * Floors must therefore be positive: zero is rejected rather than treated as
+ * "disable this check". Disabling a floor is not a supported configuration,
+ * precisely because it is indistinguishable from the misconfiguration above.
+ * NaN (from an unparseable value) is rejected for the same reason, though it
+ * fails safe rather than open — every comparison against it is false, so the
+ * guard would trip on a healthy archive.
+ */
+/** Report invalid floors and stop. Never returns. */
+function rejectFloors(problems: string[]): never {
+    const message = `guard floors are invalid: ${problems.join('; ')}`;
+    console.error(message);
+    // dwca-nightly.yml pre-seeds this file with "Workflow failed before
+    // scripts/dwca/guard.ts could run", and files it as the issue body. That would
+    // be wrong here — the guard ran, its configuration was rejected — and the
+    // difference matters to whoever reads the issue. Overwrite with the truth.
+    writeFileSync(
+        DIFF_PATH,
+        `DwC-A nightly guard did not run\n\n${message}\n\n` +
+        `No archive was published; yesterday's remains the published version.\n`,
+    );
+    process.exit(1);
+}
+
+function assertValidFloors(floors: GuardFloors): void {
+    const problems: string[] = [];
+
+    for (const key of ['zipBytes', 'parquetBytes'] as const) {
+        const value = floors[key];
+        if (!Number.isSafeInteger(value) || value < 1) {
+            problems.push(`${key} must be a positive integer, got ${value}`);
+        }
+    }
+    // `typeof` matters as much as the range here. GuardFloors is erased at
+    // runtime, so a JavaScript caller can pass `rows: NaN`; `NaN < 1n` is false,
+    // which would slip an unusable floor past a bare range check even though the
+    // same value in zipBytes is caught by Number.isSafeInteger. Reported
+    // separately so a wrong type and a wrong value do not share one message.
+    if (typeof floors.rows !== 'bigint') {
+        problems.push(`rows must be a bigint, got ${typeof floors.rows} (${String(floors.rows)})`);
+    } else if (floors.rows < 1n) {
+        problems.push(`rows must be a positive integer, got ${floors.rows}`);
+    }
+
+    if (problems.length > 0) rejectFloors(problems);
+}
 
 // ---------------------------------------------------------------------------
 // DSN masking helper (mirrors scripts/dwca/build.ts maskDsn)
@@ -65,7 +168,14 @@ function maskDsn(s: string): string {
 // Main guard logic
 // ---------------------------------------------------------------------------
 
-export async function main(): Promise<void> {
+export async function main(floors: GuardFloors = floorsFromEnv()): Promise<void> {
+    // Before anything else: a zero or unparseable floor silently passes everything.
+    assertValidFloors(floors);
+    // Snapshot the validated values. `floors` belongs to the caller and there are
+    // two awaits between here and the comparisons below, so reading it again at
+    // the end would mean applying floors that were never validated.
+    const { zipBytes: zipFloor, parquetBytes: parquetFloor, rows: rowFloor } = floors;
+
     // DSN guard — read SUPABASE_DB_URL; exit 1 if missing. NEVER log the DSN.
     const dsn = process.env['SUPABASE_DB_URL'];
     if (!dsn) {
@@ -112,13 +222,13 @@ export async function main(): Promise<void> {
     }
 
     // Evaluate guard conditions.
-    const zipOk = zipBytes > ZIP_FLOOR_BYTES;
-    const parquetOk = parquetBytes > PARQUET_FLOOR_BYTES;
-    const rowOk = rowCount > ROW_FLOOR;
+    const zipOk = zipBytes > zipFloor;
+    const parquetOk = parquetBytes > parquetFloor;
+    const rowOk = rowCount > rowFloor;
 
     if (zipOk && parquetOk && rowOk) {
         console.log(
-            `guard ok: zip=${zipBytes} bytes (>${ZIP_FLOOR_BYTES}), parquet=${parquetBytes} (>${PARQUET_FLOOR_BYTES}), rows=${rowCount} (>${ROW_FLOOR})`,
+            `guard ok: zip=${zipBytes} bytes (>${zipFloor}), parquet=${parquetBytes} (>${parquetFloor}), rows=${rowCount} (>${rowFloor})`,
         );
         return;
     }
@@ -126,13 +236,13 @@ export async function main(): Promise<void> {
     // G-04: Trip — build structured diff, write to file, exit 1.
     const diff = {
         zip_bytes: Number(zipBytes),
-        zip_floor: ZIP_FLOOR_BYTES,
+        zip_floor: zipFloor,
         zip_ok: zipOk,
         parquet_bytes: Number(parquetBytes),
-        parquet_floor: PARQUET_FLOOR_BYTES,
+        parquet_floor: parquetFloor,
         parquet_ok: parquetOk,
         row_count: Number(rowCount),
-        row_floor: Number(ROW_FLOOR),
+        row_floor: Number(rowFloor),
         row_ok: rowOk,
     };
 


### PR DESCRIPTION
Closes `salish-52s`. Found while verifying the pnpm migration; it reproduces identically under npm.

## The bug

`guard.ts` read its three floors into module-level `const`s **at import time**:

```ts
const ROW_FLOOR = BigInt(process.env['ROW_FLOOR'] ?? 1000);
```

`guard.test.ts` set `process.env.ROW_FLOOR = '9999999999'` inside the test body — long after the module was imported — so the override never landed. The guard ran against the default floor of 1,000.

It passed in CI anyway, for the wrong reason: `supabase/ci-seed.sql` seeds a handful of occurrences, already below 1,000. The assertion never exercised what it claimed. Against a realistically populated local `dwc` schema (27,391 rows) the guard didn't trip and the test failed outright.

## The fix

`main()` takes a `GuardFloors` argument defaulting to `floorsFromEnv()` — evaluated per call rather than at import, so the workflow's env vars still apply and tests can vary the floors.

It also now **rejects floors that would disable the guard**. The hazard isn't a wild value but an empty one: `Number('')` is `0` and `BigInt('')` is `0n`, so a workflow referencing an unset variable yields a floor of zero — and a zero floor passes everything. The guard would report `guard ok` for an empty archive, the one outcome it exists to prevent. Floors must be positive integers; disabling a floor isn't supported, precisely because it's indistinguishable from that misconfiguration.

Malformed `ROW_FLOOR` values are screened before `BigInt()`, which throws on `'1.5'` and `'abc'`. Previously those escaped as an opaque `SyntaxError` while a malformed `ZIP_FLOOR_BYTES` produced a clear message — bad asymmetry to hit when reading a nightly failure issue.

## Mutation testing

The real measure. Failures **with no DSN set**, where the old suite caught nothing:

| Mutation | tests failed |
|---|---|
| `floors` argument ignored | **6** (was 0) |
| row check removed (`rowOk = true`) | **4** |
| floor validation removed | **5** |
| zip check removed | **3** |
| row floor made inclusive (`>` → `>=`) | **2** |
| floors frozen at import | **2** |

The "floors argument ignored" row is why the reviewer's catch mattered: every always-run test originally passed floors *equal to the defaults*, so a `main()` that ignored its argument entirely still passed the whole suite without a DSN. Fixed with a non-default-floors test.

## Coverage changes

- The row floor was previously covered **only** by the DSN-gated test, so on a machine without a local database it wasn't covered at all. Now there's an always-run mocked case.
- Every call site passes floors explicitly, so a developer's ambient `ZIP_FLOOR_BYTES`/`PARQUET_FLOOR_BYTES` can no longer perturb the mocked size cases.
- The DSN-gated test keeps its real `ATTACH` + `COUNT` path — the only test that exercises it — but now passes an explicit floor above any plausible count, so it trips deterministically against both CI's fixture and a full local import, and asserts `row_count > 0` so a silently empty `ATTACH` would fail it.

371 tests pass with and without `SUPABASE_DB_URL` (356 before). CodeRabbit reviewed locally to 0 findings.

Refs: `salish-52s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for configured data-size and row-count limits.
  * Invalid or non-positive thresholds are rejected before database access.
  * Guard checks now consistently apply configured limits and produce structured results.
  * Invalid configurations clearly report that the guard did not run.
  * Expanded coverage for boundary conditions, custom settings, environment parsing, and database row counts.

* **Documentation**
  * Updated command-line usage documentation to use `pnpm exec`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->