### PR TITLE
Unify the Supabase CLI on 2.114.0 across CI and deploys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      # Both `db start` and `gen types` pull Supabase docker images; ghcr.io
+      # avoids public.ecr.aws's 1-pull/sec anonymous rate limit. This used to
+      # arrive as a setup-cli side effect (supabase/cli#5785).
+      SUPABASE_INTERNAL_IMAGE_REGISTRY: ghcr.io
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -37,10 +42,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520 # v3.0.0
-        with:
-          version: 2.53.6
-      - run: supabase db start
+      # The CLI is the `supabase` devDependency, so the database is started by
+      # the exact version that generates types below, traceable to package.json.
+      - run: pnpm exec supabase db start
       - name: Apply CI seed fixture
         run: psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -v ON_ERROR_STOP=1 -f supabase/ci-seed.sql
       - name: Verify generated types match Postgres schema

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,9 +119,12 @@ jobs:
           role-to-assume: arn:aws:iam::648183724555:role/salishsea-deploy-action
           aws-region: us-west-2
       - run: ls
+      # This job never installs the root node_modules, so the CLI comes from
+      # setup-cli rather than the `supabase` devDependency. With `version`
+      # omitted, the action installs the version declared in pnpm-lock.yaml
+      # (verifying npm integrity metadata), so prod (`db push`) and CI
+      # (build.yml) run the same CLI, pinned in one place.
       - uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520 # v3.0.0
-        with:
-          version: 2.53.6
       - run: supabase link --project-ref "${PROJECT_REF}"
         env:
           PROJECT_REF: ${{ vars.SUPABASE_PROJECT_ID }}

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "jsdom": "^29.0.2",
     "postgres": "^3.4.9",
     "size-limit": "^13.0.1",
-    "supabase": "^2.110.0",
+    "supabase": "^2.114.0",
     "supertest": "^7.2.2",
     "tsx": "^4.23.1",
     "type-fest": "^5.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
         specifier: ^13.0.1
         version: 13.0.1
       supabase:
-        specifier: ^2.110.0
-        version: 2.110.0
+        specifier: ^2.114.0
+        version: 2.114.0
       supertest:
         specifier: ^7.2.2
         version: 7.2.2
@@ -781,47 +781,47 @@ packages:
     resolution: {integrity: sha512-TQ5neTUDX2C2WmyYa03yGhLMkhdE/SkHXtK8/qxO/APUy3rsymsJCBP48p4jcN6iO2G0ow6RRexQd2mX+dSyJg==}
     engines: {node: '>=22.0.0'}
 
