### PR TITLE
Decision 028: SalishSea.io is the single voice speaking to OrcaSound

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ Use `bd worktree create <name>`, not `git worktree add` — it shares the main r
 Two rules that survive the isolation, because worktrees separate files and nothing else:
 
 - **The local Supabase stack is a singleton** on port 54321. Only one worktree at a time runs anything that touches it (`pnpm build:dwca`, `pnpm gen-types`, `scripts/dwca/build.test.ts`).
-- **Commit a new file as soon as it exists**, even as a stub. A tracked file's edits can be swept up by another agent's `git add -A`; an untracked file cannot — which is precisely how the two halves of a change get separated.
+- **Commit a new file as soon as it exists**, even as a stub. In a shared directory, a tracked file's edits get swept up by another agent's `git add -A` while an untracked file doesn't, which is precisely how the two halves of a change separate. In a worktree the risk inverts rather than disappears: nothing else can touch your files, and uncommitted work is discarded outright when the worktree is cleaned up.
 
 ## Architecture Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,20 @@ pnpm exec playwright test  # e2e
 
 Node version is pinned in `.nvmrc`. The DwC-A build's CI gate needs the Supabase local stack (not bare Postgres) — see [decision 003](docs/decisions/003-dwc-export-pipeline.md).
 
+## Parallel agents
+
+**More than one agent at a time means one worktree each.** Sharing a working directory is how uncommitted work gets swept into someone else's commit — on 2026-08-13 a decision record's index row and forward pointer landed in an unrelated PR while the record itself, being untracked, stayed behind, leaving two dangling links on `main`.
+
+Use `bd worktree create <name>`, not `git worktree add` — it shares the main repo's beads database via git's common directory, so the issue tracker stays single. Then, before working:
+
+- **Copy `.env` and `.env.test` in.** Both are gitignored, so a fresh worktree has neither, and the resulting failures look like code problems.
+- **`pnpm install` in the worktree, and again in `infra/`** — a separate pnpm project with its own lockfile. Cheap: pnpm's global store hardlinks rather than copies.
+
+Two rules that survive the isolation, because worktrees separate files and nothing else:
+
+- **The local Supabase stack is a singleton** on port 54321. Only one worktree at a time runs anything that touches it (`pnpm build:dwca`, `pnpm gen-types`, `scripts/dwca/build.test.ts`).
+- **Commit a new file as soon as it exists**, even as a stub. A tracked file's edits can be swept up by another agent's `git add -A`; an untracked file cannot — which is precisely how the two halves of a change get separated.
+
 ## Architecture Overview
 
 Static SPA (Lit web components + Vite + TypeScript, OpenLayers maps) on AWS S3/CloudFront, Supabase backend (Postgres + auth + storage), AWS CDK infra in `infra/`, deployed by GitHub Actions on push to `main`. A Lambda@Edge function serves OG meta tags to crawlers for rich link previews and rewrites `/individuals/<designation>` profile-page paths to the `individual.html` shell (fail-open; `/dwca/*` carved out; decision 015). A nightly workflow regenerates the DarwinCore Archive from the read-only `dwc` Postgres schema. Details: [docs/decisions/](docs/decisions/), [docs/data-provenance.md](docs/data-provenance.md).

--- a/docs/decisions/028-salishsea-io-speaks-to-orcasound.md
+++ b/docs/decisions/028-salishsea-io-speaks-to-orcasound.md
@@ -67,8 +67,14 @@ OrcaSound to adjudicate.
 
 - **orcasound/orcasite#1001 is this repository's issue to carry**, including the corrected
   cost estimate — it currently understates the ask as "only slug conventions and a
-  moderator habit", where the register's uncertainty requirement implies a schema change
-  (a `certainty` column on `item_tags`). Reposting it is tracked as `salish-8vr.2`.
+  moderator habit". Preserving a moderator's uncertainty ("J123?", "+L?") is a requirement
+  *this* repository makes as the owner of annotation, and it implies a schema change rather
+  than a convention. The register makes no such demand: ADR-0018 grants it exactly two
+  claims on an annotation — cite an identifier, and record the edition behind a derived
+  fact — and ADR-0009's five-column sketch is explicitly illustrative. Where the field
+  lands is ours to propose and OrcaSound's to decide; naming one here as though the
+  register mandated it would re-create the confusion this record exists to end. Reposting
+  is tracked as `salish-8vr.2`.
 - **The recommendation cannot be posted before the shape is settled here.** Q18's
   substance — the confidence/verification split, and allowing a signal recorded with no
   animal named (an occurrence with zero identifications) — has to land as an amendment to

