### PR TITLE
Bump nanoid to 3.3.18 (CVE-2026-67213)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1574,8 +1574,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3281,7 +3281,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   nanospinner@1.2.2:
     dependencies:
@@ -3359,7 +3359,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
Closes Dependabot alert [#156](https://github.com/salish-sea/salishsea-io/security/dependabot/156) (high).

`nanoid@3.3.17` → `3.3.18`, transitive via `postcss` ← `vite`. Flagged high because `vite` sits in `dependencies` rather than `devDependencies`, so the scope reads as runtime.

The advisory ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)) is an infinite loop when a *custom* generator is called with size zero. Nothing here does that — postcss mints ids internally and never exposes the generator — so real exposure is nil. Bumping anyway because the fix is a single lockfile line inside postcss's existing `^3.3.x` range: no override, no dependency change, nothing to trade off.

`pnpm build` passes (tsc, vite build, html-validate, CSP hash verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)