-  '@supabase/cli-darwin-arm64@2.110.0':
-    resolution: {integrity: sha512-VC+3vipRUtLrZKVYuxfRtP1gUPwUa+oZSeOJTRPSjLYN1FlnXIFcVDp/Xe21tZLYbVZBx3zJmy50OG2vTeNL3Q==}
+  '@supabase/cli-darwin-arm64@2.114.0':
+    resolution: {integrity: sha512-zdZA+hf8W2sMDQkWWJKYcgOS6AAMsc8oMTaspfYrga41paUqSvuXZ4uAhBaNm3DiNeJmQ0ddb9EaLo0lPxaQpw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@supabase/cli-darwin-x64@2.110.0':
-    resolution: {integrity: sha512-PtDmolyEXqm6hpsNOTBB15xWadhbFOelaKaxBTflk1TBJO1Hugrzw4xophbi8hg4vG9HXh4GNc7TY24BA93zqA==}
+  '@supabase/cli-darwin-x64@2.114.0':
+    resolution: {integrity: sha512-r89Go+y0IyBS+8pHsBZcs9s1W7xB8IL60k97INn0EYgPlE99Bgy7aZF+FQd+c1e3RAXLPS4/Znf7fheXKuNCtg==}
     cpu: [x64]
     os: [darwin]
 
-  '@supabase/cli-linux-arm64-musl@2.110.0':
-    resolution: {integrity: sha512-RyPgJr7hAdyhlxwUR36+s6P6rENupfN+meN+3+c/9XYT5cRwGuaJRnM4nsh9s1fs33lu7v22oy2N7IHZfgujew==}
+  '@supabase/cli-linux-arm64-musl@2.114.0':
+    resolution: {integrity: sha512-G5/97+h2CXzoK95jNlWY8CyOt+Zm0k3A9/d1r/jDYoB/y1P5cQmK1TYPPfI+ErWYQeoiQ6okfftAAg8bZEGqcA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@supabase/cli-linux-arm64@2.110.0':
-    resolution: {integrity: sha512-FHSVK7sR5quvAfDqwoA850ci3EP0hu6tjL1MDMWokkSwvILaHYp2AWq6jzZwa78dk+/SGeVPl8andkfyvH2qeg==}
+  '@supabase/cli-linux-arm64@2.114.0':
+    resolution: {integrity: sha512-vYFAP+gI6BOcwjZ+Zs9kpqtUt3KTE5kL56H65CTCdwRBJ/fXU+vCW3WvhLyFmKmJ8sDzjCvMcHwuhjKPbTmM7A==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@supabase/cli-linux-x64-musl@2.110.0':
-    resolution: {integrity: sha512-GLYhJhOhQmkkH3gygZy8x0VLmnGuLk0giSGAc19FtA12qfXdVsVeTiZWBzIEFvrJ4nK8NWqf0K4HIe2C4sBFqg==}
+  '@supabase/cli-linux-x64-musl@2.114.0':
+    resolution: {integrity: sha512-87e8MzkKZryXOsmMSbrS4b4jX95uPohS/AplJb2QWwTzLuOXZ+G60e0NR9tkuYYc7TIrDAHhFxcGaQweRIERug==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@supabase/cli-linux-x64@2.110.0':
-    resolution: {integrity: sha512-mShXx1+8yQfpxEzVyBxH8plbrHoXE/6j/8jIzQXmzuOFbVyaJzJU3HMmuEUsptcgwj/FpWoE1HrI77TmzWrJ/w==}
+  '@supabase/cli-linux-x64@2.114.0':
+    resolution: {integrity: sha512-MKgeafQEWYVKCtJgOgGJo1SqiKI4dd5eN460FbLOg01j1sYh7zGqhHk8WxF3enc4WeFQpVMpv147UyrOueHheg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@supabase/cli-windows-arm64@2.110.0':
-    resolution: {integrity: sha512-gLiQLv9geh3TV3t/uAd2GhNfLMJW/l8jyBclc2sPiljM5wosIKsxm8Uf9e97mgVVHgGLrRR1igXtru1YU+n8AQ==}
+  '@supabase/cli-windows-arm64@2.114.0':
+    resolution: {integrity: sha512-nhF/H5tPs0YsuKcdX5gGV6Ku7pFpSobXubt0y3rHfmR4itG6hhGE2We1hCyc7it0ozlDsA2NxOb1m9YlmY38+A==}
     cpu: [arm64]
     os: [win32]
 
-  '@supabase/cli-windows-x64@2.110.0':
-    resolution: {integrity: sha512-J4dXRahjAEQy3w0cTtJsvwCuoMY7OHAYPaR81Gxac0315HvSf+8Cf2cEpwAkUKpAhUpCE0pa1Gl3BrmKtd7qaw==}
+  '@supabase/cli-windows-x64@2.114.0':
+    resolution: {integrity: sha512-JtdgR9HvhgUxyd+GMpTECHCSFbAFP67/FJIWybYOVt5Qh6g4rqlLSWmT5zWFCQBSBw0dSw7xf2V3YB1+HESmiA==}
     cpu: [x64]
     os: [win32]
 
@@ -1773,8 +1773,8 @@ packages:
   strnum@2.4.1:
     resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
 
-  supabase@2.110.0:
-    resolution: {integrity: sha512-63QKsdLSVOFKTqABIAeOpg12daBZb9WYqc1NeMNimDP+gFGY8YsIh7VOJawUENXhIWWRlWNprHCOmafCc3LD7Q==}
+  supabase@2.114.0:
+    resolution: {integrity: sha512-JtCR+eDgVs2YtmZl5THdkaTeXex80lax+3V2SXRSuj280SWJPTIKxMLc82iDKjZlqXnt9zrGnJkrWb7DwHGPhQ==}
     hasBin: true
 
   superagent@10.3.0:
@@ -2566,28 +2566,28 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/cli-darwin-arm64@2.110.0':
+  '@supabase/cli-darwin-arm64@2.114.0':
     optional: true
 
-  '@supabase/cli-darwin-x64@2.110.0':
+  '@supabase/cli-darwin-x64@2.114.0':
     optional: true
 
-  '@supabase/cli-linux-arm64-musl@2.110.0':
+  '@supabase/cli-linux-arm64-musl@2.114.0':
     optional: true
 
-  '@supabase/cli-linux-arm64@2.110.0':
+  '@supabase/cli-linux-arm64@2.114.0':
     optional: true
 
-  '@supabase/cli-linux-x64-musl@2.110.0':
+  '@supabase/cli-linux-x64-musl@2.114.0':
     optional: true
 
-  '@supabase/cli-linux-x64@2.110.0':
+  '@supabase/cli-linux-x64@2.114.0':
     optional: true
 
-  '@supabase/cli-windows-arm64@2.110.0':
+  '@supabase/cli-windows-arm64@2.114.0':
     optional: true
 
-  '@supabase/cli-windows-x64@2.110.0':
+  '@supabase/cli-windows-x64@2.114.0':
     optional: true
 
   '@supabase/functions-js@2.110.8':
@@ -3476,19 +3476,19 @@ snapshots:
     dependencies:
       anynum: 1.0.1
 
-  supabase@2.110.0:
+  supabase@2.114.0:
     dependencies:
       eciesjs: 0.5.0
       jose: 6.2.5
     optionalDependencies:
-      '@supabase/cli-darwin-arm64': 2.110.0
-      '@supabase/cli-darwin-x64': 2.110.0
-      '@supabase/cli-linux-arm64': 2.110.0
-      '@supabase/cli-linux-arm64-musl': 2.110.0
-      '@supabase/cli-linux-x64': 2.110.0
-      '@supabase/cli-linux-x64-musl': 2.110.0
-      '@supabase/cli-windows-arm64': 2.110.0
-      '@supabase/cli-windows-x64': 2.110.0
+      '@supabase/cli-darwin-arm64': 2.114.0
+      '@supabase/cli-darwin-x64': 2.114.0
+      '@supabase/cli-linux-arm64': 2.114.0
+      '@supabase/cli-linux-arm64-musl': 2.114.0
+      '@supabase/cli-linux-x64': 2.114.0
+      '@supabase/cli-linux-x64-musl': 2.114.0
+      '@supabase/cli-windows-arm64': 2.114.0
+      '@supabase/cli-windows-x64': 2.114.0
 
   superagent@10.3.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,3 +20,13 @@ allowBuilds:
   # --frozen-lockfile` in every workflow. Every package with a build script must
   # appear here as either true or false. Flip to true if a config is ever added.
   exifreader: false
+minimumReleaseAgeExclude:
+  - '@supabase/cli-darwin-arm64@2.114.0'
+  - '@supabase/cli-darwin-x64@2.114.0'
+  - '@supabase/cli-linux-arm64-musl@2.114.0'
+  - '@supabase/cli-linux-arm64@2.114.0'
+  - '@supabase/cli-linux-x64-musl@2.114.0'
+  - '@supabase/cli-linux-x64@2.114.0'
+  - '@supabase/cli-windows-arm64@2.114.0'
+  - '@supabase/cli-windows-x64@2.114.0'
+  - supabase@2.114.0


### PR DESCRIPTION
CI ran two different Supabase CLI versions (beads salish-7od): build.yml started the database with setup-cli's pinned 2.53.6 while `gen-types` resolved the devDependency (2.110.0). This was what made the postgres-meta registry bug (salish-cr0's sibling) hard to see.

Changes:

- **package.json**: `supabase` devDependency bumped to ^2.114.0 (latest), lockfile regenerated. pnpm auto-added the release-age policy excludes to pnpm-workspace.yaml.
- **build.yml**: drops setup-cli entirely; `db start` now runs via `pnpm exec`, so the database is started by the exact CLI that generates types, traceable to package.json. `SUPABASE_INTERNAL_IMAGE_REGISTRY=ghcr.io` — previously a setup-cli side effect — is set explicitly at the job level.
- **deploy.yml**: keeps setup-cli (that job never installs the root node_modules) but omits `version`, which makes the v3 action resolve the version from pnpm-lock.yaml with npm integrity verification. One source of truth for both workflows.

Verified:

- 2.114.0 honours `SUPABASE_INTERNAL_IMAGE_REGISTRY` for `gen types` (supabase/cli#5785 is fixed) and `ghcr.io/supabase/postgres-meta:v0.97.0` is anonymously pullable (manifest probe returns 200).
- Types regenerated with 2.114.0 are byte-identical, so the drift gate is unaffected.
- 378 unit tests pass; actionlint clean; local CodeRabbit review clean (one earlier finding — setup-cli's lockfile resolution — is applied here).

Note for the merger: this bumps the CLI that runs `supabase link` / `functions deploy` / `db push` against production from 2.53.6 to 2.114.0.

Closes salish-7od.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the database tooling to a newer supported version.
  - Standardized build and deployment processes to use the project’s configured database CLI version.
  - Improved consistency between local development, automated builds, and deployments.
  - Adjusted release-age policy exceptions to support the updated tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->