### PR TITLE
Amend decision 013: identifications arrive typed, not as tag slugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ e2e/screenshots
 
 # Private strategy notes — the honest version of the uptake stall; not for the public repo.
 docs/strategy/private-notes.md
+.beads.gate.lock

--- a/docs/decisions/013-orcasound-acoustic-occurrences.md
+++ b/docs/decisions/013-orcasound-acoustic-occurrences.md
@@ -74,11 +74,19 @@ the tags carried identifiers — see the [Amendment](#amendment-2026-08-14).
 
 ## Consequences
 
-- **Blocked on upstream.** The integration's value depends on OrcaSound adopting the tag
-  vocabulary (orcasound/orcasite#1001). #178 is parked at `needs-info` pending that response,
-  which may not come. This ADR records *our* side of the decision; the upstream contract is not
-  yet ratified. *(Still true 2026-08-14, but no longer one all-or-nothing answer — the ask is
-  now six issues that can be accepted separately. See the Amendment.)*
+- **Blocked on upstream, but no longer on one answer.** The integration depends on OrcaSound
+  adopting the changes that let a tag carry identity, certainty and machine classification —
+  now six issues that can each be accepted separately, listed under
+  [Upstream status](#upstream-status) in the Amendment. orcasound/orcasite#1001 is retained as
+  the narrative that links them, not as the ask itself. #178 stays parked at `needs-info`. This
+  ADR records *our* side; the upstream contract is not ratified, and OrcaSound may adopt some,
+  all, or none of it.
+
+  > ~~The integration's value depends on OrcaSound adopting the tag vocabulary
+  > (orcasound/orcasite#1001). #178 is parked at `needs-info` pending that response, which may
+  > not come.~~ *Superseded 2026-08-14: the vocabulary already exists and was never the ask —
+  > see the Amendment. Kept because "waiting for one response" is what this record wrongly told
+  > a reader to do for five weeks.*
 - Acoustic occurrences carry a **time range, not an instant** — new for our model, which is
   otherwise point-in-time. Segment/travel-chain heuristics and any DwC mapping must account for
   a bout's duration.

--- a/docs/decisions/013-orcasound-acoustic-occurrences.md
+++ b/docs/decisions/013-orcasound-acoustic-occurrences.md
@@ -1,6 +1,8 @@
 # 013 — OrcaSound acoustic occurrences come from curated biophony bouts, identified by upstream tags
 
-**Status:** accepted (our side) · **pending upstream adoption** · **Decided:** 2026-07-06
+**Status:** accepted (our side) · **pending upstream adoption** · **Decided:** 2026-07-06 ·
+**Amended:** 2026-08-14 (see [Amendment](#amendment-2026-08-14) — identifications arrive
+typed, and the upstream ask is a schema change)
 
 ## Context
 
@@ -34,18 +36,24 @@ bout's `feed` coordinates, spanning the bout's `start_time`/`end_time`. `anthrop
 `geophony` bouts are excluded (not organisms), as are raw detections and candidates.
 
 A bout's **species / ecotype / pod / matriline** is read from **structured upstream tags**, not
-parsed from the free-text `name`. We asked OrcaSound (orcasound/orcasite#1001) to apply a
-controlled tag vocabulary to bouts (`ecotype:srkw`, `pod:j`, `matriline:t090`,
-`species:humpback`, `unconfirmed`/`false-positive`, …). Bouts already expose a `tags`
-relationship on the JSON:API (`Bout` `includes [:feed, :tags]`), so consuming it needs no
-upstream schema change — only slug conventions and moderator habit.
+parsed from the free-text `name`.
+
+> ~~We asked OrcaSound (orcasound/orcasite#1001) to apply a controlled tag vocabulary to bouts
+> (`ecotype:srkw`, `pod:j`, `matriline:t090`, `species:humpback`, `unconfirmed`/`false-positive`,
+> …). Bouts already expose a `tags` relationship on the JSON:API (`Bout` `includes [:feed,
+> :tags]`), so consuming it needs no upstream schema change — only slug conventions and
+> moderator habit.~~
+>
+> *Retracted 2026-08-14. The vocabulary was not ours to invent and the cost was understated;
+> both halves are corrected in the [Amendment](#amendment-2026-08-14) below, and the retraction
+> is public in orcasound/orcasite#1001.*
 
 Ingest follows the established pattern: mirror bouts + their tags **verbatim** into an
-`orcasound` upstream-mirror schema, then **translate** tag slugs into our taxon + candidate
-identifiers at the boundary (decision [008](008-source-schemas-are-upstream-mirrors.md)),
-within the imperative-shell ingest architecture (decision
-[011](011-ingest-imperative-shell.md)). OrcaSound is already modeled as a **Collection** with
-`collection_kind = acoustic_feed`.
+`orcasound` upstream-mirror schema, then **translate** at the boundary (decision
+[008](008-source-schemas-are-upstream-mirrors.md)), within the imperative-shell ingest
+architecture (decision [011](011-ingest-imperative-shell.md)). OrcaSound is already modeled as
+a **Collection** with `collection_kind = acoustic_feed`. What "translate" means changed once
+the tags carried identifiers — see the [Amendment](#amendment-2026-08-14).
 
 ## Rejected alternatives
 
@@ -69,7 +77,8 @@ within the imperative-shell ingest architecture (decision
 - **Blocked on upstream.** The integration's value depends on OrcaSound adopting the tag
   vocabulary (orcasound/orcasite#1001). #178 is parked at `needs-info` pending that response,
   which may not come. This ADR records *our* side of the decision; the upstream contract is not
-  yet ratified.
+  yet ratified. *(Still true 2026-08-14, but no longer one all-or-nothing answer — the ask is
+  now six issues that can be accepted separately. See the Amendment.)*
 - Acoustic occurrences carry a **time range, not an instant** — new for our model, which is
   otherwise point-in-time. Segment/travel-chain heuristics and any DwC mapping must account for
   a bout's duration.
@@ -78,6 +87,117 @@ within the imperative-shell ingest architecture (decision
   [004](004-rights-and-licensing.md), [docs/rights-policy.md](../rights-policy.md)).
 - Volume is thin and currently declining; even a clean integration adds only a few occurrences
   per month until OrcaSound's curation cadence recovers.
+
+## Amendment (2026-08-14)
+
+Three things this record got wrong, and one that changed underneath it. The core decision —
+an acoustic occurrence is one curated biophony bout, identified by structured upstream tags
+rather than by parsing `name` — is unchanged and now better supported.
+
+### 1. The vocabulary already exists, and it isn't ours
+
+The original proposed slugs (`ecotype:srkw`, `pod:j`, `matriline:t090`) for OrcaSound to
+adopt. By the time anyone acted on it, moderators had built their own: **94 distinct tags,
+573 applications across 157 of 206 bouts** (live API, 2026-08-13), largely by Scott Veirs.
+It is a better vocabulary than the one we sketched, because it came from the work.
+
+So the ask was never "adopt tags". It is that the existing tags carry no *identity* and no
+*structure* — `J` is a pod, `S01` is a call type, `MMSI-367479990` is a vessel, and nothing on
+the record distinguishes them. A consumer is back to pattern-matching strings, which is the
+fragility this record objected to, moved one field over.
+
+**A tag's kind cannot be inferred from its shape.** `T090s` is an animal and `WCT07` is a
+*sound* — a Bigg's call type, counterpart to the SRKW `S` numbers. We got that wrong ourselves
+while drafting the upstream issues, from the strings alone, and published it before catching
+it. The register [says so plainly](https://github.com/salish-sea/animals/blob/main/docs/scope.md).
+That is the argument for an explicit `kind` column, not against it.
+
+### 2. It is a schema change, and the requirement is ours
+
+"No upstream schema change — only slug conventions and moderator habit" was wrong. Preserving a
+moderator's uncertainty needs a column. The evidence is in OrcaSound's own data: eleven bouts
+carry a `?` in the name, and in every one the hedge survives in prose and dies in the tags —
+`SRKW signals at PT (J+K +L? pods)` is tagged `J`, `K`, `SRKW`, and **not** `L`. Both available
+moves are wrong: applying `L` overstates what was heard, omitting it discards an observation.
+
+That requirement is **this repository's**, as the owner of annotation semantics (decision
+[028](028-salishsea-io-speaks-to-orcasound.md)). The register makes no such demand —
+[ADR-0018](https://github.com/salish-sea/animals/blob/main/decisions/0018-annotation-semantics-belong-to-consumers.md)
+grants it exactly two claims on an annotation, and ADR-0009's five-column table is explicitly
+illustrative. Attributing the column to the register would re-create the confusion ADR-0018
+exists to end.
+
+### 3. `unconfirmed` / `false-positive` are withdrawn
+
+Reading the live bouts, that request was three problems wearing one hat, and the register
+[declined it](https://github.com/salish-sea/animals/blob/main/docs/open-questions.md) (Q21)
+for the right reason:
+
+- a **detector false positive** names no animal, so it is a flag on the detection or the bout,
+  never a tag (note `detections.visible` already exists upstream and may cover it);
+- **boat noise filed as `biophony`** is a wrong value in `bout.category`, not a vocabulary gap;
+- a **mystery signal** should be tagged at the level the moderator is sure of, which is now
+  possible because the register mints `kind = taxon` entities (`SSA:0000900` *Orcinus orca*,
+  `SSA:0000901` humpback, the pinnipeds).
+
+So `unconfirmed` was never a missing modality — it was a missing *entity*.
+
+### 4. Identifications arrive typed, so the anti-corruption layer thins
+
+This is the substantive architectural change. The original plan was to mirror tags verbatim and
+**translate slugs** into our taxon + candidate identifiers at the boundary. If orcasite carries
+`tags.kind` and `tags.iri` as asked, there are no slugs to translate: a tag arrives already
+typed and already citing `SSA:0000020`, and the boundary's job shrinks from *parsing a
+convention* to *resolving a stable identifier*.
+
+Decision [008](008-source-schemas-are-upstream-mirrors.md) is unaffected — we still mirror
+verbatim, and the mirror is still the place upstream shape is allowed to leak. What shrinks is
+the amount of *interpretation* in the translation step, which is exactly the fragile part.
+
+Where an `iri` is absent — free text remains legal upstream, deliberately, so vocabulary gaps
+stay visible — we fall back to matching the tag name against the register. **That match uses
+the register's published fold**
+([ADR-0019](https://github.com/salish-sea/animals/blob/main/decisions/0019-names-are-compared-by-folding.md)):
+lowercase, delete apostrophes and hyphens, collapse whitespace, replace each run of digits with
+its decimal value, and never fold a trailing `s`. Under it, every animal-kind tag in the live
+corpus resolves except `fish` (outside the register's taxonomic bound) and `calf` (a life
+stage). Bare `T37` correctly yields **two** candidates — the matriline `T037s` and the
+individual `T037` — which is ambiguity the vocabulary genuinely has, to be surfaced rather than
+adjudicated by string manipulation.
+
+Consequence for our code: `normalize_designation()` and the fold disagree — ours pads where the
+fold strips, and our trailing-`s` stripping is the matriline/matriarch merge the fold refuses
+across 126 pairs. Reconciling them is `salish-8vr.18`. This supersedes finding F9 in
+[occurrence-identification-findings.md](../design-notes/occurrence-identification-findings.md),
+which proposed `searchable_name.tsv` as a lookup *table*; the register publishes a *rule*
+instead, with executable cases in `dist/fold_test.tsv`.
+
+### What this amendment does not decide
+
+`certainty` arriving from upstream is the **asserter's confidence**, and is not the same axis as
+our `identifications.status` (`candidate` / `validated` / `rejected`), which is the dataset's
+verification state. Keeping those apart is the whole of Q18's substance, along with allowing a
+bout with no animal tags to land as an occurrence with **zero identifications**. That is a
+separate decision, tracked as `salish-8vr.4`, and deliberately not settled here.
+
+[028](028-salishsea-io-speaks-to-orcasound.md) makes that a gate — the recommendation "cannot
+be posted before the shape is settled here". It was read as satisfied: what #1014 asks orcasite
+for is a three-value hedge on the application, which is settled, and nothing published upstream
+commits our own `identifications` schema beyond what this record already said. The genuinely
+open question — whether our `confidence` stays a `REAL`, becomes a coarse enum, or both — never
+surfaces in the upstream ask, because a *source* system records what its moderator said and
+takes no position on how we verify it later.
+
+### Upstream status
+
+The single ask became six issues that can be accepted independently:
+orcasound/orcasite[#1013](https://github.com/orcasound/orcasite/issues/1013) (`kind` + `iri`),
+[#1014](https://github.com/orcasound/orcasite/issues/1014) (`certainty`),
+[#1015](https://github.com/orcasound/orcasite/issues/1015) (register-aware picker),
+[#1016](https://github.com/orcasound/orcasite/issues/1016) (classify the existing 94 tags),
+[#1017](https://github.com/orcasound/orcasite/issues/1017) (machine class on detections), and
+orcasound/orcahello[#597](https://github.com/orcasound/orcahello/issues/597) (send the class
+label). #1001 is retained as the narrative that links them.
 
 ## Reference
 
@@ -88,3 +208,13 @@ this repository, not the animal register, is the voice that carries it
 Provenance model: [006](006-provenance-graph.md). Anti-corruption layer:
 [008](008-source-schemas-are-upstream-mirrors.md). Ingest architecture:
 [011](011-ingest-imperative-shell.md).
+
+Register-side contracts this record now depends on:
+[ADR-0019](https://github.com/salish-sea/animals/blob/main/decisions/0019-names-are-compared-by-folding.md)
+(the fold, with cases in `dist/fold_test.tsv`),
+[ADR-0018](https://github.com/salish-sea/animals/blob/main/decisions/0018-annotation-semantics-belong-to-consumers.md)
+(annotation belongs to consumers),
+[ADR-0010](https://github.com/salish-sea/animals/blob/main/decisions/0010-identifiers-are-never-reused.md)
+(identifiers never change meaning, which is what makes storing one safe).
+Open on our side: `salish-8vr.4` (the confidence/verification split) and `salish-8vr.18`
+(reconciling `normalize_designation()` with the fold).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -16,7 +16,7 @@ Product and technical decisions with rationale and rejected alternatives. Add a 
 | [010](010-fresh-codebase-vs-acartia.md) | SalishSea.io is a fresh codebase, not an extension of acartia.io | accepted |
 | [011](011-ingest-imperative-shell.md) | Network ingest as a TypeScript imperative shell over a functional core | accepted |
 | [012](012-ingest-heartbeat.md) | Ingest heartbeat: external observer via scheduled GitHub Action | accepted |
-| [013](013-orcasound-acoustic-occurrences.md) | OrcaSound acoustic occurrences from curated biophony bouts, identified by upstream tags | accepted (our side); pending upstream adoption |
+| [013](013-orcasound-acoustic-occurrences.md) | OrcaSound acoustic occurrences from curated biophony bouts, identified by upstream tags (amended 2026-08-14: identifications arrive typed) | accepted (our side); pending upstream adoption |
 | [014](014-trust-and-curation-model.md) | Trust & curation: claims have status, people have reputation, curators assert both | proposed (direction) |
 | [015](015-individual-profile-pages.md) | Individual profile pages at `/individuals/<designation>` | accepted |
 | [016](016-matriline-profile-pages.md) | Matriline profile pages | accepted |


### PR DESCRIPTION
013 told a story we have since retracted in public. It said consuming OrcaSound tags needed *"no upstream schema change — only slug conventions and moderator habit"*, and proposed a slug vocabulary (`ecotype:srkw`, `pod:j`, …) for OrcaSound to adopt. Both are wrong, both are now corrected in orcasound/orcasite#1001, and until this lands our own record contradicts what we told a sister project — which [028](https://github.com/salish-sea/salishsea-io/blob/main/docs/decisions/028-salishsea-io-speaks-to-orcasound.md) calls "a bug to fix here before posting".

In-place amendment rather than a successor record: the core decision is unchanged and better supported than when it was written. Follows the convention 019 and 020 already use, with the retracted paragraph struck in place so nobody acts on it before reaching the amendment.

## The four corrections

**1. The vocabulary already exists, and it isn't ours.** Moderators built one while we were proposing one — 94 tags, 573 applications across 157 of 206 bouts, largely Scott Veirs. Better than our sketch, because it came from the work. The ask was never "adopt tags"; it is that the tags carry no identity and no structure.

Included because it cost us: **a tag's kind cannot be inferred from its shape.** `T090s` is an animal and `WCT07` is a *sound* — a Bigg's call type. I got that wrong from the strings alone and published it in three repos before it was caught. The register's `scope.md` had already written the warning.

**2. It is a schema change, and the requirement is ours.** Eleven live bouts carry a `?` in the name; the hedge dies in the tags every time — `SRKW signals at PT (J+K +L? pods)` is tagged `J`, `K`, `SRKW`, and not `L`. The certainty column is this repository's requirement as owner of annotation semantics (028), not the register's — attributing it to the register would re-create the confusion animals ADR-0018 exists to end.

**3. `unconfirmed` / `false-positive` withdrawn**, per the register's Q21 three-way split: a detector false positive is a bout/detection flag, boat noise filed as `biophony` is a wrong `category` value, and a mystery signal gets tagged at the level the moderator is sure of.

**4. The anti-corruption layer thins.** The substantive architectural change. With `tags.iri` upstream there are no slugs to translate — the boundary goes from *parsing a convention* to *resolving a stable identifier*. Where an `iri` is absent, we match by the register's published fold (animals ADR-0019), under which **every animal-kind live tag resolves** except `fish` (out of scope) and `calf` (a life stage). 008 is unaffected; we still mirror verbatim.

Two consequences fall out, both recorded:
- **Supersedes finding F9** in `occurrence-identification-findings.md`, which proposed `searchable_name.tsv` as a lookup *table*. The register publishes a *rule* instead, with executable cases in `dist/fold_test.tsv` (verified — a scratch implementation reproduces them exactly).
- **`normalize_designation()` conflicts with the fold** — ours pads where the fold strips, and our trailing-`s` stripping is the matriline/matriarch merge the fold refuses across 126 pairs. Tracked as `salish-8vr.18`, not fixed here.

## Deliberately not decided

The confidence/verification split — whether our `confidence` stays a `REAL`, becomes a coarse enum, or both — is `salish-8vr.4`. The amendment records why 028's gate was read as satisfied without it: nothing published upstream commits our schema, because a *source* system records what its moderator said and takes no position on how we verify it later.

## Note on commits

This branch carries `4eda6d5` (gitignore `.beads.gate.lock`) as well — it was already committed on local `main` and unpushed before this work started. Carried along rather than pushed separately, to avoid a deploy cycle for a one-line gitignore change.

## Verification

- All internal links and the `#amendment-2026-08-14` anchor resolve.
- CodeRabbit local review: no findings.
- Docs only; no code paths touched.

Closes `salish-8vr.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the acoustic occurrence decision record with an August 2026 amendment.
  * Clarified typed identifiers, tag handling, uncertainty semantics, and unresolved identification cases.
  * Updated the decisions index to reflect the amendment date and revised identification details.

* **Chores**
  * Excluded the Beads gate lock file from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->