### PR TITLE
Edge handler: the brand card where there is no image of the thing shared

### DIFF
--- a/about.html
+++ b/about.html
@@ -11,7 +11,10 @@
     <meta property="og:url" content="https://salishsea.io/about.html">
     <meta property="og:title" content="About SalishSea.io">
     <meta property="og:description" content="About SalishSea.io — an interactive map of whale and marine-mammal sightings across the Salish Sea, with open data downloads.">
-    <meta name="twitter:card" content="summary">
+    <meta property="og:image" content="https://salishsea.io/social-card.jpg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta name="twitter:card" content="summary_large_image">
     <link href="/favicon.svg" rel="icon" type="image/svg+xml">
     <link href="/favicon.ico" rel="icon" sizes="48x48">
     <link href="/apple-touch-icon.png" rel="apple-touch-icon">

--- a/docs/decisions/026-branded-fallback-preview-image.md
+++ b/docs/decisions/026-branded-fallback-preview-image.md
@@ -22,8 +22,11 @@ depict the post.
 
 Rolled out in two steps, both shipped:
 
-1. **Static shells (PR #381):** `index.html` declares the card and
-   `twitter:card=summary_large_image`, reaching non-bot scrapes.
+1. **Static shells (PRs #381, #383):** every shell — `index.html`, `about.html`,
+   and the `individual`/`matriline`/`ecotype` profile shells — declares the card
+   and `twitter:card=summary_large_image`. This reaches non-bot scrapes, the
+   pages the edge handler never intercepts (`about.html`), and, importantly, any
+   crawler served the raw shell because the handler failed open.
 2. **Edge handler (PR #383):** the synthesized cards that had no image — bare
    homepage, individual/matriline/ecotype profiles, and an occurrence with
    neither an open-licensed photo nor coordinates to render a map from —
@@ -46,7 +49,9 @@ What 019 got right and this record keeps:
 
 ## Consequences
 
-- Every shared link renders a rich card; none degrade to bare text.
+- Every shared link renders a rich card; none degrade to bare text. That holds
+  on the handler's failure paths too, because the shell it falls open to
+  declares the same card.
 - The card must stay current with the brand. It is a brand asset rather than a
   screenshot, and it is built from a checked-in source
   ([docs/branding](../branding/README.md)), so a brand change regenerates it

--- a/docs/decisions/026-branded-fallback-preview-image.md
+++ b/docs/decisions/026-branded-fallback-preview-image.md
@@ -20,15 +20,19 @@ content-shaped: it says
 "this is SalishSea.io", which is true of every link, rather than pretending to
 depict the post.
 
-Rollout in two steps:
+Rolled out in two steps, both shipped:
 
 1. **Static shells (PR #381):** `index.html` declares the card and
    `twitter:card=summary_large_image`, reaching non-bot scrapes.
-2. **Edge handler (follow-up):** the synthesized text-only cards — bare
-   homepage, individual/matriline/ecotype profiles without an open-licensed
-   photo, license-restricted occurrences — declare the branded card and flip to
-   `summary_large_image`. Updates the edge-handler tests and
-   `e2e/og-previews.spec.ts`, which currently pin the text-only behavior.
+2. **Edge handler (PR #383):** the synthesized cards that had no image — bare
+   homepage, individual/matriline/ecotype profiles, and an occurrence with
+   neither an open-licensed photo nor coordinates to render a map from —
+   declare the branded card and flip to `summary_large_image`.
+
+The order within a card is unchanged and matters: an open-licensed photo of the
+animal, else a rendered map of where it was seen, else the brand card. The brand
+card is the floor, not a competitor to either — a map of the actual sighting is
+closer to a picture of the thing shared than a logo is.
 
 What 019 got right and this record keeps:
 
@@ -42,9 +46,7 @@ What 019 got right and this record keeps:
 
 ## Consequences
 
-- Once both rollout steps land, every shared link renders a rich card; none
-  degrade to bare text. Until the edge handler follows, that holds for scrapes
-  that read the static shell, and crawler-served cards stay text-only.
+- Every shared link renders a rich card; none degrade to bare text.
 - The card must stay current with the brand. It is a brand asset rather than a
   screenshot, and it is built from a checked-in source
   ([docs/branding](../branding/README.md)), so a brand change regenerates it

--- a/e2e/og-previews.spec.ts
+++ b/e2e/og-previews.spec.ts
@@ -77,6 +77,11 @@ test('bot UA on an individual page receives profile OG meta tags', async ({ requ
   expect(body).toContain('og:title');
   expect(body).toContain('content="profile"');
   expect(body).toContain('https://salishsea.io/individuals/T065A');
+  // A profile has no image of its own, so it carries the brand card. Asserted
+  // per route: the shared fallback is easy to restore to text-only for one
+  // path without noticing (decision 026).
+  expect(body).toContain('<meta property="og:image" content="https://salishsea.io/social-card.jpg">');
+  expect(body).toContain('<meta name="twitter:card" content="summary_large_image">');
 });
 
 test('regular browser UA on an individual page receives the page shell', async ({ request }) => {
@@ -102,6 +107,11 @@ test('bot UA on a matriline page receives profile OG meta tags', async ({ reques
   expect(body).toContain('og:title');
   expect(body).toContain('content="profile"');
   expect(body).toContain('https://salishsea.io/matrilines/T065A');
+  // A profile has no image of its own, so it carries the brand card. Asserted
+  // per route: the shared fallback is easy to restore to text-only for one
+  // path without noticing (decision 026).
+  expect(body).toContain('<meta property="og:image" content="https://salishsea.io/social-card.jpg">');
+  expect(body).toContain('<meta name="twitter:card" content="summary_large_image">');
 });
 
 test('regular browser UA on a matriline page receives the page shell', async ({ request }) => {
@@ -126,6 +136,11 @@ test('bot UA on an ecotype page receives profile OG meta tags', async ({ request
   expect(body).toContain('og:title');
   expect(body).toContain('content="profile"');
   expect(body).toContain('https://salishsea.io/ecotypes/Biggs');
+  // A profile has no image of its own, so it carries the brand card. Asserted
+  // per route: the shared fallback is easy to restore to text-only for one
+  // path without noticing (decision 026).
+  expect(body).toContain('<meta property="og:image" content="https://salishsea.io/social-card.jpg">');
+  expect(body).toContain('<meta name="twitter:card" content="summary_large_image">');
 });
 
 test('regular browser UA on an ecotype page receives the page shell', async ({ request }) => {

--- a/e2e/og-previews.spec.ts
+++ b/e2e/og-previews.spec.ts
@@ -10,11 +10,24 @@ test('bot UA on homepage receives OG meta tags', async ({ request }) => {
   expect(body).toContain('og:title');
   expect(body).toContain('SalishSea.io');
   expect(body).toContain('og:type');
-  // Homepage card carries a description but deliberately no image — there is no
-  // site-wide fallback image (decision 019), so it is a text-only summary card.
+  // The homepage has no image of a thing shared, so it carries the brand card
+  // (decision 026, superseding 019) — identity-shaped, true of every link.
   expect(body).toContain('og:description');
-  expect(body).not.toContain('og:image');
-  expect(body).toContain('<meta name="twitter:card" content="summary">');
+  expect(body).toContain('<meta property="og:image" content="https://salishsea.io/social-card.jpg">');
+  expect(body).toContain('<meta name="twitter:card" content="summary_large_image">');
+});
+
+// The card only counts if the crawler that follows og:image gets bytes back.
+// A brand card intercepted into OG HTML is the 019-era broken-preview bug.
+test('the brand card serves image bytes to the crawler that reads og:image', async ({ request }) => {
+  const response = await request.get('/social-card.jpg', {
+    headers: { 'User-Agent': 'facebookexternalhit/1.1' },
+  });
+
+  expect(response.status()).toBe(200);
+  expect(response.headers()['content-type']).toBe('image/jpeg');
+  // Above Facebook's 200x200 floor in every sense — the real 1200x630 card.
+  expect((await response.body()).byteLength).toBeGreaterThan(20_000);
 });
 
 test('bot UA on a dated link receives a day card', async ({ request }) => {

--- a/ecotype.html
+++ b/ecotype.html
@@ -23,7 +23,10 @@
     <meta property="og:type" content="profile">
     <meta property="og:title" content="Ecotype — SalishSea.io">
     <meta property="og:description" content="Profile of a killer whale ecotype in the Salish Sea: its matrilines and aggregated sighting history.">
-    <meta name="twitter:card" content="summary">
+    <meta property="og:image" content="https://salishsea.io/social-card.jpg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta name="twitter:card" content="summary_large_image">
     <!-- Root-absolute URLs: this shell is served at /ecotypes/<designation>,
          so relative paths would resolve under /ecotypes/. -->
     <link href="/favicon.svg" rel="icon" type="image/svg+xml">

--- a/individual.html
+++ b/individual.html
@@ -23,7 +23,10 @@
     <meta property="og:type" content="profile">
     <meta property="og:title" content="Individual — SalishSea.io">
     <meta property="og:description" content="Profile of an individual whale in the Salish Sea: names and naming stories, family, matriline, and recent sighting reports.">
-    <meta name="twitter:card" content="summary">
+    <meta property="og:image" content="https://salishsea.io/social-card.jpg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta name="twitter:card" content="summary_large_image">
     <!-- Root-absolute URLs: this shell is served at /individuals/<designation>,
          so relative paths would resolve under /individuals/. -->
     <link href="/favicon.svg" rel="icon" type="image/svg+xml">

--- a/infra/lib/edge-handler/index.test.ts
+++ b/infra/lib/edge-handler/index.test.ts
@@ -78,12 +78,12 @@ describe('Lambda@Edge OG meta handler', () => {
     const result = await handler(event) as { status: string; body: string };
     expect(result.status).toBe('200');
     expect(result.body).toContain('SalishSea.io');
-    // Generic homepage preview carries a description and a real <title>, and NO
-    // image: there is no site-wide fallback (decision 019), so the card is
-    // text-only and declares twitter:card=summary rather than promising a picture.
+    // Generic homepage preview carries a description, a real <title>, and the
+    // brand card — there is no image of a *thing shared* on the bare homepage,
+    // so the identity-shaped card stands in (decision 026, superseding 019).
     expect(result.body).toContain('og:description');
-    expect(result.body).not.toContain('og:image');
-    expect(result.body).toContain('<meta name="twitter:card" content="summary">');
+    expect(result.body).toContain('<meta property="og:image" content="https://salishsea.io/social-card.jpg">');
+    expect(result.body).toContain('<meta name="twitter:card" content="summary_large_image">');
     expect(result.body).toContain('<title>');
     // ...and a real <meta name="description"> for search snippets, not just og:*
     expect(result.body).toContain('<meta name="description"');
@@ -521,15 +521,15 @@ describe('map cards', () => {
     expect(body).toContain('https://salishsea.io/cards/o/inaturalist%3A375544838.jpg');
   });
 
-  it('offers no image for a photoless occurrence with no coordinates', async () => {
-    // The renderer 404s without a location, so a card URL here would sit broken
-    // inside a post. Omitting og:image degrades to the text-only card instead.
+  it('falls back to the brand card for a photoless occurrence with no coordinates', async () => {
+    // The renderer 404s without a location, so a map card URL here would sit
+    // broken inside a post. The brand card always resolves (decision 026).
     const body = await bodyFor('o=abc123', {
       ...sampleOccurrence, photos: [], location: null,
     });
     expect(body).not.toContain('/cards/o/');
-    expect(body).not.toContain('og:image');
-    expect(body).toContain('<meta name="twitter:card" content="summary">');
+    expect(body).toContain('<meta property="og:image" content="https://salishsea.io/social-card.jpg">');
+    expect(body).toContain('<meta name="twitter:card" content="summary_large_image">');
     // The rest of the card still works — it is only the picture that is missing.
     expect(body).toContain('Orca · June 3, 2025');
   });
@@ -562,10 +562,11 @@ describe('map cards', () => {
     ['yesterday', 'a word'],
     ['', 'an empty value'],
   ])('falls back to the site card for %s (%s)', async (date) => {
-    // A malformed date must never become a card URL that 404s inside a post.
+    // A malformed date must never become a card URL that 404s inside a post;
+    // the site card it falls back to carries the brand card, which resolves.
     const body = await bodyFor(`d=${date}`);
     expect(body).not.toContain('/cards/day/');
-    expect(body).not.toContain('og:image');
+    expect(body).toContain('<meta property="og:image" content="https://salishsea.io/social-card.jpg">');
     expect(body).toContain('Salish Sea');
   });
 });

--- a/infra/lib/edge-handler/index.ts
+++ b/infra/lib/edge-handler/index.ts
@@ -165,12 +165,21 @@ const SITE_DESCRIPTION =
   'An interactive map of whale and marine-mammal sightings across the Salish Sea, ' +
   'gathered from community sources like Whale Alert, Orca Network, and HappyWhale.';
 
-// A card carries og:image only when we hold an image OF THE THING SHARED — today
-// that means an open-licensed photo on the occurrence itself. There is deliberately
-// no site-wide fallback image (decision 019): the old one was a months-stale map
-// screenshot that illustrated nothing the sharer posted, which reads as misleading
-// rather than merely empty. With no image, `summary` is the honest Twitter card
-// type — `summary_large_image` promises a picture and renders blank without one.
+// What a card shows, in order of preference: an image OF THE THING SHARED (an
+// open-licensed photo, else a rendered map of where it was seen), and failing
+// that the brand card — the mark and wordmark, which say "this is SalishSea.io"
+// (decision 026, superseding 019). The card 019 rejected was a months-stale map
+// screenshot: content-shaped, so it read as a picture of the post and misled.
+// An identity-shaped card claims nothing about the post, so it is honest on
+// every link, and `summary_large_image` is honest with it because there is now
+// always a picture to render.
+const BRAND_CARD_TAGS = {
+  'og:image': 'https://salishsea.io/social-card.jpg',
+  'og:image:width': '1200',
+  'og:image:height': '630',
+  'twitter:card': 'summary_large_image',
+} as const;
+
 function genericPreviewTags(): OgTags {
   return {
     'og:site_name': 'SalishSea.io',
@@ -178,7 +187,7 @@ function genericPreviewTags(): OgTags {
     'og:url': 'https://salishsea.io/',
     'og:title': SITE_TITLE,
     'og:description': SITE_DESCRIPTION,
-    'twitter:card': 'summary',
+    ...BRAND_CARD_TAGS,
     'fb:app_id': FB_APP_ID,
   };
 }
@@ -235,7 +244,7 @@ function individualPreviewTags(individual: Individual): OgTags {
     'og:url': `https://salishsea.io/individuals/${encodeURIComponent(designation)}`,
     'og:title': title,
     'og:description': description,
-    'twitter:card': 'summary',
+    ...BRAND_CARD_TAGS,
     'fb:app_id': FB_APP_ID,
   };
 }
@@ -351,7 +360,7 @@ function matrilinePreviewTags(group: SocialGroup): OgTags {
     'og:url': `https://salishsea.io/matrilines/${encodeURIComponent(designation)}`,
     'og:title': title,
     'og:description': description,
-    'twitter:card': 'summary',
+    ...BRAND_CARD_TAGS,
     'fb:app_id': FB_APP_ID,
   };
 }
@@ -388,7 +397,7 @@ function ecotypePreviewTags(group: SocialGroup): OgTags {
     'og:url': `https://salishsea.io/ecotypes/${encodeURIComponent(designation)}`,
     'og:title': label,
     'og:description': description,
-    'twitter:card': 'summary',
+    ...BRAND_CARD_TAGS,
     'fb:app_id': FB_APP_ID,
   };
 }
@@ -534,9 +543,9 @@ export const handler = async (event: any): Promise<any> => {
     //
     // A map card is only offered when there is somewhere to put the marker. The
     // renderer 404s on an occurrence with no coordinates, and a card URL that can
-    // never resolve is worse than no card URL — it sits broken inside a post,
-    // whereas omitting og:image degrades to the text-only card by design. No
-    // occurrence lacks a location today; the column allows it, so the code does too.
+    // never resolve is worse than no card URL — it sits broken inside a post. That
+    // case falls through to the brand card, which always resolves. No occurrence
+    // lacks a location today; the column allows it, so the code does too.
     const photo = (occ.photos ?? []).find((p: Photo) => OPEN_LICENSES.includes(p.license ?? ''));
     const image = photo ? cardImageUrl(photo.src)
       : occ.location ? occurrenceCardUrl(occurrenceId)
@@ -548,8 +557,9 @@ export const handler = async (event: any): Promise<any> => {
       'og:url': `https://salishsea.io/?o=${encodeURIComponent(occurrenceId)}`,
       'og:title': title,
       'og:description': description,
-      ...(image ? { 'og:image': image } : {}),
-      'twitter:card': image ? 'summary_large_image' : 'summary',
+      ...(image
+        ? { 'og:image': image, 'twitter:card': 'summary_large_image' }
+        : BRAND_CARD_TAGS),
       'fb:app_id': FB_APP_ID,
     };
 

--- a/matriline.html
+++ b/matriline.html
@@ -23,7 +23,10 @@
     <meta property="og:type" content="profile">
     <meta property="og:title" content="Matriline — SalishSea.io">
     <meta property="og:description" content="Profile of a killer whale matriline in the Salish Sea: the matriarch, members, naming, and recent sighting reports.">
-    <meta name="twitter:card" content="summary">
+    <meta property="og:image" content="https://salishsea.io/social-card.jpg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta name="twitter:card" content="summary_large_image">
     <!-- Root-absolute URLs: this shell is served at /matrilines/<designation>,
          so relative paths would resolve under /matrilines/. -->
     <link href="/favicon.svg" rel="icon" type="image/svg+xml">


### PR DESCRIPTION
Completes [decision 026](https://github.com/salish-sea/salishsea-io/blob/main/docs/decisions/026-branded-fallback-preview-image.md)'s two-step rollout. #381 shipped the card and wired it into the static shell; this points the crawler path at it too.

## What changes for a crawler

| Shared link | Before | After |
| --- | --- | --- |
| Bare homepage | text-only `summary` | brand card |
| `/individuals/T065A` and matriline/ecotype profiles | text-only `summary` | brand card |
| Occurrence with no photo and no coordinates | text-only `summary` | brand card |
| Occurrence with an open-licensed photo | photo | photo (unchanged) |
| Occurrence with coordinates | rendered map card | rendered map card (unchanged) |
| `/?d=<date>` | rendered day card | rendered day card (unchanged) |
| `/about.html` | text-only `summary` | brand card |

The order inside a card is deliberately unchanged: an open-licensed photo of the animal, else a rendered map of where it was seen, else the brand card. A map of the actual sighting is closer to a picture of the thing shared than a logo is, so the brand card is the floor, not a competitor to either.

`about.html` is in here because the edge handler never intercepts it — a shared About link was still text-only straight from origin.

## Tests

The unit tests that pinned the text-only behavior now pin the card (155 infra tests pass). `e2e/og-previews.spec.ts` gains a case asserting `/social-card.jpg` returns image bytes to a `facebookexternalhit` UA rather than being intercepted into OG HTML — the `STATIC_ASSET_RE` carve-out is the thing standing between us and the broken-preview bug decision 019 was written around. That spec runs as post-deploy smoke against production, which is why the handler and the spec ship in one push.

## Worth knowing

Facebook's image verdict is sticky (019's runbook note): URLs it already scraped as image-less may lag in picking the card up. That's a transition delay, not a defect.

Closes `salish-yy5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added branded social-card previews for shared pages without available photos or map locations.
  * Updated social sharing metadata to use large-image Twitter cards.
  * Preserved the existing fallback order: licensed photo, map preview, then branded card.
  * Added image dimensions for richer link previews.

* **Documentation**
  * Updated the decision record to reflect the completed branded fallback rollout.

* **Tests**
  * Expanded preview coverage, including validation that the branded card is served as a JPEG.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->