--- a/docs/decisions/028-salishsea-io-speaks-to-orcasound.md
+++ b/docs/decisions/028-salishsea-io-speaks-to-orcasound.md
@@ -1,0 +1,97 @@
+# 028 — SalishSea.io is the single voice recommending an identification schema to OrcaSound
+
+**Status:** accepted · **Decided:** 2026-08-13 · **Answers:** the closing open question of [animals ADR-0018](https://github.com/salish-sea/animals/blob/main/decisions/0018-annotation-semantics-belong-to-consumers.md)
+
+## Context
+
+Two repositories in the salish-sea org have a stake in how OrcaSound records what a
+moderator heard:
+
+- **[salish-sea/animals](https://github.com/salish-sea/animals)** — the register. It owns
+  *identity*: which animals and social groups exist, what they are called, and how they
+  nest. Its identifiers are what a tag would have to cite.
+- **this repository** — the aggregator. It owns *annotation*: what an occurrence is and how
+  a claim about which animals were present is recorded — evidence, method, confidence,
+  verification state, presence/absence. `public.identifications` has shipped with data in
+  it; decision [013](013-orcasound-acoustic-occurrences.md) defines an acoustic occurrence
+  as one curated biophony bout identified by structured upstream tags.
+
+OrcaSound ([orcasound/orcasite](https://github.com/orcasound/orcasite)) is external to
+both. Neither repository decides its schema; the most either can do is publish a
+recommendation — [orcasound/orcasite#1001](https://github.com/orcasound/orcasite/issues/1001).
+ADR-0018 closed by naming the risk and leaving it open: *"Two projects independently telling
+a third what its annotation schema should be is worse than one."*
+
+## Decision
+
+**SalishSea.io writes and posts the recommendation. The register does not address OrcaSound
+directly on annotation.**
+
+Because SalishSea.io is the **consumer of the occurrence records orcasite emits**. The
+recommendation asks orcasite to change what it publishes; the party qualified to make that
+ask is the one that reads the output and can say concretely what breaks without it —
+which bouts become unusable, which identifications land as `candidate` instead of dropped,
+what the free-text fallback costs. The register has no consumer and no annotation data, so
+its version of the same ask would be a shape argued from first principles rather than a
+requirement traced to a downstream failure.
+
+This is the same split ADR-0018 already made, carried one step further: annotation
+semantics live here, and so does the mouth that speaks them.
+
+The register's identifiers still travel in the recommendation — that is most of its
+substance — but they travel **cited by the consumer**, the way any other upstream
+dependency does. Where the register wants something (an identifier rather than a name; a
+derived fact recording its edition), it states it as a requirement in its own ADRs and this
+repository carries it into #1001 in a form OrcaSound can implement. If the recommendation
+and the register disagree, that is a bug to fix here before posting, not two positions for
+OrcaSound to adjudicate.
+
+## Rejected alternatives
+
+- **The register speaks.** It is where the tag vocabulary's terms come from, and it is the
+  more formally reviewed repository. But it would be recommending an annotation schema it
+  has explicitly disclaimed owning four times over — reintroducing exactly the confusion
+  ADR-0018 exists to end, and inviting a reader to implement from ADR-0009's illustrative
+  five-column table.
+- **Both, on their own topics** — the register on identifiers, SalishSea.io on annotation
+  columns. Clean in theory, unworkable in practice: a tag slug *is* both at once, and
+  splitting the ask across two issue threads in two voices leaves OrcaSound reconciling
+  them. One recommendation with one author is the whole point.
+- **A joint statement from the salish-sea org.** No worse in substance, but it invents a
+  publishing venue with no status field, no supersession, and no owner — the objection
+  ADR-0018 already sustained against moving contested design into discussions.
+- **Say nothing and parse the bout `name` downstream.** Already rejected in 013 as fragile
+  and lossy. Nothing here revisits it.
+
+## Consequences
+
+- **orcasound/orcasite#1001 is this repository's issue to carry**, including the corrected
+  cost estimate — it currently understates the ask as "only slug conventions and a
+  moderator habit", where the register's uncertainty requirement implies a schema change
+  (a `certainty` column on `item_tags`). Reposting it is tracked as `salish-8vr.2`.
+- **The recommendation cannot be posted before the shape is settled here.** Q18's
+  substance — the confidence/verification split, and allowing a signal recorded with no
+  animal named (an occurrence with zero identifications) — has to land as an amendment to
+  013 or a successor first (`salish-8vr.4`). Speaking with one voice only helps if the
+  voice has something coherent to say.
+- **Register changes reach OrcaSound through here.** A new entity kind, a renamed label, or
+  a deprecation does not become an upstream ask on its own; it lands in
+  [docs/design-notes/occurrence-identification-findings.md](../design-notes/occurrence-identification-findings.md),
+  gets decided in `docs/decisions/`, and is carried into #1001 if it changes what we ask of
+  orcasite.
+- **This adds a hop for the register.** Accepted: the alternative is two authors, and in
+  practice both hats are worn by the same person, which is precisely why the boundary needs
+  to be written down rather than remembered.
+- OrcaSound remains free to ignore all of it. 013's "pending upstream adoption" status is
+  unchanged by this record.
+
+## Reference
+
+Register-side context: [animals ADR-0018](https://github.com/salish-sea/animals/blob/main/decisions/0018-annotation-semantics-belong-to-consumers.md)
+(annotation belongs to consumers), [ADR-0009](https://github.com/salish-sea/animals/blob/main/decisions/0009-uncertainty-on-the-annotation.md)
+(no hedge terms in the vocabulary), [ADR-0011](https://github.com/salish-sea/animals/blob/main/decisions/0011-label-is-a-preferred-name.md)
+(a label is a preferred name), [ADR-0012](https://github.com/salish-sea/animals/blob/main/decisions/0012-relationship-to-the-salishsea-io-catalogue.md)
+(register ↔ catalogue). Our side: [013](013-orcasound-acoustic-occurrences.md),
+[docs/design-notes/occurrence-identification-findings.md](../design-notes/occurrence-identification-findings.md).
+Upstream: [orcasound/orcasite#1001](https://github.com/orcasound/orcasite/issues/1001).
+Epic: `salish-8vr`.


### PR DESCRIPTION
Two docs commits from one session, related by the incident in the middle.

## Decision 028

Resolves which repository issues the tag/identification recommendation in [orcasound/orcasite#1001](https://github.com/orcasound/orcasite/issues/1001): **SalishSea.io**, because it consumes the occurrence records orcasite emits and can therefore trace the ask to a concrete downstream failure — which bouts become unusable, what the free-text fallback costs. The animal register owns identity and speaks through the consumer rather than alongside it.

This answers the closing open question of [animals ADR-0018](https://github.com/salish-sea/animals/blob/main/decisions/0018-annotation-semantics-belong-to-consumers.md): *"Two projects independently telling a third what its annotation schema should be is worse than one."*

**This file should have been in #386.** That PR carried the index row in `docs/decisions/README.md` and the forward pointer in `013`, but not the record they reference — so `main` has been advertising a decision record that doesn't exist. This is the missing half; the dangling links resolve when it lands.

## Parallel-agent guidance in CLAUDE.md

The same near-miss, written down. Concurrent agents in one working directory is how uncommitted work gets swept into an unrelated commit: a tracked file's edits ride along with someone else's `git add -A`, an untracked file doesn't, and the two halves of a change separate silently.

Records one worktree per agent, `bd worktree create` over `git worktree add` (it shares the main repo's beads database via git's common directory, keeping the tracker single), and the three things worktrees don't solve on their own — the gitignored `.env`/`.env.test`, the second pnpm project in `infra/`, and the singleton Supabase stack on 54321.

Docs only; no code, schema, or config touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for coordinating parallel development work, including environment setup and worktree isolation.
  * Documented the decision for SalishSea.io to provide the identification-schema recommendation to OrcaSound.
  * Clarified ownership, annotation requirements, recommendation timing, and how related register changes are propagated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->